### PR TITLE
TIP-694: Add filled in product values to completeness

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Completeness.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Completeness.orm.yml
@@ -23,6 +23,9 @@ Pim\Component\Catalog\Model\Completeness:
         missingCount:
             type: integer
             column: missing_count
+        filledInCount:
+            type: integer
+            column: filled_in_count
         requiredCount:
             type: integer
             column: required_count
@@ -60,4 +63,15 @@ Pim\Component\Catalog\Model\Completeness:
                         onDelete: CASCADE
                 inverseJoinColumns:
                     missing_attribute_id:
+                        referencedColumnName: id
+        filledInAttributes:
+            targetEntity: Pim\Component\Catalog\Model\AttributeInterface
+            joinTable:
+                name: pim_catalog_completeness_filled_in_attribute
+                joinColumns:
+                    completeness_id:
+                        referencedColumnName: id
+                        onDelete: CASCADE
+                inverseJoinColumns:
+                    filled_in_attribute_id:
                         referencedColumnName: id

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
@@ -56,6 +56,21 @@ abstract class AbstractCompletenessIntegration extends TestCase
     }
 
     /**
+     * @param CompletenessInterface $completeness
+     * @param string[]              $expectedAttributeCodes
+     */
+    protected function assertFilledInAttributeCodes(CompletenessInterface $completeness, array $expectedAttributeCodes)
+    {
+        $filledInAttributes = $completeness->getFilledInAttributes();
+
+        $filledInAttributeCodes = array_map(function (AttributeInterface $filledInAttribute) {
+            return $filledInAttribute->getCode();
+        }, $filledInAttributes->toArray());
+
+        $this->assertEquals(sort($expectedAttributeCodes), sort($filledInAttributeCodes));
+    }
+
+    /**
      * @param ProductInterface $product
      * @param int              $expectedNumberOfCompletenesses
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/AbstractCompletenessPerAttributeTypeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/AbstractCompletenessPerAttributeTypeIntegration.php
@@ -73,4 +73,15 @@ abstract class AbstractCompletenessPerAttributeTypeIntegration extends AbstractC
 
         $this->assertMissingAttributeCodes($completeness, $expectedAttributeCodes);
     }
+
+    /**
+     * @param ProductInterface $product
+     * @param string[]         $expectedAttributeCodes
+     */
+    protected function assertFilledInAttributeForProduct(ProductInterface $product, array $expectedAttributeCodes)
+    {
+        $completeness = $this->getCurrentCompleteness($product);
+
+        $this->assertFilledInAttributeCodes($completeness, $expectedAttributeCodes);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
             ]
         );
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_boolean']);
 
         $productCompleteFalse = $this->createProductWithStandardValues(
             $family,
@@ -56,6 +57,7 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
             ]
         );
         $this->assertComplete($productCompleteFalse);
+        $this->assertFilledInAttributeForProduct($productCompleteFalse, ['sku', 'a_boolean']);
     }
 
     public function testNotCompleteBoolean()
@@ -84,12 +86,14 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_boolean']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         // TODO: This is not as it should be, but inevitable because of PIM-6056
         // TODO: When PIM-6056 is fixed, we should be able to use "assertNotComplete"
         $this->assertComplete($productWithoutValues);
         $this->assertBooleanValueIsFalse($productWithoutValues, 'a_boolean');
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku', 'a_boolean']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class DateAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_date']);
     }
 
     public function testNotCompleteDate()
@@ -67,9 +68,11 @@ class DateAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_date']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValues);
         $this->assertMissingAttributeForProduct($productWithoutValues, ['a_date']);
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class FileAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_file']);
     }
 
     public function testNotCompleteFile()
@@ -67,9 +68,11 @@ class FileAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_file']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValues);
         $this->assertMissingAttributeForProduct($productWithoutValues, ['a_file']);
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
@@ -41,7 +41,10 @@ class IdentifierAttributeTypeCompletenessIntegration extends AbstractCompletenes
         );
 
         $this->assertComplete($productCompleteWithIdentifier);
