### PR TITLE
TIP-613: Minor fixes

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -21,15 +21,59 @@
 
     <testsuites>
 
-        <!-- PIM test suites -->
+        <!-- Legacy PIM phpunit unit tests -->
         <testsuite name="PIM_Unit_Test">
             <directory suffix="Test.php">../src/Pim/Bundle/*Bundle/Tests/Unit</directory>
         </testsuite>
 
+        <!-- Complete suite for PIM integration tests -->
         <testsuite name="PIM_Integration_Test">
             <directory suffix="Integration.php">../src/Pim/Component/*/tests/integration</directory>
             <directory suffix="Integration.php">../src/Pim/Bundle/*Bundle/tests/integration</directory>
             <directory suffix="Integration.php">../src/Akeneo/Bundle/*Bundle/tests/integration</directory>
+        </testsuite>
+
+        <!-- Set of small suites for PIM integration tests -->
+        <testsuite name="Akeneo_Integration_Test">
+            <directory suffix="Integration.php">../src/Akeneo/Bundle/*/tests/integration</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Base_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Component/Api/tests/integration</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Security</directory>
+            <file>../src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php</file>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controllers_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controllers_Catalog_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controller_Product_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Validation</directory>
+            <directory suffix="Integration.php">../src/Pim/Component/Catalog/tests/integration</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_Completeness_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Completeness</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_PQB_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/PQB</directory>
         </testsuite>
 
     </testsuites>

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/CompletenessRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/CompletenessRepository.php
@@ -104,20 +104,12 @@ SQL;
 
         $categoryMetadata = $this->entityManager->getClassMetadata($categoryMapping['targetEntity']);
 
-        $valueMapping = $this->entityManager->getClassMetadata($this->productClass)->getAssociationMapping('values');
-        $valueMetadata = $this->entityManager->getClassMetadata($valueMapping['targetEntity']);
-
-        $attributeMapping = $valueMetadata->getAssociationMapping('attribute');
-        $attributeMetadata = $this->entityManager->getClassMetadata($attributeMapping['targetEntity']);
-
         return strtr(
             $sql,
             [
                 '%category_table%'      => $categoryMetadata->getTableName(),
                 '%category_join_table%' => $categoryMapping['joinTable']['name'],
                 '%product_table%'       => $this->entityManager->getClassMetadata($this->productClass)->getTableName(),
-                '%product_value_table%' => $valueMetadata->getTableName(),
-                '%attribute_table%'     => $attributeMetadata->getTableName(),
             ]
         );
     }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/DateNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/DateNormalizer.php
@@ -18,24 +18,24 @@ class DateNormalizer extends AbstractProductValueNormalizer implements Normalize
     /**
      * {@inheritdoc}
      */
