### PR TITLE
TIP-330: Remove "id" and "code" from field filters

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -43,3 +43,5 @@
 - Remove methods `setData`, `setText`, `setDecimal`, `setOptions`, `setOption`, `setPrices`, `setPrice`, `setBoolean`, `setVarchar`, `setMedia`, `setMetric`, `setScope`, `setLocale`, `setDate` and `setDatetime` from `Pim\Component\Catalog\Model\ProductValueInterface`
     and make them protected in `Pim\Component\Catalog\Model\AbstractProductValue`
 - Change the constructor of `Pim\Bundle\VersioningBundle\Denormalizer\Flat\ProductValue\PricesDenormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface` as third parameter
+- Change the constructor of `Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter` to remove `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface`
+- Change the constructor of `Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter` to remove `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface`

--- a/features/filter/category.feature
+++ b/features/filter/category.feature
@@ -13,7 +13,7 @@ Feature: Filter on category
       | BOOTBL  |                                    |
       | BOOTRXS | 2014_collection, summer_collection |
     Then I should get the following results for the given filters:
-      | filter                                                                                               | result                           |
+      | filter                                                                                          | result                           |
       | [{"field":"categories", "operator":"IN",                 "value": ["winter_boots", "sandals"]}] | ["BOOTBXS", "BOOTWXS", "BOOTBS"] |
       | [{"field":"categories", "operator":"NOT IN",             "value": ["winter_boots"]}]            | ["BOOTBS", "BOOTBL", "BOOTRXS"]  |
       | [{"field":"categories", "operator":"UNCLASSIFIED",       "value": []}]                          | ["BOOTBL"]                       |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
@@ -40,8 +40,8 @@ class CategoryFilter implements FieldFilterInterface
      * @param CategoryRepositoryInterface           $categoryRepository
      * @param CategoryFilterableRepositoryInterface $itemCategoryRepo
      * @param ObjectIdResolverInterface             $objectIdResolver