+        $this->assertFilledInAttributeForProduct($productCompleteWithIdentifier, ['sku']);
+
         $this->assertComplete($productCompleteWithIdentifierUpdated);
+        $this->assertFilledInAttributeForProduct($productCompleteWithIdentifierUpdated, ['sku']);
     }
 
     /**
@@ -79,5 +82,6 @@ class IdentifierAttributeTypeCompletenessIntegration extends AbstractCompletenes
         $this->assertEquals(100, $completeness->getRatio());
         $this->assertEquals(1, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
+        $this->assertEquals(0, $completeness->getMissingAttributes()->count());
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class ImageAttributeTypeCompletenessIntegration extends AbstractCompletenessPerA
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'an_image']);
     }
 
     public function testNotCompleteImage()
@@ -67,9 +68,11 @@ class ImageAttributeTypeCompletenessIntegration extends AbstractCompletenessPerA
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['an_image']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValues);
         $this->assertMissingAttributeForProduct($productWithoutValues, ['an_image']);
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
@@ -40,6 +40,7 @@ class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
             ]
         );
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_metric']);
 
         $productAmountZero = $this->createProductWithStandardValues(
             $family,
@@ -57,6 +58,7 @@ class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
             ]
         );
         $this->assertComplete($productAmountZero);
+        $this->assertFilledInAttributeForProduct($productAmountZero, ['sku', 'a_metric']);
     }
 
     public function testNotCompleteMetric()
@@ -87,6 +89,7 @@ class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_metric']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productAmountNull = $this->createProductWithStandardValues(
             $family,
@@ -105,6 +108,7 @@ class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
         );
         $this->assertNotComplete($productAmountNull);
         $this->assertMissingAttributeForProduct($productAmountNull, ['a_metric']);
+        $this->assertFilledInAttributeForProduct($productAmountNull, ['sku']);
 
         $productAmountAndUnitNull = $this->createProductWithStandardValues(
             $family,
@@ -123,6 +127,7 @@ class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
         );
         $this->assertNotComplete($productAmountAndUnitNull);
         $this->assertMissingAttributeForProduct($productAmountAndUnitNull, ['a_metric']);
+        $this->assertFilledInAttributeForProduct($productAmountAndUnitNull, ['sku']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
@@ -38,6 +38,7 @@ class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
             ]
         );
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_number_integer']);
 
         $productCompleteWithZero = $this->createProductWithStandardValues(
             $family,
@@ -55,6 +56,7 @@ class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
             ]
         );
         $this->assertComplete($productCompleteWithZero);
+        $this->assertFilledInAttributeForProduct($productCompleteWithZero, ['sku', 'a_number_integer']);
     }
 
     public function testNotCompleteNumber()
@@ -83,9 +85,11 @@ class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_number_integer']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValue);
         $this->assertMissingAttributeForProduct($productWithoutValue, ['a_number_integer']);
+        $this->assertFilledInAttributeForProduct($productWithoutValue, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
@@ -34,6 +34,7 @@ class OptionAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_simple_select']);
     }
 
     public function testNotCompleteOption()
@@ -58,6 +59,7 @@ class OptionAttributeTypeCompletenessIntegration extends AbstractCompletenessPer
 
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_simple_select']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
@@ -33,6 +33,7 @@ class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
             ]
         );
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_multi_select']);
 
         $productCompleteOneOption = $this->createProductWithStandardValues(
             $family,
@@ -50,6 +51,7 @@ class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
             ]
         );
         $this->assertComplete($productCompleteOneOption);
+        $this->assertFilledInAttributeForProduct($productCompleteOneOption, ['sku', 'a_multi_select']);
     }
 
     public function testNotCompleteOptions()
@@ -73,6 +75,7 @@ class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         );
         $this->assertNotComplete($productDataEmptyArray);
         $this->assertMissingAttributeForProduct($productDataEmptyArray, ['a_multi_select']);
+        $this->assertFilledInAttributeForProduct($productDataEmptyArray, ['sku']);
 
         $productDataNull = $this->createProductWithStandardValues(
             $family,
@@ -91,6 +94,7 @@ class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_multi_select']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
@@ -131,8 +131,8 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
             ]
         );
         $this->assertCompleteOnChannel($productCompleteEcommerce, 'ecommerce');
-        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'print', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'print');
+        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'tablet');
 
         $productCompletePrint = $this->createProductWithStandardValues(
             $family,
@@ -154,9 +154,9 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
                 ],
             ]
         );
-        $this->assertNotCompleteOnChannel($productCompletePrint, 'ecommerce', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productCompletePrint, 'ecommerce');
         $this->assertCompleteOnChannel($productCompletePrint, 'print');
-        $this->assertNotCompleteOnChannel($productCompletePrint, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productCompletePrint, 'tablet');
     }
 
     public function testNotCompletePriceCollection()
@@ -164,9 +164,9 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
         $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
-        $this->assertNotCompleteOnChannel($productWithoutValues, 'ecommerce', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productWithoutValues, 'print', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productWithoutValues, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'print');
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'tablet');
 
         $productAmountsNull = $this->createProductWithStandardValues(
             $family,
@@ -192,9 +192,9 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
                 ],
             ]
         );
-        $this->assertNotCompleteOnChannel($productAmountsNull, 'ecommerce', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productAmountsNull, 'print', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productAmountsNull, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'print');
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'tablet');
 
         $productAmountNull = $this->createProductWithStandardValues(
             $family,
@@ -221,8 +221,8 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
             ]
         );
         $this->assertCompleteOnChannel($productAmountNull, 'ecommerce');
-        $this->assertNotCompleteOnChannel($productAmountNull, 'print', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productAmountNull, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productAmountNull, 'print');
+        $this->assertNotCompleteOnChannel($productAmountNull, 'tablet');
 
         $productMissingPrice = $this->createProductWithStandardValues(
             $family,
@@ -245,8 +245,8 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
             ]
         );
         $this->assertCompleteOnChannel($productMissingPrice, 'ecommerce');
-        $this->assertNotCompleteOnChannel($productMissingPrice, 'print', ['a_price_collection']);
-        $this->assertNotCompleteOnChannel($productMissingPrice, 'tablet', ['a_price_collection']);
+        $this->assertNotCompleteOnChannel($productMissingPrice, 'print');
+        $this->assertNotCompleteOnChannel($productMissingPrice, 'tablet');
     }
 
     /**
@@ -318,6 +318,7 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
         $this->assertEquals(2, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes($completeness, ['sku', 'a_price_collection']);
     }
 
     /**
@@ -326,9 +327,8 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
      *
      * @param ProductInterface $product
      * @param string           $channelCode
-     * @param string[]         $expectedAttributeCodes
      */
