### PR TITLE
TIP-706: Add simple text normalizer for indexing

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/TextFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/TextFilter.php
@@ -52,7 +52,7 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
-            $value = $this->escapeValue($value);
+            $escapedValue = $this->escapeValue($value);
         }
 
         $attributePath = $this->getAttributePath($attribute, $locale, $channel);
@@ -62,7 +62,7 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
-                        'query'         => $value . '*',
+                        'query'         => $escapedValue . '*',
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -72,7 +72,7 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
-                        'query'         => '*' . $value . '*',
+                        'query'         => '*' . $escapedValue . '*',
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -82,16 +82,11 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 $mustNotClause = [
                     'query_string' => [
                         'default_field' => $attributePath,
-                        'query'         => '*' . $value . '*',
+                        'query'         => '*' . $escapedValue . '*',
                     ],
                 ];
 
-                $filterClause = [
-                    'exists' => ['field' => $attributePath],
-                ];
-
                 $this->searchQueryBuilder->addMustNot($mustNotClause);
-                $this->searchQueryBuilder->addFilter($filterClause);
                 break;
 
             case Operators::EQUALS:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -15,6 +15,7 @@ parameters:
     pim_catalog.query.elasticsearch.filter.identifier.class:      Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter
     pim_catalog.query.elasticsearch.filter.completeness.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\CompletenessFilter
     pim_catalog.query.elasticsearch.filter.number.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\NumberFilter
+    pim_catalog.query.elasticsearch.filter.text.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\TextFilter
 
 services:
     pim_catalog.query.product_query_builder_factory:
@@ -167,3 +168,11 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.text:
+        class: '%pim_catalog.query.elasticsearch.filter.text.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_text']
+            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -6,6 +6,7 @@ parameters:
     pim_catalog.normalizer.indexing.product.completeness_collection.class: Pim\Component\Catalog\Normalizer\Indexing\Product\CompletenessCollectionNormalizer
     pim_catalog.normalizer.indexing.product.number.class: Pim\Component\Catalog\Normalizer\Indexing\Product\NumberNormalizer
     pim_catalog.normalizer.indexing.product.dummy.class: Pim\Component\Catalog\Normalizer\Indexing\Product\DummyNormalizer
+    pim_catalog.normalizer.indexing.product.text.class: Pim\Component\Catalog\Normalizer\Indexing\Product\TextNormalizer
 
 services:
     pim_catalog.normalizer.indexing.product:
@@ -46,3 +47,8 @@ services:
         class: '%pim_catalog.normalizer.indexing.product.dummy.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 80 }
+
+    pim_catalog.normalizer.indexing.text:
+        class: '%pim_catalog.normalizer.indexing.product.text.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -15,7 +15,7 @@ mappings:
                 normalizer: 'varchar_normalizer'
         dynamic_templates:
             -
-                text:
+                text_area:
                     match: '*-text'
                     match_mapping_type: 'string'
                     mapping:
@@ -26,8 +26,8 @@ mappings:
                         type: 'text'
                         analyzer: 'text_analyzer'
             -
-                varchar:
-                    match: '*-varchar'
+                text:
+                    path_match: 'values.*-varchar.*'
                     match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/TextFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/TextFilterSpec.php
@@ -185,12 +185,6 @@ class TextFilterSpec extends ObjectBehavior
             ]
         )->shouldBeCalled();
 
-        $sqb->addFilter([
-            'exists' => [
-                'field' => 'values.name-varchar.en_US.ecommerce'
-            ],
-        ])->shouldBeCalled();
-
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::DOES_NOT_CONTAIN, 'sony', 'en_US', 'ecommerce', []);
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
@@ -41,7 +41,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'filter' => [
                         'query_string' => [
-                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
+                            'default_field'       => 'values.name-varchar.<all_locales>.<all_channels>',
                             'query'               => 'My\ product*',
                             'split_on_whitespace' => true,
                         ],
@@ -106,32 +106,28 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                             'query'         => '*Love*',
                         ],
                     ],