-    protected function getNormalizedData(ProductValueInterface $productValue)
-    {
-        $date = $productValue->getData();
-
-        if (null !== $date && $date instanceof \DateTimeInterface) {
-            return $date->format('Y-m-d');
-        }
-
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof ProductValueInterface &&
             AttributeTypes::BACKEND_TYPE_DATE === $data->getAttribute()->getBackendType() &&
             'indexing' === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNormalizedData(ProductValueInterface $productValue)
+    {
+        $date = $productValue->getData();
+
+        if ($date instanceof \DateTimeInterface) {
+            return $date->format('Y-m-d');
+        }
+
+        return null;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/NumberNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/NumberNormalizer.php
@@ -24,8 +24,9 @@ class NumberNormalizer extends AbstractProductValueNormalizer implements Normali
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ProductValueInterface && AttributeTypes::BACKEND_TYPE_DECIMAL === $data->getAttribute()->getBackendType()
-            && 'indexing' === $format;
+        return $data instanceof ProductValueInterface &&
+            AttributeTypes::BACKEND_TYPE_DECIMAL === $data->getAttribute()->getBackendType() &&
+            'indexing' === $format;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/OptionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/OptionNormalizer.php
@@ -3,8 +3,8 @@
 namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
 
 use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
-use Pim\Component\Catalog\ProductValue\OptionProductValue;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -31,6 +31,11 @@ class OptionNormalizer extends AbstractProductValueNormalizer implements Normali
      */
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
-        return $productValue->getData()->getCode();
+        $data = $productValue->getData();
+        if ($data instanceof AttributeOptionInterface) {
+            return $data->getCode();
+        }
+
+        return null;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/OptionNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/OptionNormalizerSpec.php
@@ -42,10 +42,9 @@ class OptionNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($optionValue, 'indexing')->shouldReturn(true);
     }
 
-    function it_normalize_an_option_product_value_with_no_locale_and_no_channel(
+    function it_normalize_an_empty_option_product_value(
         ProductValueInterface $optionValue,
-        AttributeInterface $optionAttribute,
-        AttributeOptionInterface $colorValue
+        AttributeInterface $optionAttribute
     ) {
         $optionValue->getAttribute()->willReturn($optionAttribute);
         $optionAttribute->getBackendType()->willReturn('option');
@@ -55,8 +54,34 @@ class OptionNormalizerSpec extends ObjectBehavior
 
         $optionAttribute->getCode()->willReturn('color');
 
-        $optionValue->getData()->willReturn($colorValue);
-        $colorValue->getCode()->willReturn('red');
+        $optionValue->getData()->willReturn(null);
+
+        $this->normalize($optionValue, 'indexing')->shouldReturn(
+            [
+                'color-option' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => null,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_normalize_an_option_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $optionValue,
+        AttributeInterface $optionAttribute,
+        AttributeOptionInterface $color
+    ) {
+        $optionValue->getAttribute()->willReturn($optionAttribute);
+        $optionAttribute->getBackendType()->willReturn('option');
+
+        $optionValue->getLocale()->willReturn(null);
+        $optionValue->getScope()->willReturn(null);
+
+        $optionAttribute->getCode()->willReturn('color');
+
+        $optionValue->getData()->willReturn($color);
+        $color->getCode()->willReturn('red');
 
         $this->normalize($optionValue, 'indexing')->shouldReturn(
             [
@@ -72,7 +97,7 @@ class OptionNormalizerSpec extends ObjectBehavior
     function it_normalizes_an_option_product_value_with_locale(
         ProductValueInterface $optionValue,
         AttributeInterface $optionAttribute,
-        AttributeOptionInterface $colorValue
+        AttributeOptionInterface $color
     ) {
         $optionValue->getAttribute()->willReturn($optionAttribute);
         $optionAttribute->getBackendType()->willReturn('option');
@@ -82,8 +107,8 @@ class OptionNormalizerSpec extends ObjectBehavior
 
         $optionAttribute->getCode()->willReturn('color');
 
-        $optionValue->getData()->willReturn($colorValue);
-        $colorValue->getCode()->willReturn('red');
+        $optionValue->getData()->willReturn($color);
+        $color->getCode()->willReturn('red');
 
         $this->normalize($optionValue, 'indexing')->shouldReturn(
             [
@@ -99,7 +124,7 @@ class OptionNormalizerSpec extends ObjectBehavior
     function it_normalizes_an_option_product_value_with_channel(
         ProductValueInterface $optionValue,
         AttributeInterface $optionAttribute,
-        AttributeOptionInterface $colorValue
+        AttributeOptionInterface $color
     ) {
         $optionValue->getAttribute()->willReturn($optionAttribute);
         $optionAttribute->getBackendType()->willReturn('option');
@@ -109,8 +134,8 @@ class OptionNormalizerSpec extends ObjectBehavior
 
         $optionAttribute->getCode()->willReturn('color');
 
-        $optionValue->getData()->willReturn($colorValue);
-        $colorValue->getCode()->willReturn('red');
+        $optionValue->getData()->willReturn($color);
+        $color->getCode()->willReturn('red');
 
         $this->normalize($optionValue, 'indexing')->shouldReturn(
             [
@@ -126,7 +151,7 @@ class OptionNormalizerSpec extends ObjectBehavior
     function it_normalizes_an_option_product_value_with_locale_and_channel(
         ProductValueInterface $optionValue,
         AttributeInterface $optionAttribute,
-        AttributeOptionInterface $colorValue
+        AttributeOptionInterface $color
     ) {
         $optionValue->getAttribute()->willReturn($optionAttribute);
         $optionAttribute->getBackendType()->willReturn('option');
@@ -136,8 +161,8 @@ class OptionNormalizerSpec extends ObjectBehavior
 
         $optionAttribute->getCode()->willReturn('color');
 
-        $optionValue->getData()->willReturn($colorValue);
-        $colorValue->getCode()->willReturn('red');
+        $optionValue->getData()->willReturn($color);
+        $color->getCode()->willReturn('red');
 
         $this->normalize($optionValue, 'indexing')->shouldReturn(
             [


### PR DESCRIPTION
## Description

This PR fixes:
- the completeness widget of the PIM homepage
- some wrong behavior of the index product normalizers
- split integration tests to gain time on CI (PHP 5.6 is removed as it does not work at all, and some error is fixed for behat preparation)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