-    private function assertNotCompleteOnChannel(ProductInterface $product, $channelCode, array $expectedAttributeCodes)
+    private function assertNotCompleteOnChannel(ProductInterface $product, $channelCode)
     {
         $this->assertCompletenessesCount($product, 3);
 
@@ -341,7 +341,8 @@ class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractComple
         $this->assertEquals(50, $completeness->getRatio());
         $this->assertEquals(2, $completeness->getRequiredCount());
         $this->assertEquals(1, $completeness->getMissingCount());
-        $this->assertMissingAttributeCodes($completeness, $expectedAttributeCodes);
+        $this->assertMissingAttributeCodes($completeness, ['sku']);
+        $this->assertFilledInAttributeCodes($completeness, ['a_price_collection']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
@@ -41,6 +41,7 @@ class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCom
 
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_multi_select_reference_data']);
     }
 
     public function testNotCompleteMultiSelectReferenceData()
@@ -69,6 +70,7 @@ class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCom
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_multi_select_reference_data']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productDataEmptyArray = $this->createProductWithStandardValues(
             $family,
@@ -87,10 +89,12 @@ class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCom
         );
         $this->assertNotComplete($productDataEmptyArray);
         $this->assertMissingAttributeForProduct($productDataEmptyArray, ['a_multi_select_reference_data']);