-                    'filter'   => [
-                        'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
-                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertProducts($productsFound, ['product_1', 'product_2', 'product_5']);
+        $this->assertProducts($productsFound, ['product_1', 'product_2', 'product_4', 'product_5']);
     }
 
     public function testEqualsOperator()
     {
-        $query =
-            [
-                'query' => [
-                    'bool' => [
-                        'filter' => [
-                            'term' => [
-                                'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
-                            ],
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'term' => [
+                            'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
                         ],
                     ],
                 ],
-            ];
+            ],
+        ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -140,21 +136,20 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
 
     public function testNotEqualsOperator()
     {
-        $query =
-            [
-                'query' => [
-                    'bool' => [
-                        'must_not' => [
-                            'term' => [
-                                'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
-                            ],
-                        ],
-                        'filter'   => [
-                            'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'term' => [
+                            'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
                         ],
                     ],
+                    'filter'   => [
+                        'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
+                    ],
                 ],
-            ];
+            ],
+        ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -166,8 +161,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
 
     public function testEmptyOperator()
     {
-        $query =
-            [
+        $query = [
                 'query' => [
                     'bool' => [
                         'must_not' => [
@@ -184,8 +178,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
 
     public function testNotEmptyOperator()
     {
-        $query =
-            [
+        $query = [
                 'query' => [
                     'bool' => [
                         'filter' => [
@@ -274,7 +267,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'Another product',
                         ],
-                    ]
+                    ],
                 ],
             ],
             [
@@ -284,7 +277,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'Yeah, love this name',
                         ],
-                    ]
+                    ],
                 ],
             ],
             [
@@ -297,7 +290,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'And an uppercase NAME',
                         ],
-                    ]
+                    ],
                 ],
             ],
             [
@@ -307,7 +300,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'Love this product',
                         ],
-                    ]
+                    ],
                 ],
             ],
             [
@@ -317,7 +310,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'I.love.dots',
                         ],
-                    ]
+                    ],
                 ],
             ],
             [
@@ -327,7 +320,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                         '<all_locales>' => [
                             '<all_channels>' => 'I-love.dots',
                         ],
-                    ]
+                    ],
                 ],
             ],
         ];

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
@@ -21,7 +21,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'filter' => [
                         'query_string' => [
-                            'default_field' => 'name-varchar',
+                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
                             'query'         => 'an*',
                         ],
                     ],
@@ -41,9 +41,9 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'filter' => [
                         'query_string' => [
-                            'default_field' => 'name-varchar',
-                            'query'         => 'My\ product*',
-                            'split_on_whitespace' => true
+                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
+                            'query'               => 'My\ product*',
+                            'split_on_whitespace' => true,
                         ],
                     ],
                 ],
@@ -62,7 +62,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'filter' => [
                         'query_string' => [
-                            'default_field' => 'name-varchar',
+                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
                             'query'         => '*Love*',
                         ],
                     ],
@@ -82,7 +82,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'filter' => [
                         'query_string' => [
-                            'default_field' => 'name-varchar',
+                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
                             'query'         => '*Love\\ this*',
                         ],
                     ],
@@ -102,12 +102,12 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'bool' => [
                     'must_not' => [
                         'query_string' => [
-                            'default_field' => 'name-varchar',
+                            'default_field' => 'values.name-varchar.<all_locales>.<all_channels>',
                             'query'         => '*Love*',
                         ],
                     ],
                     'filter'   => [
-                        'exists' => ['field' => 'name-varchar'],
+                        'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
                     ],
                 ],
             ],
@@ -126,13 +126,12 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                     'bool' => [
                         'filter' => [
                             'term' => [
-                                'name-varchar' => 'I-love.dots',
+                                'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
                             ],
                         ],
                     ],
                 ],
-            ]
-        ;
+            ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -147,16 +146,15 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                     'bool' => [
                         'must_not' => [
                             'term' => [
-                                'name-varchar' => 'I-love.dots',
+                                'values.name-varchar.<all_locales>.<all_channels>' => 'I-love.dots',
                             ],
                         ],
-                        'filter' => [
-                            'exists' => ['field' => 'name-varchar'],
+                        'filter'   => [
+                            'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
                         ],
                     ],
                 ],
-            ]
-        ;
+            ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -173,12 +171,11 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'query' => [
                     'bool' => [
                         'must_not' => [
-                            'exists' => ['field' => 'name-varchar'],
+                            'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
                         ],
                     ],
                 ],
