### PR TITLE
TIP-705: Add SearchQuery (Clauses) object to hold search conditions

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/ElasticSearch/SearchQuery.php
+++ b/src/Pim/Bundle/CatalogBundle/ElasticSearch/SearchQuery.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\ElasticSearch;
+
+/**
+ * This stateful class holds the multiple parts of an Elastic Search search query.
+ *
+ * In two different arrays, it keeps track of the conditions where:
+ * - a property should be equal to a value (ES filter clause)
+ * - a property should *not* be equal to a value (ES must_not clause)
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @internal This class is used by the ProductQueryBuilder to create an ES search query.
+ */
+class SearchQuery
+{
+    /** @var array */
+    private $mustNotClauses = [];
+
+    /** @var array */
+    private $filterClauses = [];
+
+    /**
+     * Adds a filter clause to the query
+     *
+     * @param array $clause
+     */
+    public function addMustNot(array $clause)
+    {
+        $this->mustNotClauses[] = $clause;
+    }
+
+    /**
+     * Adds a must_not clause to the query
+     *
+     * @param array $clause
+     */
+    public function addFilter(array $clause)
+    {
+        $this->filterClauses[] = $clause;
+    }
+
+    /**
+     * Returns an Elastic search Query
+     *
+     * @param array $source
+     *
+     * @return array
+     */
+    public function getQuery(array $source = [])
+    {
+        if (empty($source)) {
+            $source = ['identifier'];
+        }
+
+        $searchQuery = [
+            '_source' => $source,
+            'query'   => [],
+        ];
+
+        if (!empty($this->filterClauses)) {
+            $searchQuery['query']['bool']['filter'] = $this->filterClauses;
+        }
+
+        if (!empty($this->mustNotClauses)) {
+            $searchQuery['query']['bool']['must_not'] = $this->mustNotClauses;
+        }
+
+        return $searchQuery;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/ElasticSearch/SearchQuerySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/ElasticSearch/SearchQuerySpec.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\ElasticSearch;
+
+use PhpSpec\ObjectBehavior;
+
+class SearchQuerySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\CatalogBundle\ElasticSearch\SearchQuery');
+    }
+
+    function it_generates_an_empty_query()
+    {
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [],
+            ]
+        );
+    }
+
+    function it_adds_one_filter_clause()
+    {
+        $this->addFilter([
+            'term' => ['family' => 'camcorders'],
+        ]);
+
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [
+                    'bool' => [
+                        'filter' => [
+                            ['term' => ['family' => 'camcorders']],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_adds_multiple_filter_clauses()
+    {
+        $this->addFilter([
+            'term' => ['family' => 'camcorders'],
+        ]);
+        $this->addFilter([
+            'query_string' => [
+                'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                'query'         => '*Best camcorder in town*',
+            ],
+        ]);
+
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [
+                    'bool' => [
+                        'filter' => [
+                            ['term' => ['family' => 'camcorders']],
+                            [
+                                'query_string' => [
+                                    'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                                    'query'         => '*Best camcorder in town*',
+                                ],
+
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_adds_one_must_not_clause()
+    {
+        $this->addMustNot([
+            'term' => ['family' => 'camcorders'],
+        ]);
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [
+                    'bool' => [
+                        'must_not' => [
+                            ['term' => ['family' => 'camcorders']],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_adds_multiple_must_not_clauses()
+    {
+        $this->addMustNot([
+            'term' => ['family' => 'camcorders'],
+        ]);
+        $this->addMustNot([
+            'query_string' => [
+                'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                'query'         => '*Best camcorder in town*',
+            ],
+        ]);
+
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [
+                    'bool' => [
+                        'must_not' => [
+                            ['term' => ['family' => 'camcorders']],
+                            [
+                                'query_string' => [
+                                    'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                                    'query'         => '*Best camcorder in town*',
+                                ],
+
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_adds_filter_and_must_not_clauses()
+    {
+        $this->addFilter([
+            'term' => ['family' => 'camcorders'],
+        ]);
+        $this->addFilter([
+            'query_string' => [
+                'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                'query'         => '*Best camcorder in town*',
+            ],
+        ]);
+
+        $this->addMustNot([
+            'range' => [
+                'values.price-pim_catalog_price.<all_channels>.<all_locales>' => ['lte' => 500],
+            ],
+        ]);
+        $this->addMustNot([
+            'term' => [
+                'name' => 'cheap',
+            ],
+        ]);
+
+        $this->getQuery()->shouldReturn(
+            [
+                '_source' => ['identifier'],
+                'query'   => [
+                    'bool' => [
+                        'filter'   => [
+                            [
+                                'term' => ['family' => 'camcorders'],
+                            ],
+                            [
+                                'query_string' => [
+                                    'default_field' => 'values.description-pim_catalog_text.ecommerce.en_US',
+                                    'query'         => '*Best camcorder in town*',
+                                ],
+                            ],
+                        ],
+                        'must_not' => [
+                            [
+                                'range' => [
+                                    'values.price-pim_catalog_price.<all_channels>.<all_locales>' => ['lte' => 500],
+                                ],
+                            ],
+                            [
+                                'term' => [
+                                    'name' => 'cheap',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This object is central in the way we will use ES to search for products. It is highly stateful and 

The workflow of building and executing an ES search query with the PQB is the following:

1. When creating a PQB this object will be instanciated with empty conditions (filter and must nots)
2. As long as a filter is added to the pqb, the supported filter will add to this objects the query representing the ES condition of the filter (again filter or must_nots depending on the filter operator used)
3. When every filters have been added, and the pqb is executed, the SearchQueryBuilder object compiles down a complete array representing a full featured ES request (We could easily json_encode this array and curl this DATA directly to the ES server)

*Hey what do you think of the name ?*

I chose SearchQueryBuilder because the way a doctrine QB is working is not so different:
- They both keeps tracks of the filter conditions
- Highly statefuls
- Can be passed along to be modified using their API

But it could be misleading as well. So *SearchQuery* could also be a good candidate even *ESSearchQuery*

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