+        $this->assertFilledInAttributeForProduct($productDataEmptyArray, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValues);
         $this->assertMissingAttributeForProduct($productWithoutValues, ['a_multi_select_reference_data']);
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
@@ -40,6 +40,7 @@ class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCo
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_simple_select_reference_data']);
     }
 
     public function testNotCompleteSimpleSelectReferenceData()
@@ -68,10 +69,12 @@ class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCo
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_simple_select_reference_data']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValues);
         $this->assertMissingAttributeForProduct($productWithoutValues, ['a_simple_select_reference_data']);
+        $this->assertFilledInAttributeForProduct($productWithoutValues, ['sku']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_text']);
     }
 
     public function testNotCompleteText()
@@ -67,6 +68,7 @@ class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_text']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productDataEmptyString = $this->createProductWithStandardValues(
             $family,
@@ -85,9 +87,11 @@ class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAt
         );
         $this->assertNotComplete($productDataEmptyString);
         $this->assertMissingAttributeForProduct($productDataEmptyString, ['a_text']);
+        $this->assertFilledInAttributeForProduct($productDataEmptyString, ['sku']);
 
         $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValue);
         $this->assertMissingAttributeForProduct($productWithoutValue, ['a_text']);
+        $this->assertFilledInAttributeForProduct($productWithoutValue, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
@@ -39,6 +39,7 @@ class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessP
         );
 
         $this->assertComplete($productComplete);
+        $this->assertFilledInAttributeForProduct($productComplete, ['sku', 'a_text_area']);
     }
 
     public function testNotCompleteTextarea()
@@ -67,6 +68,7 @@ class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessP
         );
         $this->assertNotComplete($productDataNull);
         $this->assertMissingAttributeForProduct($productDataNull, ['a_text_area']);
+        $this->assertFilledInAttributeForProduct($productDataNull, ['sku']);
 
         $productDataEmptyString = $this->createProductWithStandardValues(
             $family,
@@ -85,9 +87,11 @@ class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessP
         );
         $this->assertNotComplete($productDataEmptyString);
         $this->assertMissingAttributeForProduct($productDataEmptyString, ['a_text_area']);
+        $this->assertFilledInAttributeForProduct($productDataEmptyString, ['sku']);
 
         $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
         $this->assertNotComplete($productWithoutValue);
         $this->assertMissingAttributeForProduct($productWithoutValue, ['a_text_area']);
+        $this->assertFilledInAttributeForProduct($productWithoutValue, ['sku']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -57,8 +57,8 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
             ]
         );
 
-        $this->assertComplete($product, 'en_US', 2);
-        $this->assertNotComplete($product, 'fr_FR', 2, ['a_text']);
+        $this->assertComplete($product, 'en_US', 2, ['sku', 'a_text']);
+        $this->assertNotComplete($product, 'fr_FR', 2, ['a_text'], ['sku']);
     }
 
     public function testNotCompleteLocaleSpecificNoLocale()
@@ -79,8 +79,8 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
             $family,
             'product_locale_specific_no_locale'
         );
-        $this->assertNotComplete($productLocaleSpecificNoLocale, 'fr_FR', 2, ['a_text']);
-        $this->assertComplete($productLocaleSpecificNoLocale, 'en_US', 1);
+        $this->assertNotComplete($productLocaleSpecificNoLocale, 'fr_FR', 2, ['a_text'], ['sku']);
+        $this->assertComplete($productLocaleSpecificNoLocale, 'en_US', 1, ['sku']);
     }
 
     public function testNotCompleteLocaleSpecificLocaleEmpty()
@@ -112,8 +112,8 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
                 ]
             ]
         );
-        $this->assertNotComplete($productLocaleSpecificLocaleEmpty, 'fr_FR', 2, ['a_text']);
-        $this->assertComplete($productLocaleSpecificLocaleEmpty, 'en_US', 1);
+        $this->assertNotComplete($productLocaleSpecificLocaleEmpty, 'fr_FR', 2, ['a_text'], ['sku']);
+        $this->assertComplete($productLocaleSpecificLocaleEmpty, 'en_US', 1, ['sku']);
     }
 
     public function testCompleteLocaleSpecific()
