### PR TITLE
TIP-682-2: Add independent integration tests for versionning

### DIFF
--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -53,7 +53,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
      */
     public function getNewestLogEntryForRessources($resourceNames)
     {
-        return $this->findOneBy(['resourceName' => $resourceNames], ['loggedAt' => 'desc'], 1);
+        return $this->findOneBy(['resourceName' => $resourceNames], ['version' => 'desc'], 1);
     }
 
     /**
@@ -61,7 +61,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
      */
     public function getPendingVersions($limit = null)
     {
-        return $this->findBy(['pending' => true], ['loggedAt' => 'asc'], $limit);
+        return $this->findBy(['pending' => true], ['version' => 'asc'], $limit);
     }
 
     /**
@@ -219,9 +219,6 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
             $criteria['pending'] = $pending;
         }
 
-        return $this->findOneBy(
-            $criteria,
-            ['loggedAt' => $sort]
-        );
+        return $this->findOneBy($criteria, ['version' => $sort]);
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -28,7 +28,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
     {
         return $this->findBy(
             ['resourceId' => $resourceId, 'resourceName' => $resourceName, 'pending' => false],
-            ['loggedAt' => 'desc']
+            ['version' => 'desc']
         );
     }
 

--- a/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddVersionSubscriber.php
+++ b/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddVersionSubscriber.php
@@ -236,5 +236,7 @@ class AddVersionSubscriber implements EventSubscriber
         }
 
         $this->versions = [];
+        $this->versionableEntities = [];
+        $this->versionedEntities = [];
     }
 }

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -102,10 +102,6 @@ class FixturesLoader
         //         "/project/features/Context/catalog/footwear/jobs.yml"
         //         "/project/features/PimEnterprise/Behat/Context/../../../Context/catalog/footwear/jobs.yml"
         // ]
-        if (empty($files)) {
-            return;
-        }
-
         $replacePaths = [];
         foreach ($files as $file) {
             $tokens = explode(DIRECTORY_SEPARATOR, $file);

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -102,6 +102,10 @@ class FixturesLoader
         //         "/project/features/Context/catalog/footwear/jobs.yml"
         //         "/project/features/PimEnterprise/Behat/Context/../../../Context/catalog/footwear/jobs.yml"
         // ]
+        if (empty($files)) {
+            return;
+        }
+
         $replacePaths = [];
         foreach ($files as $file) {
             $tokens = explode(DIRECTORY_SEPARATOR, $file);

--- a/tests/catalog/technical_sql/050_common.sql
+++ b/tests/catalog/technical_sql/050_common.sql
@@ -144,6 +144,13 @@ DELETE FROM `pim_catalog_channel`;
 INSERT INTO `pim_catalog_channel` VALUES (209,895,'ecommerce','a:0:{}'),(210,895,'tablet','a:0:{}');
 /*!40000 ALTER TABLE `pim_catalog_channel` ENABLE KEYS */;
 
+--
+-- Dumping data for table `pim_catalog_currency`
+--
+
+/*!40000 ALTER TABLE `pim_catalog_channel_currency` DISABLE KEYS */;
+INSERT INTO `pim_catalog_currency` VALUES (10101,'USD',1),(10102,'EUR',1);
+/*!40000 ALTER TABLE `pim_catalog_channel_currency` ENABLE KEYS */;
 
 --
 -- Dumping data for table `pim_catalog_channel_currency`


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PRs adapts the integration tests written for the versioningManager into independent tests (meaning the DB is reset every test methods).

Doing this shown that we fell through the net with the addVersionSubscriber which kept references to older object even if their version were created and inserted into DB. So, on Detach, we explicitly reset some statefull variables of this class.

Also this PR shown that, even if we used only the technical_sql catalogs, the fixture loader would load some other files/jobInstances. Preventing this, I added an early return to the `loadImportFiles` method.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
