### PR TITLE
TIP-613: Fix some behat import scenarios

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1134,7 +1134,7 @@ class FixturesContext extends BaseFixturesContext
                     if ('**empty**' === $value) {
                         assertEmpty((string) $productValue);
                     } else {
-                        assertTrue(false !== strpos((string) $productValue, $value));
+                        assertTrue(false !== strpos($productValue->getData()->getOriginalFilename(), $value));
                     }
                 } elseif ('prices' === $attribute->getBackendType() && null !== $priceCurrency) {
                     // $priceCurrency can be null if we want to test all the currencies at the same time

--- a/src/Pim/Component/Catalog/Factory/ProductValue/PriceCollectionProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValue/PriceCollectionProductValueFactory.php
@@ -125,10 +125,67 @@ class PriceCollectionProductValueFactory implements ProductValueFactoryInterface
     {
         $prices = new PriceCollection();
 
-        foreach ($data as $price) {
+        $sortedData = $this->sortByCurrency($data);
+        foreach ($sortedData as $price) {
             $prices->add($this->priceFactory->createPrice($price['amount'], $price['currency']));
         }
 
         return $prices;
+    }
+
+    /**
+     * Sorts the array of prices data by their currency.
+     *
+     * For example:
+     *
+     * [
+     *     [
+     *         'amount'   => 20,
+     *         'currency' => 'USD',
+     *     ],
+     *     [
+     *         'amount'   => 100,
+     *         'currency' => 'EUR',
+     *     ],
+     * ]
+     *
+     * will become:
+     *
+     * [
+     *     [
+     *         'amount'   => 100,
+     *         'currency' => 'EUR',
+     *     ],
+     *     [
+     *         'amount'   => 20,
+     *         'currency' => 'USD',
+     *     ],
+     * ]
+     *
+     * @param array $arrayPrices
+     *
+     * @return array
+     */
+    protected function sortByCurrency(array $arrayPrices)
+    {
+        $amouts = [];
+        $currencies = [];
+
+        foreach ($arrayPrices as $price) {
+            $amouts[] = $price['amount'];
+            $currencies[] = $price['currency'];
+        }
+
+        $sort = array_multisort($currencies, SORT_ASC, $amouts, SORT_ASC, $arrayPrices);
+
+        if (false === $sort) {
+            throw new \LogicException(
+                sprintf('Impossible to permorm multisort on the following array: %s', json_encode($arrayPrices)),
+                0,
+                static::class
+            );
+        }
+
+        return $arrayPrices;
     }
 }

--- a/src/Pim/Component/Connector/Writer/Database/VariantGroupWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/VariantGroupWriter.php
@@ -55,13 +55,14 @@ class VariantGroupWriter implements ItemWriterInterface, StepExecutionAwareInter
     {
         $this->incrementCount($variantGroups);
         $this->bulkSaver->saveAll($variantGroups);
-        $this->bulkDetacher->detachAll($variantGroups);
 
         $jobParameters = $this->stepExecution->getJobParameters();
         $isCopyValues = $jobParameters->get('copyValues');
         if ($isCopyValues) {
             $this->copyValuesToProducts($variantGroups);
         }
+
+        $this->bulkDetacher->detachAll($variantGroups);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes some import related issues:
- Assertion test on Media product values did not work: `toString` now return the full key, when in 1.7 it only returned the originalFilename (what the behats expect in their assertions)
- Variant group were detached before copying templates to products, when they were still needed for product saving
- Asserted prices were not ordered correctly: in 1.7 they were ordered by currency, now they are by amount.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