@@ -145,8 +145,8 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
                 ]
             ]
         );
-        $this->assertComplete($productComplete, 'fr_FR', 2);
-        $this->assertComplete($productComplete, 'en_US', 1);
+        $this->assertComplete($productComplete, 'fr_FR', 2, ['sku', 'a_text']);
+        $this->assertComplete($productComplete, 'en_US', 1, ['sku']);
     }
 
     /**
@@ -197,13 +197,15 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
      * @param ProductInterface $product
      * @param string           $localeCode
      * @param int              $requiredCount
-     * @param array            $expectedAttributeCodes
+     * @param string[]         $expectedMissingAttributeCodes
+     * @param string[]         $expectedFilledInAttributeCodes
      */
     private function assertNotComplete(
         ProductInterface $product,
         $localeCode,
         $requiredCount,
-        array $expectedAttributeCodes
+        array $expectedMissingAttributeCodes,
+        array $expectedFilledInAttributeCodes
     ) {
         $this->assertCompletenessesCount($product, 2);
 
@@ -216,16 +218,22 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         $this->assertEquals(50, $completeness->getRatio());
         $this->assertEquals($requiredCount, $completeness->getRequiredCount());
         $this->assertEquals(1, $completeness->getMissingCount());
-        $this->assertMissingAttributeCodes($completeness, $expectedAttributeCodes);
+        $this->assertMissingAttributeCodes($completeness, $expectedMissingAttributeCodes);
+        $this->assertFilledInAttributeCodes($completeness, $expectedFilledInAttributeCodes);
     }
 
     /**
      * @param ProductInterface $product
      * @param string           $localeCode
      * @param int              $requiredCount
+     * @param string[]         $expectedFilledInAttributeCodes
      */
-    private function assertComplete(ProductInterface $product, $localeCode, $requiredCount)
-    {
+    private function assertComplete(
+        ProductInterface $product,
+        $localeCode,
+        $requiredCount,
+        array $expectedFilledInAttributeCodes
+    ) {
         $this->assertCompletenessesCount($product, 2);
 
         $completeness = $this->getCompletenessByLocaleCode($product, $localeCode);
@@ -238,5 +246,6 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         $this->assertEquals($requiredCount, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes($completeness, $expectedFilledInAttributeCodes);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -47,7 +47,7 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
             ]
         );
 
-        $this->assertComplete($product, 1);
+        $this->assertComplete($product, 1, ['sku']);
     }
 
     public function testAttributeRequiredByFamily()
@@ -75,16 +75,17 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
             ]
         );
 
-        $this->assertComplete($product, 2);
+        $this->assertComplete($product, 2, ['sku', 'a_text']);
     }
 
     /**
      * @param ProductInterface $product
      * @param int              $requiredCount
+     * @param string[]         $expectedFilledInAttributeCodes
      *
      * @internal param string $localeCode
      */
-    private function assertComplete(ProductInterface $product, $requiredCount)
+    private function assertComplete(ProductInterface $product, $requiredCount, array $expectedFilledInAttributeCodes)
     {
         $this->assertCompletenessesCount($product, 1);
 
@@ -98,6 +99,7 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
         $this->assertEquals($requiredCount, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes($completeness, $expectedFilledInAttributeCodes);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -40,6 +40,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(5, $completeness->getRequiredCount());
         $this->assertEquals(3, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['name', 'price', 'size']);
+        $this->assertFilledInAttributeCodes($completeness, ['sku', 'color']);
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'en_US');
         $this->assertNotNull($completeness->getLocale());
@@ -53,6 +54,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
             $completeness,
             ['name', 'price', 'size', 'description', 'rating', 'side_view']
         );
+        $this->assertFilledInAttributeCodes($completeness, ['sku', 'color']);
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'fr_FR');
         $this->assertNotNull($completeness->getLocale());
@@ -63,6 +65,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(5, $completeness->getRequiredCount());
         $this->assertEquals(2, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['price', 'size']);
