### PR TITLE
TIP-706: tiny enhancements on the completenesses

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -863,13 +863,15 @@ Equals (=)
 
 Completeness
 ************
-:Apply: 'completenesses' field
+:Apply: 'completeness' field
 
 Data model
 ~~~~~~~~~~
+As completenesses are indexed by channel and locale, the "completeness" dynamic template is applied to this field. Completenesses' ratios are indexed as integers.
+
 .. code-block:: yaml
 
-    completenesses:
+    completeness:
         print:
             en_US: 100
             fr_FR: 89
@@ -888,7 +890,7 @@ Example with the ``>`` operator:
 .. code-block:: yaml
 
     range:
-        completenesses.print.en_US:
+        completeness.print.en_US:
             gt: 4
 
 Category

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -1,6 +1,7 @@
 mappings:
     pim_catalog_product:
         properties:
+            # "completeness" property is handled by the "completeness" dynamic template
             categories:
                 type: 'keyword'
             family:
@@ -12,10 +13,6 @@ mappings:
             identifier:
                 type: 'keyword'
                 normalizer: 'varchar_normalizer'
-            # TODO TIP-706: we'll do this mapping with the numbers' mapping, as we don't know yet
-            # TODO TIP-706: how we should configure the index for such cases
-#            completenesses:
-#                type: ?
         dynamic_templates:
             -
                 text:
@@ -35,7 +32,12 @@ mappings:
                     mapping:
                         type: 'keyword'
                         normalizer: 'varchar_normalizer'
-
+            -
+                completeness:
+                     path_match: 'completeness.*'
+                     match_mapping_type: 'long'
+                     mapping:
+                         type: 'integer'
 settings:
     analysis:
         normalizer:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessFloorRoundedRatioIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessFloorRoundedRatioIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Pim\Component\Catalog\AttributeTypes;
+
+class CompletenessFloorRoundedRatioIntegration extends AbstractCompletenessIntegration
+{
+    public function testFloorRoundedRatio()
+    {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier('ecommerce');
+        $extraAttribute = $this->createAttribute('a_number', AttributeTypes::NUMBER);
+
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT
+        );
+
+        $requirement = $this->get('pim_catalog.factory.attribute_requirement')
+            ->createAttributeRequirement($extraAttribute, $channel, true);
+        $family->addAttributeRequirement($requirement);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        $firstProduct = $this->createProductWithStandardValues(
+            $family,
+            'one_third_of_the_attributes_filled_in',
+            [
+                'values' => [
+                    'a_text'   => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                    'a_number' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        // the real ratio would 1/3 = 33.33333...%
+        // here we want to floor to 33%
+        $this->assertEquals(33, $firstProduct->getCompletenesses()->first()->getRatio());
+
+        $secondProduct = $this->createProductWithStandardValues(
+            $family,
+            'two_third_of_the_attributes_filled_in',
+            [
+                'values' => [
+                    'a_text'   => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'Just a text.',
+                        ],
+                    ],
+                    'a_number' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        // the real ratio would 123 = 66.666666...%
+        // here we want to floor to 66%
+        $this->assertEquals(66, $secondProduct->getCompletenesses()->first()->getRatio());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -104,7 +104,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals('en_US', $completeness->getLocale()->getCode());
         $this->assertNotNull($completeness->getChannel());
         $this->assertEquals('tablet', $completeness->getChannel()->getCode());
-        $this->assertEquals(89, $completeness->getRatio());
+        $this->assertEquals(88, $completeness->getRatio());
         $this->assertEquals(9, $completeness->getRequiredCount());
         $this->assertEquals(1, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['side_view']);
@@ -124,7 +124,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
         $this->assertEquals('fr_FR', $completeness->getLocale()->getCode());
         $this->assertNotNull($completeness->getChannel());
         $this->assertEquals('tablet', $completeness->getChannel()->getCode());
-        $this->assertEquals(78, $completeness->getRatio());
+        $this->assertEquals(77, $completeness->getRatio());
         $this->assertEquals(9, $completeness->getRequiredCount());
         $this->assertEquals(2, $completeness->getMissingCount());
         $this->assertMissingAttributeCodes($completeness, ['description', 'side_view']);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -17,8 +17,8 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
      * |               | fr_FR | en_US | fr_FR | en_US | de_DE | en_US | zh_CN   |
      * +---------------+-------+-------+-------+---------------------------------+
      * | empty_product |   -   |  33%  |  25%  | 25%   |  25%  | 100%  | 100%    |
-     * | product_one   |   -   |  67%  |  50%  | 50%   |  50%  | 100%  | 100%    |
-     * | product_two   |   -   |  67%  |  75%  | 100%  |  75%  | 100%  | 100%    |
+     * | product_one   |   -   |  66%  |  50%  | 50%   |  50%  | 100%  | 100%    |
+     * | product_two   |   -   |  66%  |  75%  | 100%  |  75%  | 100%  | 100%    |
      * | no_family     |   -   |  -    |   -   |   -   |   -   |   -   |   -     |
      * +-------------------------------------------------------------------------+
      *
@@ -165,7 +165,7 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
         $result = $this->execute([['completeness', $operator, 25, ['scope' => 'tablet', 'locale' => 'fr_FR']]]);
         $this->assert($result, ['empty_product']);
 
-        $result = $this->execute([['completeness', $operator, 67, ['scope' => 'ecommerce']]]);
+        $result = $this->execute([['completeness', $operator, 66, ['scope' => 'ecommerce']]]);
         $this->assert($result, ['product_one', 'product_two']);
     }
 
@@ -312,13 +312,13 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
 
     public function testOperatorLowerThanAllLocales()
     {
-        $result = $this->execute([['completeness', Operators::LOWER_THAN_ON_ALL_LOCALES, 67, [
+        $result = $this->execute([['completeness', Operators::LOWER_THAN_ON_ALL_LOCALES, 66, [
             'scope'   => 'ecommerce',
             'locales' => ['en_US']
         ]]]);
         $this->assert($result, ['empty_product']);
 
-        $result = $this->execute([['completeness', Operators::LOWER_THAN_ON_ALL_LOCALES, 67, [
+        $result = $this->execute([['completeness', Operators::LOWER_THAN_ON_ALL_LOCALES, 66, [
             'scope'   => 'ecommerce',
             'locales' => ['fr_FR', 'en_US']
         ]]]);
@@ -339,13 +339,13 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
 
     public function testOperatorLowerOrEqualThanAllLocales()
     {
-        $result = $this->execute([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 67, [
+        $result = $this->execute([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 66, [
             'scope'   => 'ecommerce',
             'locales' => ['en_US']
         ]]]);
         $this->assert($result, ['product_one', 'product_two', 'empty_product']);
 
-        $result = $this->execute([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 67, [
+        $result = $this->execute([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 66, [
             'scope'   => 'ecommerce',
             'locales' => ['fr_FR', 'en_US']
         ]]]);

--- a/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
+++ b/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
@@ -62,7 +62,7 @@ abstract class AbstractCompleteness implements CompletenessInterface
         $this->missingCount = $missingCount;
         $this->requiredCount = $requiredCount;
 
-        $this->ratio = (int) round(100 * ($this->requiredCount - $this->missingCount) / $this->requiredCount);
+        $this->ratio = (int) floor(100 * ($this->requiredCount - $this->missingCount) / $this->requiredCount);
     }
 
     /**


### PR DESCRIPTION
Two small things here:
- make the ES completeness indexing configuration explicit
- ensure we floor the completeness ratio to avoid to have a misleading 100% ratio with a missing attribute 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Y
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
