### PR TITLE
TIP-688: make the reference data work again

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -21,7 +21,7 @@ class AppKernel extends Kernel
     {
         return [
             // your app bundles should be registered here
-//            new Acme\Bundle\AppBundle\AcmeAppBundle(),
+            new Acme\Bundle\AppBundle\AcmeAppBundle(),
         ];
     }
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -91,3 +91,14 @@ fos_oauth_server:
     auth_code_class:          Pim\Bundle\ApiBundle\Entity\AuthCode
     service:
         user_provider:        pim_user.provider.user
+
+pim_reference_data:
+    fabrics:
+        class: Acme\Bundle\AppBundle\Entity\Fabric
+        type: multi
+    color:
+        class: Acme\Bundle\AppBundle\Entity\Color
+        type: simple
+
+akeneo_storage_utils:
+    mapping_overrides: ~

--- a/features/Context/CatalogConfigurationContext.php
+++ b/features/Context/CatalogConfigurationContext.php
@@ -95,24 +95,17 @@ class CatalogConfigurationContext extends RawMinkContext
         // install the catalog via the job instances
         $jobInstances = $this->getFixtureJobLoader()->getLoadedJobInstances();
         foreach ($jobInstances as $jobInstance) {
-            try {
-                $exitCode = $command->execute(
-                    [
-                        'command'  => $batchJobCommand->getName(),
-                        'code'     => $jobInstance->getCode(),
-                        '--no-log' => true,
-                        '-v'       => true
-                    ]
-                );
-            } catch (\Exception $e) {
-                // TODO TIP-688: here we allow the catalog to be installed with errors
-                // TODO TIP-688: currently the attributes fails to be imported because we disabled the reference data
-                // TODO TIP-688: (but all other attributes are well imported)
-                // TODO TIP-688: revert this whole commit
+            $exitCode = $command->execute(
+                [
+                    'command'    => $batchJobCommand->getName(),
+                    'code'       => $jobInstance->getCode(),
+                    '--no-log'   => true,
+                    '-v'         => true
+                ]
+            );
+            if (0 !== $exitCode) {
+                throw new \Exception(sprintf('Catalog not installable! "%s"', $command->getDisplay()));
             }
-//            if (0 !== $exitCode) {
-//                throw new \Exception(sprintf('Catalog not installable! "%s"', $command->getDisplay()));
-//            }
         }
 
         // delete the job instances

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -558,6 +558,9 @@ class ProductRepository extends EntityRepository implements
         $qb = $this->createQueryBuilder('Product');
 
         //TODO - TIP-697: make the variant groups work again
+        $qb->where('Product.identifier = :no_identifier');
+        $qb->setParameter('no_identifier', 'THERE_IS_NO_SKU_LIKE_DAT');
+
         return $qb;
 
         $qb

--- a/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/ProductValue/BaseSelector.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/ProductValue/BaseSelector.php
@@ -33,19 +33,20 @@ class BaseSelector implements SelectorInterface
             $path = sprintf(ContextConfigurator::SOURCE_PATH, ContextConfigurator::DISPLAYED_ATTRIBUTES_KEY);
             $attributeIds = $configuration->offsetGetByPath($path);
 
-            $datasource->getQueryBuilder()
-                ->leftJoin(
-                    $rootAlias.'.values',
-                    'values',
-                    'WITH',
-                    'values.attribute IN (:attributeIds) '
-                    .'AND (values.locale = :dataLocale OR values.locale IS NULL) '
-                    .'AND (values.scope = :scopeCode OR values.scope IS NULL)'
-                )
-                ->addSelect('values')
-                ->leftJoin('values.attribute', 'attribute')
-                ->addSelect('attribute')
-                ->setParameter('attributeIds', $attributeIds);
+            // TODO: TIP-664: make the datagrid work again
+//            $datasource->getQueryBuilder()
+//                ->leftJoin(
+//                    $rootAlias.'.values',
+//                    'values',
+//                    'WITH',
+//                    'values.attribute IN (:attributeIds) '
+//                    .'AND (values.locale = :dataLocale OR values.locale IS NULL) '
+//                    .'AND (values.scope = :scopeCode OR values.scope IS NULL)'
+//                )
+//                ->addSelect('values')
+//                ->leftJoin('values.attribute', 'attribute')
+//                ->addSelect('attribute')
+//                ->setParameter('attributeIds', $attributeIds);
         }
         $this->applied = true;
     }

--- a/src/Pim/Bundle/InstallerBundle/CommandExecutor.php
+++ b/src/Pim/Bundle/InstallerBundle/CommandExecutor.php
@@ -64,11 +64,7 @@ class CommandExecutor
             $errorMessage = sprintf('The command terminated with an error code: %u.', $exitCode);
             $this->output->writeln("<error>$errorMessage</error>");
             $e = new \Exception($errorMessage, $exitCode);
-            // TODO TIP-688: here we allow the catalog to be installed with errors
-            // TODO TIP-688: currently the attributes fails to be imported because we disabled the reference data
-            // TODO TIP-688: (but all other attributes are well imported)
-            // TODO TIP-688: revert this whole commit//
-//            throw $e;
+            throw $e;
         }
 
         return $this;


### PR DESCRIPTION
During the POC, we had to disable reference data in order to be able to load and save products with JSON values. 

This PR re enable the reference data feature after having ensured we can load, save and import products. The goal  here is just to make it work again. Do not update the documentation on this PR. This will come later.

Here we disabled the check on the variant axis and the selection of attributes in the grid. Both features will be re enabled later. At the moment, this allows us to launch a lot of Behat manually, which is a good small step further.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