-     * @param array                                 $supportedFields
-     * @param array                                 $supportedOperators
+     * @param string[]                              $supportedFields
+     * @param string[]                              $supportedOperators
      */
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
@@ -66,9 +66,7 @@ class CategoryFilter implements FieldFilterInterface
         if ($operator !== Operators::UNCLASSIFIED) {
             $this->checkValue($field, $value);
 
-            if (FieldFilterHelper::getProperty($field) === FieldFilterHelper::CODE_PROPERTY) {
-                $categoryIds = $this->objectIdResolver->getIdsFromCodes('category', $value);
-            }
+            $categoryIds = $this->objectIdResolver->getIdsFromCodes('category', $value);
         }
 
         switch ($operator) {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/FamilyFilter.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -16,20 +15,12 @@ use Pim\Component\Catalog\Query\Filter\Operators;
  */
 class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    /** @var ObjectIdResolverInterface */
-    protected $objectIdResolver;
-
     /**
-     * @param ObjectIdResolverInterface $objectIdResolver
-     * @param array                     $supportedFields
-     * @param array                     $supportedOperators
+     * @param string[] $supportedFields
+     * @param string[] $supportedOperators
      */
-    public function __construct(
-        ObjectIdResolverInterface $objectIdResolver,
-        array $supportedFields = [],
-        array $supportedOperators = []
-    ) {
-        $this->objectIdResolver = $objectIdResolver;
+    public function __construct(array $supportedFields = [], array $supportedOperators = [])
+    {
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -41,10 +32,6 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
     {
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($field, $value);
-
-            if (FieldFilterHelper::getProperty($field) === FieldFilterHelper::CODE_PROPERTY) {
-                $value = $this->objectIdResolver->getIdsFromCodes('family', $value);
-            }
         }
 
         $rootAlias = $this->qb->getRootAlias();
@@ -54,24 +41,24 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
         switch ($operator) {
             case Operators::IN_LIST:
                 $this->qb->andWhere(
-                    $this->qb->expr()->in($entityAlias . '.id', $value)
+                    $this->qb->expr()->in($entityAlias . '.code', $value)
                 );
                 break;
             case Operators::NOT_IN_LIST:
                 $this->qb->andWhere(
                     $this->qb->expr()->orX(
-                        $this->qb->expr()->notIn($entityAlias . '.id', $value),
-                        $this->qb->expr()->isNull($entityAlias . '.id')
+                        $this->qb->expr()->notIn($entityAlias . '.code', $value),
+                        $this->qb->expr()->isNull($entityAlias . '.code')
                     )
                 );
                 break;
             case Operators::IS_EMPTY:
                 $this->qb->andWhere(
-                    $this->qb->expr()->isNull($entityAlias . '.id')
+                    $this->qb->expr()->isNull($entityAlias . '.code')
                 );
                 break;
             case Operators::IS_NOT_EMPTY:
-                $this->qb->andWhere($this->qb->expr()->isNotNull($entityAlias . '.id'));
+                $this->qb->andWhere($this->qb->expr()->isNotNull($entityAlias . '.code'));
                 break;
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
@@ -29,8 +29,8 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /**
      * @param AttributeValidatorHelper  $attrValidatorHelper
      * @param ObjectIdResolverInterface $objectIdResolver
-     * @param array                     $supportedAttributeTypes
-     * @param array                     $supportedOperators
+     * @param string[]                  $supportedAttributeTypes
+     * @param string[]                  $supportedOperators
      */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
@@ -29,8 +29,8 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
     /**
      * @param AttributeValidatorHelper  $attrValidatorHelper
      * @param ObjectIdResolverInterface $objectIdResolver
-     * @param array                     $supportedAttributeTypes
-     * @param array                     $supportedOperators
+     * @param string[]                  $supportedAttributeTypes
+     * @param string[]                  $supportedOperators
      */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -69,7 +69,7 @@ services:
             - '@pim_catalog.repository.category'
             - '@pim_catalog.repository.product_category'
             - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['categories', 'categories.id', 'categories.code']
+            - ['categories']
             - ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
@@ -97,8 +97,7 @@ services:
     pim_catalog.doctrine.query.filter.family:
         class: '%pim_catalog.doctrine.query.filter.family.class%'
         arguments:
-            - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['family', 'family.id', 'family.code']
+            - ['family']
             - ['IN', 'NOT IN' ,'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
@@ -106,8 +105,7 @@ services:
     pim_catalog.doctrine.query.filter.groups:
         class: '%pim_catalog.doctrine.query.filter.groups.class%'
         arguments:
-            - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['groups', 'groups.id', 'groups.code']
+            - ['groups']
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/ProductQueryHelp/FieldFilterDumperSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/ProductQueryHelp/FieldFilterDumperSpec.php
@@ -32,7 +32,7 @@ class FieldFilterDumperSpec extends ObjectBehavior
         $output->writeln(Argument::any())->shouldBeCalled();
 
         $operators = ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY'];
-        $fields = ['groups.id', 'groups'];
+        $fields = ['groups', 'groups'];
         $registry->getFieldFilters()->willReturn([$groupFilter]);
         $groupFilter->getOperators()->willReturn($operators);
         $groupFilter->getFields()->willReturn($fields);
@@ -41,7 +41,7 @@ class FieldFilterDumperSpec extends ObjectBehavior
         $headers = ['field', 'operators', 'filter_class'];
         $table->setHeaders($headers)->shouldBeCalled()->willReturn($table);
         $table->setRows(Argument::that(function ($param) {
-            return 'groups.id' === $param[0][0] &&
+            return 'groups' === $param[0][0] &&
                 'IN, NOT IN, EMPTY, NOT EMPTY' === $param[0][1] &&
                 false !== strpos($param[0][2], 'FieldFilterInterface') &&
                 'groups' === $param[1][0] &&

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/CategoryFilterSpec.php
@@ -46,22 +46,6 @@ class CategoryFilterSpec extends ObjectBehavior
         $this->addFieldFilter('categories', 'IN', ['foo', 'bar']);
     }
 
-    function it_adds_a_filter_on_category_codes($qb, $itemRepo, $objectIdResolver)
-    {
-        $itemRepo->applyFilterByCategoryIds($qb, [42, 84], true)->shouldBeCalled();
-        $objectIdResolver->getIdsFromCodes('category', ['foo', 'bar'])->willReturn([42, 84]);
-
-        $this->addFieldFilter('categories.code', 'IN', ['foo', 'bar']);
-    }
-
-    function it_adds_a_filter_on_category_ids($qb, $itemRepo, $objectIdResolver)
-    {
-        $itemRepo->applyFilterByCategoryIds($qb, [42, 84], true)->shouldBeCalled();
-        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
-
-        $this->addFieldFilter('categories.id', 'IN', [42, 84]);
-    }
-
     function it_adds_a_in_filter_on_categories_in_the_query($qb, $itemRepo, $objectIdResolver)
     {
         $itemRepo->applyFilterByCategoryIds($qb, [42, 84], true)->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -5,15 +5,14 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 class FamilyFilterSpec extends ObjectBehavior
 {
-    function let(QueryBuilder $qb, ObjectIdResolverInterface $objectIdResolver)
+    function let(QueryBuilder $qb)
     {
-        $this->beConstructedWith($objectIdResolver, ['family', 'groups'], ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']);
+        $this->beConstructedWith(['family'], ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']);
         $this->setQueryBuilder($qb);
     }
 
@@ -24,7 +23,7 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_returns_supported_fields()
     {
-        $this->getFields()->shouldReturn(['family', 'groups']);
+        $this->getFields()->shouldReturn(['family']);
     }
 
     function it_supports_operators()
@@ -34,59 +33,38 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_filter_on_codes_by_default($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filterfamily.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filterfamily.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
-
-        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
-
-    }
-
-    function it_adds_a_filter_on_codes($qb, $objectIdResolver, Expr $expr)
-    {
-        $qb->getRootAlias()->willReturn('f');
-        $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
-
-        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
-        $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
 
         $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
     }
 
-    function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_filter_on_codes($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filterfamily.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filterfamily.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
 
-        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
-
-        $this->addFieldFilter('family.id', 'IN', [1, 2]);
+        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
     }
 
-    function it_adds_a_in_filter_on_a_field_in_the_query($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_in_filter_on_a_field_in_the_query($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filterfamily.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filterfamily.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
 
         $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
     }
@@ -95,29 +73,27 @@ class FamilyFilterSpec extends ObjectBehavior
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id IS NULL')->willReturn($qb);
+        $qb->andWhere('filterfamily.code IS NULL')->willReturn($qb);
 
-        $expr->isNull(Argument::any())->willReturn('filterfamily.id IS NULL');
+        $expr->isNull(Argument::any())->willReturn('filterfamily.code IS NULL');
         $qb->expr()->willReturn($expr);
 
         $this->addFieldFilter('family', 'EMPTY', null);
     }
 
-    function it_adds_a_not_in_filter_on_a_field_in_the_query($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_not_in_filter_on_a_field_in_the_query($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
-        $qb->andWhere('filterfamily.id NOT IN(3)'.'filterfamily.id IS NULL')->willReturn($qb);
+        $qb->andWhere('filterfamily.code NOT IN ("foo")'.'filterfamily.code IS NULL')->willReturn($qb);
         $qb->expr()->willReturn($expr);
 
-        $expr->notIn(Argument::any(), [3])->willReturn('filterfamily.id NOT IN');
-        $expr->isNull(Argument::any())->willReturn('filterfamily.id IS NULL');
+        $expr->notIn(Argument::any(), ['foo'])->willReturn('filterfamily.code NOT IN');
+        $expr->isNull(Argument::any())->willReturn('filterfamily.code IS NULL');
 
-        $expr->orX('filterfamily.id NOT IN', 'filterfamily.id IS NULL')
+        $expr->orX('filterfamily.code NOT IN', 'filterfamily.code IS NULL')
             ->shouldBeCalled()
-            ->willReturn('filterfamily.id NOT IN(3)'.'filterfamily.id IS NULL');
-
-        $objectIdResolver->getIdsFromCodes('family', ['foo'])->willReturn([3]);
+            ->willReturn('filterfamily.code NOT IN ("foo")'.'filterfamily.code IS NULL');
 
         $this->addFieldFilter('family', 'NOT IN', ['foo']);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -6,15 +6,14 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 class GroupsFilterSpec extends ObjectBehavior
 {
-    function let(QueryBuilder $qb, ObjectIdResolverInterface $objectIdResolver)
+    function let(QueryBuilder $qb)
     {
-        $this->beConstructedWith($objectIdResolver, ['groups'], ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']);
+        $this->beConstructedWith(['groups'], ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']);
         $this->setQueryBuilder($qb);
     }
 
@@ -35,70 +34,52 @@ class GroupsFilterSpec extends ObjectBehavior
         $this->getFields()->shouldReturn(['groups']);
     }
 
-    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_filter_on_codes_by_default($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
-        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filtergroups.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filtergroups.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([1, 2]);
 
         $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
     }
 
-    function it_adds_a_filter_on_codes($qb, $objectIdResolver, Expr $expr)
+    function it_adds_a_filter_on_codes($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
-        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filtergroups.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filtergroups.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([1, 2]);
 
         $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
-    }
-
-    function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)
-    {
-        $qb->getRootAlias()->willReturn('f');
-        $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
-        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
-
-        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
-        $qb->expr()->willReturn($expr);
-
-        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
-
-        $this->addFieldFilter('groups.id', 'IN', [1, 2]);
     }
 
     function it_adds_a_in_filter_on_a_field_in_the_query($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
-        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+        $qb->andWhere('filtergroups.code IN ("foo", "bar")')->willReturn($qb);
 
-        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $expr->in(Argument::any(), ['foo', 'bar'])->willReturn('filtergroups.code IN ("foo", "bar")');
         $qb->expr()->willReturn($expr);
 
-        $this->addFieldFilter('groups.id', 'IN', [1, 2]);
+        $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
     }
 
     function it_adds_an_empty_filter_on_a_field_in_the_query($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
-        $qb->andWhere('filtergroups.id IS NULL')->willReturn($qb);
+        $qb->andWhere('filtergroups.code IS NULL')->willReturn($qb);
 
-        $expr->isNull(Argument::any())->willReturn('filtergroups.id IS NULL');
+        $expr->isNull(Argument::any())->willReturn('filtergroups.code IS NULL');
         $qb->expr()->willReturn($expr);
 
-        $this->addFieldFilter('groups.id', 'EMPTY', null);
+        $this->addFieldFilter('groups', 'EMPTY', null);
     }
 
     function it_adds_an_not_in_filter_on_a_field_in_the_query(
@@ -114,11 +95,11 @@ class GroupsFilterSpec extends ObjectBehavior
         $qb->getEntityManager()->willReturn($em);
         $em->createQueryBuilder()->willReturn($notInQb);
         $qb->getRootEntities()->willReturn(['ProductClassName']);
-        $notInQb->select(Argument::containingString('.id'))->shouldBeCalled()->willReturn($notInQb);
+        $notInQb->select(Argument::containingString('.code'))->shouldBeCalled()->willReturn($notInQb);
         $notInQb->from(
             'ProductClassName',
             Argument::any(),
-            Argument::containingString('.id')
+            Argument::containingString('.code')
         )->shouldBeCalled()->willReturn($notInQb);
         $notInQb->getRootAlias()->willReturn('ep');
         $notInQb->innerJoin(
@@ -126,19 +107,19 @@ class GroupsFilterSpec extends ObjectBehavior
             Argument::containingString('filtergroups')
         )->shouldBeCalled()->willReturn($notInQb);
         $notInQb->expr()->willReturn($expr);
-        $expr->in(Argument::containingString('.id'), [3])
+        $expr->in(Argument::containingString('.code'), ["foo"])
             ->shouldBeCalled()
             ->willReturn($inFunc);
         $notInQb->where($inFunc)->shouldBeCalled();
         $notInQb->getDQL()->willReturn('excluded products DQL');
 
         $qb->expr()->willReturn($expr);
-        $expr->notIn('f.id', 'excluded products DQL')
+        $expr->notIn('f.code', 'excluded products DQL')
             ->shouldBeCalled()
             ->willReturn($whereFunc);
         $qb->andWhere($whereFunc)->shouldBeCalled();
 
-        $this->addFieldFilter('groups.id', 'NOT IN', [3]);
+        $this->addFieldFilter('groups', 'NOT IN', ['foo']);
     }
 
     function it_checks_if_field_is_supported()

--- a/src/Pim/Bundle/DataGridBundle/spec/Adapter/OroToPimGridFilterAdapterSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Adapter/OroToPimGridFilterAdapterSpec.php
@@ -25,7 +25,7 @@ class OroToPimGridFilterAdapterSpec extends ObjectBehavior
                 'value'    => 'DP',
             ],
             [
-                'field'    => 'categories.id',
+                'field'    => 'categories',
                 'operator' => 'IN',
                 'value'    => [12, 13, 14],
             ]
@@ -38,7 +38,7 @@ class OroToPimGridFilterAdapterSpec extends ObjectBehavior
                 'value'    => 'DP',
             ],
             [
-                'field'    => 'categories.id',
+                'field'    => 'categories',
                 'operator' => 'IN',
                 'value'    => [12, 13, 14],
             ]

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
@@ -16,9 +16,6 @@ class FieldFilterHelper
     /** @var string */
     const CODE_PROPERTY = 'code';
 
-    /** @var string */
-    const ID_PROPERTY = 'id';
-
     /**
      * Get field code part
      *


### PR DESCRIPTION
## Description

PQB filters for families, groups, and categories can be called in three different ways. For instance for the family:
- `family`
- `family.id`
- `family.code`

With this PR, it is now possible to filter on:
- categories only by `categories` (not `categories.code` nor `categories.id`)
- families only by `family` (not `family.code` nor `family.id`)
- groups only by `groups` (not `groups.code` nor `groups.id`)

This PR has, in fact, no effect on the PIM, as the ESBundle filters are used instead of native ones, but this allows to clean the code and prepare the path.
The real, effective PR is this one: https://github.com/akeneo/ElasticSearchBundle/pull/136.

## Definition Of Done

| Q | A
| --------------------------------- | ---
| Added Specs | ❎
| Added Behats | ❎
| Added integration tests | ❎
| Changelog updated | ✅
| Review and 2 GTM | 🕐
| Micro Demo to the PO (Story only) | ❎
| Migration script | ❎
| Tech Doc | ❎

🕐 Pending / Work in progress
✅ Done / Validated
❎ Not needed