-            ]
-        ;
+            ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -192,12 +189,11 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
                 'query' => [
                     'bool' => [
                         'filter' => [
-                            'exists' => ['field' => 'name-varchar'],
+                            'exists' => ['field' => 'values.name-varchar.<all_locales>.<all_channels>'],
                         ],
                     ],
                 ],
-            ]
-        ;
+            ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -215,7 +211,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
             ],
             'sort'  => [
                 [
-                    'name-varchar' => [
+                    'values.name-varchar.<all_locales>.<all_channels>' => [
                         'order'   => 'asc',
                         'missing' => '_first',
                     ],
@@ -239,7 +235,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
             ],
             'sort'  => [
                 [
-                    'name-varchar' => [
+                    'values.name-varchar.<all_locales>.<all_channels>' => [
                         'order'   => 'desc',
                         'missing' => '_last',
                     ],
@@ -262,35 +258,77 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
     {
         $products = [
             [
-                'identifier'   => 'product_1',
-                'name-varchar' => 'My product',
+                'identifier' => 'product_1',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'My product',
+                        ],
+                    ],
+                ],
             ],
             [
-                'identifier'   => 'product_2',
-                'name-varchar' => 'Another product',
+                'identifier' => 'product_2',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'Another product',
+                        ],
+                    ]
+                ],
             ],
             [
-                'identifier'   => 'product_3',
-                'name-varchar' => 'Yeah, love this name',
+                'identifier' => 'product_3',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'Yeah, love this name',
+                        ],
+                    ]
+                ],
             ],
             [
-                'identifier'  => 'product_4',
+                'identifier' => 'product_4',
             ],
             [
-                'identifier'   => 'product_5',
-                'name-varchar' => 'And an uppercase NAME',
+                'identifier' => 'product_5',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'And an uppercase NAME',
+                        ],
+                    ]
+                ],
             ],
             [
-                'identifier'   => 'product_6',
-                'name-varchar' => 'Love this product',
+                'identifier' => 'product_6',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'Love this product',
+                        ],
+                    ]
+                ],
             ],
             [
-                'identifier'   => 'product_7',
-                'name-varchar' => 'I.love.dots',
+                'identifier' => 'product_7',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'I.love.dots',
+                        ],
+                    ]
+                ],
             ],
             [
-                'identifier'   => 'product_8',
-                'name-varchar' => 'I-love.dots',
+                'identifier' => 'product_8',
+                'values'     => [
+                    'name-varchar' => [
+                        '<all_locales>' => [
+                            '<all_channels>' => 'I-love.dots',
+                        ],
+                    ]
+                ],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_localizable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/ScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_scopable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
@@ -20,6 +20,8 @@ class TextFilterIntegration extends AbstractFilterTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createProduct('cat', [
                 'values' => [
                     'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]]

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
@@ -24,26 +24,26 @@ class TextFilterIntegration extends AbstractFilterTestCase
 
             $this->createProduct('cat', [
                 'values' => [
-                    'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]]
-                ]
+                    'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]],
+                ],
             ]);
 
             $this->createProduct('cattle', [
                 'values' => [
-                    'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]]
-                ]
+                    'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]],
+                ],
             ]);
 
             $this->createProduct('dog', [
                 'values' => [
-                    'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]]
-                ]
+                    'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]],
+                ],
             ]);
 
             $this->createProduct('best_dog', [
                 'values' => [
-                    'a_text' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]]
-                ]
+                    'a_text' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]],
+                ],
             ]);
 
             // There is no html tags in TEXT attributes usually set in the PIM.
@@ -52,12 +52,12 @@ class TextFilterIntegration extends AbstractFilterTestCase
                 'values' => [
                     'a_text' => [
                         [
-                            'data' => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
+                            'data'   => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
                             'locale' => null,
-                            'scope' => null,
+                            'scope'  => null,
                         ],
                     ],
-                ]
+                ],
             ]);
 
             $this->createProduct('empty_product', []);