+        $this->assertFilledInAttributeCodes($completeness, ['sku', 'color', 'name']);
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'fr_FR');
         $this->assertNotNull($completeness->getLocale());
@@ -73,6 +76,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(8, $completeness->getRequiredCount());
         $this->assertEquals(4, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['price', 'size', 'rating', 'side_view']);
+        $this->assertFilledInAttributeCodes($completeness, ['sku', 'color', 'description', 'name']);
     }
 
     public function testProductCompleteOnOneChannel()
@@ -98,6 +102,10 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(5, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes(
+            $completeness,
+            ['sku', 'color', 'name', 'price', 'size', 'weather_conditions']
+        );
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'en_US');
         $this->assertNotNull($completeness->getLocale());
@@ -108,6 +116,10 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(9, $completeness->getRequiredCount());
         $this->assertEquals(1, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['side_view']);
+        $this->assertFilledInAttributeCodes(
+            $completeness,
+            ['sku', 'color', 'description', 'name', 'price', 'rating', 'size', 'weather_conditions']
+        );
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'fr_FR');
         $this->assertNotNull($completeness->getLocale());
@@ -118,6 +130,10 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(5, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes(
+            $completeness,
+            ['sku', 'color', 'name', 'price', 'size']
+        );
 
         $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'fr_FR');
         $this->assertNotNull($completeness->getLocale());
@@ -128,6 +144,10 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals(9, $completeness->getRequiredCount());
         $this->assertEquals(2, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['description', 'side_view']);
+        $this->assertFilledInAttributeCodes(
+            $completeness,
+            ['sku', 'color', 'name', 'price', 'rating', 'size', 'weather_conditions']
+        );
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
@@ -45,7 +45,7 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIn
             ]
         );
 
-        $this->assertComplete($product, 'ecommerce');
+        $this->assertComplete($product, 'ecommerce', ['sku', 'a_text']);
     }
 
     public function testNotCompleteScopable()
@@ -60,7 +60,7 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIn
         );
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_witout_values');
-        $this->assertNotComplete($productWithoutValues, 'ecommerce', ['a_text']);
+        $this->assertNotComplete($productWithoutValues, 'ecommerce', ['a_text'], ['sku']);
 
         $productDataEmpty = $this->createProductWithStandardValues(
             $family,
@@ -77,16 +77,21 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIn
                 ]
             ]
         );
-        $this->assertNotComplete($productDataEmpty, 'ecommerce', ['a_text']);
+        $this->assertNotComplete($productDataEmpty, 'ecommerce', ['a_text'], ['sku']);
     }
 
     /**
      * @param ProductInterface $product
      * @param string           $channelCode
-     * @param array            $expectedAttributeCodes
+     * @param string[]         $expectedMissingAttributeCodes
+     * @param string[]         $expectedFilledInAttributeCodes
      */
-    private function assertNotComplete(ProductInterface $product, $channelCode, array $expectedAttributeCodes)
-    {
+    private function assertNotComplete(
+        ProductInterface $product,
+        $channelCode,
+        array $expectedMissingAttributeCodes,
+        array $expectedFilledInAttributeCodes
+    ) {
         $this->assertCompletenessesCount($product, 1);
 
         $completeness = $this->getCurrentCompleteness($product);
@@ -98,14 +103,16 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIn
         $this->assertEquals(50, $completeness->getRatio());
         $this->assertEquals(2, $completeness->getRequiredCount());
         $this->assertEquals(1, $completeness->getMissingCount());
-        $this->assertMissingAttributeCodes($completeness, $expectedAttributeCodes);
+        $this->assertMissingAttributeCodes($completeness, $expectedMissingAttributeCodes);
+        $this->assertFilledInAttributeCodes($completeness, $expectedFilledInAttributeCodes);
     }
 
     /**
      * @param ProductInterface $product
      * @param string           $channelCode
+     * @param string[]         $expectedFilledInAttributeCodes
      */
-    private function assertComplete(ProductInterface $product, $channelCode)
+    private function assertComplete(ProductInterface $product, $channelCode, array $expectedFilledInAttributeCodes)
     {
         $this->assertCompletenessesCount($product, 1);
 
@@ -119,5 +126,6 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIn
         $this->assertEquals(2, $completeness->getRequiredCount());
         $this->assertEquals(0, $completeness->getMissingCount());
         $this->assertEquals(0, $completeness->getMissingAttributes()->count());
+        $this->assertFilledInAttributeCodes($completeness, $expectedFilledInAttributeCodes);
     }
 }

