### PR TITLE
TIP-693: introduce a native JSON field type for Doctrine

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -70,6 +70,9 @@ doctrine:
                 user:         "%database_user%"
                 password:     "%database_password%"
                 charset:      UTF8
+                server_version: 5.7
+                mapping_types:
+                    json: string
             session:
                 driver:       "%database_driver%"
                 host:         "%database_host%"
@@ -81,6 +84,9 @@ doctrine:
                 charset:      UTF8
         types:
             datetime: Akeneo\Bundle\StorageUtilsBundle\Doctrine\DBAL\Types\UTCDateTimeType
+            native_json:
+                class: Akeneo\Bundle\StorageUtilsBundle\Doctrine\DBAL\Types\JsonType
+                commented: true
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         auto_mapping: true

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/JsonType.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/JsonType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\JsonArrayType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Be able to use the native MySQL 5.7 JSON type in our current Doctrine DBAL version.
+ *
+ * TODO: once https://github.com/doctrine/dbal/pull/2653 will be merged, we'll be able to drop this class
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JsonType extends JsonArrayType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'json';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return $value === null ? null : parent::convertToPHPValue($value, $platform);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'native_json';
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
@@ -18,7 +18,7 @@ Pim\Component\Catalog\Model\Product:
             unique: true
             nullable: false
         rawValues:
-            type: json_array
+            type: native_json
             column: raw_values
         created:
             type: datetime


### PR DESCRIPTION
Currently, Doctrine does not support the native MySQL 5.7 JSON type. Even the master version does not.
We have to wait for [this Doctrine PR](https://github.com/doctrine/dbal/pull/2653) to be merged. Normally it should be OK for `doctrine/dbal 2.6`.

In Doctrine ORM 2.4 the type `json_array` was available. In Doctrine ORM 2.5, this type was renamed simply `json`. The problems of these Doctrine types is that they lead to the creation of a `LONGTEXT` field in MySQL.

That means, currently, in the branch `TIP-613-unified`, the product values are not stored in a real `JSON` field as expected. Actually, they are stored in a `LONGTEXT` field. To tackle this concern, this PR creates a [custom Doctrine type](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types). 

Once the Doctrine PR will be merged, and we'll have upgraded Doctrine, we'll be able to revert this commit, without any BC break/migration for the data of our customers.

There is no impact on the performances of the import (tested on 1K products of the medium catalog.)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