@@ -103,7 +103,7 @@ class TextFilterIntegration extends AbstractFilterTestCase
     public function testOperatorDoesNotContain()
     {
         $result = $this->execute([['a_text', Operators::DOES_NOT_CONTAIN, 'at']]);
-        $this->assert($result, ['dog', 'best_dog','empty_product']);
+        $this->assert($result, ['dog', 'best_dog', 'empty_product']);
 
         $result = $this->execute([['a_text', Operators::DOES_NOT_CONTAIN, 'other']]);
         $this->assert($result, ['cat', 'cattle', 'dog', 'best_dog', 'best_cat', 'empty_product']);
@@ -112,7 +112,9 @@ class TextFilterIntegration extends AbstractFilterTestCase
         $this->assert($result, ['cat', 'cattle', 'dog', 'best_dog', 'empty_product']);
 
         $result = $this->execute([['a_text', Operators::DOES_NOT_CONTAIN, 'most beautiful']]);
-        $this->assert($result, ['cat', 'cattle', 'dog', 'empty_product']);
+
+        // best_cat does not contain "most beautiful" because it is wrapped in HTML tags
+        $this->assert($result, ['cat', 'best_cat', 'cattle', 'dog', 'empty_product']);
     }
 
     public function testOperatorEquals()
@@ -151,7 +153,7 @@ class TextFilterIntegration extends AbstractFilterTestCase
     public function testOperatorDifferent()
     {
         $result = $this->execute([['a_text', Operators::NOT_EQUAL, 'dog']]);
-        $this->assert($result, ['cat', 'cattle', 'best_cat']);
+        $this->assert($result, ['cat', 'cattle', 'best_cat', 'best_dog']);
 
         $result = $this->execute([['a_text', Operators::NOT_EQUAL, 'cat']]);
         $this->assert($result, ['cattle', 'dog', 'best_dog', 'best_cat']);

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizer for a text (simple text) product value
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TextNormalizer extends AbstractProductValueNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ProductValueInterface &&
+            AttributeTypes::BACKEND_TYPE_VARCHAR === $data->getAttribute()->getBackendType() &&
+            'indexing' === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNormalizedData(ProductValueInterface $productValue)
+    {
+        return $productValue->getData();
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -106,7 +106,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             $values = [];
             foreach ($criteria as $item) {
                 $data = $item['attribute']->isBackendTypeReferenceData() ? $item['referenceData']['data'] : $item['option'];
-                $values[] = sprintf('%s: %s', $item['attribute']->getCode(), (string) $data);
+                $values[] = sprintf('%s: %s', $item['attribute']->getCode(), (string)$data);
             }
             $this->addExistingCombinationViolation($constraint, $group->getLabel(), implode(', ', $values));
         }
@@ -126,8 +126,8 @@ class UniqueVariantAxisValidator extends ConstraintValidator
         ProductInterface $product,
         Constraint $constraint
     ) {
-            $criteria = [];
-            foreach ($variantGroup->getAxisAttributes() as $attribute) {
+        $criteria = [];
+        foreach ($variantGroup->getAxisAttributes() as $attribute) {
             $value = $product->getValue($attribute->getCode());
             $isOption = $value instanceof OptionProductValueInterface;
 
@@ -219,7 +219,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             $constraint->message,
             [
                 '%variant group%' => $variantLabel,
-                '%values%'        => $values
+                '%values%'        => $values,
             ]
         )->atPath($constraint->propertyPath)->addViolation();
     }
@@ -237,7 +237,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             [
                 '%group%'   => $variantLabel,
                 '%product%' => $productIdentifier,
-                '%axis%'    => $axisCode
+                '%axis%'    => $axisCode,
             ]
         )->atPath($constraint->propertyPath)->addViolation();
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/ProductValueCollectionNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/ProductValueCollectionNormalizerSpec.php
@@ -4,7 +4,7 @@ namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\ProductValue;
+use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductValueCollectionNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -33,10 +33,10 @@ class ProductValueCollectionNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($productValueCollection, 'indexing')->shouldReturn(true);
     }
 