--- a/src/Pim/Component/Catalog/Completeness/CompletenessCalculator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessCalculator.php
@@ -194,7 +194,9 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
 
         $actualValues = $product->getValues();
         $missingAttributes = new ArrayCollection();
+        $filledInAttributes = new ArrayCollection();
         $missingCount = 0;
+        $filledInCount = 0;
         $requiredCount = 0;
 
         foreach ($requiredValues as $requiredValue) {
@@ -209,10 +211,11 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
             if (null === $productValue ||
                 !$this->productValueCompleteChecker->isComplete($productValue, $channel, $locale)
             ) {
-                if (!$missingAttributes->contains($attribute)) {
-                    $missingAttributes->add($attribute);
-                    $missingCount++;
-                }
+                $missingAttributes->add($attribute);
+                $missingCount++;
+            } else {
+                $filledInAttributes->add($attribute);
+                $filledInCount++;
             }
 
             $requiredCount++;
@@ -223,7 +226,9 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
             $channel,
             $locale,
             $missingAttributes,
+            $filledInAttributes,
             $missingCount,
+            $filledInCount,
             $requiredCount
         );
 

--- a/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
+++ b/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
@@ -2,9 +2,7 @@
 
 namespace Pim\Component\Catalog\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Pim\Bundle\CatalogBundle\Entity\Locale;
 
 /**
  * Abstract product completeness entity
@@ -21,30 +19,38 @@ abstract class AbstractCompleteness implements CompletenessInterface
     /** @var ProductInterface */
     protected $product;
 
-    /** @var LocaleInterface */
-    protected $locale;
-
     /** @var ChannelInterface */
     protected $channel;
 
-    /** @var int */
-    protected $ratio;
+    /** @var LocaleInterface */
+    protected $locale;
+
+    /** @var Collection */
+    protected $missingAttributes;
+
+    /** @var Collection */
+    protected $filledInAttributes;
 
     /** @var int */
     protected $missingCount;
 
     /** @var int */
+    protected $filledInCount;
+
+    /** @var int */
     protected $requiredCount;
 