-    function it_normalize_product_value_collection(
+    function it_normalizes_product_value_collection(
         $productValueCollection,
-        ProductValue $productValue1,
-        ProductValue $productValue2,
+        ProductValueInterface $productValue1,
+        ProductValueInterface $productValue2,
         AttributeInterface $attribute1,
         AttributeInterface $attribute2,
         \ArrayIterator $productValueCollectionIterator,

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\Product\TextNormalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class TextNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TextNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_supports_text_product_value(
+        ProductValueInterface $numberValue,
+        ProductValueInterface $textValue,
+        AttributeInterface $numberAttribute,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $numberValue->getAttribute()->willReturn($numberAttribute);
+
+        $textAttribute->getBackendType()->willReturn('varchar');
+        $numberAttribute->getBackendType()->willReturn('decimal');
+
+        $this->supportsNormalization(new \stdClass(), 'indexing')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+
+        $this->supportsNormalization($textValue, 'indexing')->shouldReturn(true);
+        $this->supportsNormalization($numberValue, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($numberValue, 'indexing')->shouldReturn(false);
+    }
+
+    function it_normalizes_a_text_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn(null);
+        $textValue->getScope()->willReturn(null);
+        $textValue->getData()->willReturn('a product name');
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                '<all_locales>' => [
+                    '<all_channels>' => 'a product name'
+                ]
+            ]
+        ]);
+    }
+
+    function it_keeps_the_string_as_is_during_normalization(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn(null);
+        $textValue->getScope()->willReturn(null);
+        $textValue->getData()->willReturn('<h1>My <strong>ProDucT</strong> is awesome</h1>');
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                '<all_locales>' => [
+                    '<all_channels>' => '<h1>My <strong>ProDucT</strong> is awesome</h1>'
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_text_product_value_with_locale_and_no_scope(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn('fr_FR');
+        $textValue->getScope()->willReturn(null);
+        $textValue->getData()->willReturn('a product name');
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                'fr_FR' => [
+                    '<all_channels>' => 'a product name'
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_text_product_value_with_no_scope_and_no_locale(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn(null);
+        $textValue->getScope()->willReturn('ecommerce');
+        $textValue->getData()->willReturn('a product name');
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                '<all_locales>' => [
+                    'ecommerce' => 'a product name'
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_text_product_value_with_locale_and_scope(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn('fr_FR');
+        $textValue->getScope()->willReturn('ecommerce');
+        $textValue->getData()->willReturn('a product name');
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                'fr_FR' => [
+                    'ecommerce' => 'a product name'
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -83,9 +83,9 @@ class ProductIndexingIntegration extends TestCase
             'groups'       => ['groupA', 'groupB', 'variantA'],
             'completeness' => [
                 'ecommerce' => ['en_US' => 100],
-                'tablet'    => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100]
+                'tablet'    => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100],
             ],
-            'values' => [
+            'values'       => [
                 'a_date-date'                                    => [
                     '<all_locales>' => [
                         '<all_channels>' => null,
@@ -191,7 +191,7 @@ class ProductIndexingIntegration extends TestCase
                 ],
                 'a_text-varchar'                                 => [
                     '<all_locales>' => [
-                        '<all_channels>' => null,
+                        '<all_channels>' => 'this is a text',
                     ],
                 ],
                 'a_text_area-text'                               => [

--- a/src/Pim/Component/ReferenceData/ProductValue/ReferenceDataCollectionProductValue.php
+++ b/src/Pim/Component/ReferenceData/ProductValue/ReferenceDataCollectionProductValue.php
@@ -13,8 +13,8 @@ use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ReferenceDataCollectionProductValue extends AbstractProductValue
-    implements ReferenceDataCollectionProductValueInterface
+class ReferenceDataCollectionProductValue extends AbstractProductValue implements
+    ReferenceDataCollectionProductValueInterface
 {
     /** @var ReferenceDataInterface[] */
     protected $data;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- [x] Adds the simple text normalizer & service
- [X] Fix the ES index to use path_match
- [x] Add the textfilter service definition

** Since this morning review**
- [x] Updated the PimCatalogText products structure to match the index definition
- [x] Fixes broken CS & Specs

TextFilter::DOES_NOT_CONTAIN: Does not checks if the product_value actually exists like we would do for other operators (meaning that I removed the `'filter' => [ 'exists' => ...` clause). That's how it works currently in the PIM

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