-    /** @var Collection */
-    protected $missingAttributes;
+    /** @var int */
+    protected $ratio;
 
     /**
      * @param ProductInterface $product
      * @param ChannelInterface $channel
      * @param LocaleInterface  $locale
      * @param Collection       $missingAttributes
+     * @param Collection       $filledInAttributes
      * @param int              $missingCount
+     * @param int              $filledInCount
      * @param int              $requiredCount
      */
     public function __construct(
@@ -52,14 +58,18 @@ abstract class AbstractCompleteness implements CompletenessInterface
         ChannelInterface $channel,
         LocaleInterface $locale,
         Collection $missingAttributes,
+        Collection $filledInAttributes,
         $missingCount,
+        $filledInCount,
         $requiredCount
     ) {
         $this->product = $product;
         $this->channel = $channel;
         $this->locale = $locale;
         $this->missingAttributes = $missingAttributes;
+        $this->filledInAttributes = $filledInAttributes;
         $this->missingCount = $missingCount;
+        $this->filledInCount = $filledInCount;
         $this->requiredCount = $requiredCount;
 
         $this->ratio = (int) round(100 * ($this->requiredCount - $this->missingCount) / $this->requiredCount);
@@ -76,9 +86,9 @@ abstract class AbstractCompleteness implements CompletenessInterface
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
+    public function getProduct()
     {
-        return $this->locale;
+        return $this->product;
     }
 
     /**
@@ -92,9 +102,25 @@ abstract class AbstractCompleteness implements CompletenessInterface
     /**
      * {@inheritdoc}
      */
-    public function getRatio()
+    public function getLocale()
     {
-        return $this->ratio;
+        return $this->locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMissingAttributes()
+    {
+        return $this->missingAttributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilledInAttributes()
+    {
+        return $this->filledInAttributes;
     }
 
     /**
@@ -108,6 +134,14 @@ abstract class AbstractCompleteness implements CompletenessInterface
     /**
      * {@inheritdoc}
      */
+    public function getFilledInCount()
+    {
+        return $this->filledInCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRequiredCount()
     {
         return $this->requiredCount;
@@ -116,16 +150,8 @@ abstract class AbstractCompleteness implements CompletenessInterface
     /**
      * {@inheritdoc}
      */
-    public function getProduct()
+    public function getRatio()
     {
-        return $this->product;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMissingAttributes()
-    {
-        return $this->missingAttributes;
+        return $this->ratio;
     }
 }

--- a/src/Pim/Component/Catalog/Model/CompletenessInterface.php
+++ b/src/Pim/Component/Catalog/Model/CompletenessInterface.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Catalog\Model;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * Product completeness interface
+ * Product completeness interface, define the completeness of the enrichment of the product.
  *
  * @author    Julien Janvier <julien.janvier@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
@@ -19,51 +19,67 @@ interface CompletenessInterface
     public function getId();
 
     /**
-     * Getter required count
-     *
-     * @return int
-     */
-    public function getRequiredCount();
-
-    /**
-     * Getter ratio
-     *
-     * @return int
-     */
-    public function getRatio();
-
-    /**
-     * Getter locale
-     *
-     * @return LocaleInterface
-     */
-    public function getLocale();
-
-    /**
-     * Getter channel
-     *
-     * @return ChannelInterface
-     */
-    public function getChannel();
-
-    /**
-     * Getter missing count
-     *
-     * @return int
-     */
-    public function getMissingCount();
-
-    /**
-     * Getter product
+     * Returns the completeness corresponding product.
      *
      * @return ProductInterface
      */
     public function getProduct();
 
     /**
-     * Get the missing attributes
+     * Returns the completeness corresponding channel.
+     *
+     * @return ChannelInterface
+     */
+    public function getChannel();
+
+    /**
+     * Returns the completeness corresponding locale.
+     *
+     * @return LocaleInterface
+     */
+    public function getLocale();
+
+    /**
+     * Returns the collection of the attributes corresponding to the missing
+     * (i.e. incomplete) product values.
      *
      * @return Collection
      */
     public function getMissingAttributes();
+
+    /**
+     * Returns the collection of the attributes corresponding to the already
+     * filled in (i.e. complete) product values.
+     *
+     * @return Collection
+     */
+    public function getFilledInAttributes();
+
+    /**
+     * Returns the number of missing product values.
+     *
+     * @return int
+     */
+    public function getMissingCount();
+
+    /**
+     * Returns the number of already filled in product values.
+     *
+     * @return int
+     */
+    public function getFilledInCount();
+
+    /**
+     * Returns the total number of required product values for the product to be complete.
+     *
+     * @return int
+     */
+    public function getRequiredCount();
+
+    /**
+     * Returns the completeness ratio (percentage).
+     *
+     * @return int
+     */
+    public function getRatio();
 }

--- a/src/Pim/Component/Catalog/Model/ProductValueCollectionInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductValueCollectionInterface.php
@@ -136,7 +136,7 @@ interface ProductValueCollectionInterface extends \Countable, \IteratorAggregate
     /**
      * Gets a native PHP array representation of the collection.
      *
-     * @return array
+     * @return ProductValueInterface[]
      */
     public function toArray();
 


### PR DESCRIPTION
## Description

When introducing the new "completeness calculator", we added the missing product values (i.e. incomplete product values) to the completeness, so it is stored in the database and usable for SQL requests.

In the same spirit, this PR adds filled in product values (i.e. product values that are already complete).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
