### PR TITLE
TIP-613: various behat fixes

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -438,6 +438,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingFamilies(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $family = $this->getFamily($data['code']);
             unset($data['code']);
@@ -472,10 +473,11 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingCurrencies(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $currency = $this->getCurrency($data['code']);
 
-            assertEquals($data['activated'], (int)$currency->isActivated());
+            assertEquals($data['activated'], (int) $currency->isActivated());
         }
     }
 
@@ -486,6 +488,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingLocales(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $locale = $this->getLocale($data['code']);
 
@@ -500,6 +503,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingChannels(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $channel = $this->getChannel($data['code']);
             unset($data['code']);
@@ -538,6 +542,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingGroupTypes(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $groupType = $this->getGroupType($data['code']);
             unset($data['code']);
@@ -564,8 +569,8 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingAttributeGroups(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
-            /** @var AttributeGroup $group */
             $group = $this->getAttributeGroup($data['code']);
 
             assertEquals($data['label-en_US'], $group->getTranslation('en_US')->getLabel());
@@ -588,6 +593,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingOptions(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $attribute = $this->getEntityOrException('Attribute', ['code' => $data['attribute']]);
             $option    = $this->getEntityOrException(
@@ -610,6 +616,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingCategories(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $category = $this->getCategory($data['code']);
             assertEquals($data['label'], $category->getTranslation('en_US')->getLabel());
@@ -628,6 +635,7 @@ class FixturesContext extends BaseFixturesContext
      */
     public function thereShouldBeTheFollowingAssociationTypes(TableNode $table)
     {
+        $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $associationType = $this->getAssociationType($data['code']);
             unset($data['code']);
@@ -655,7 +663,6 @@ class FixturesContext extends BaseFixturesContext
         $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $group = $this->getProductGroup($data['code']);
-            $this->refresh($group);
 
             assertEquals($data['label-en_US'], $group->getTranslation('en_US')->getLabel());
             assertEquals($data['label-fr_FR'], $group->getTranslation('fr_FR')->getLabel());

--- a/features/Pim/Behat/Context/AttributeValidationContext.php
+++ b/features/Pim/Behat/Context/AttributeValidationContext.php
@@ -23,8 +23,8 @@ class AttributeValidationContext extends PimContext
      */
     public function thereShouldBeTheFollowingAttributes(TableNode $table)
     {
+        $this->getService('doctrine.orm.entity_manager')->clear();
         foreach ($table->getHash() as $data) {
-            /** @var AttributeInterface $attribute */
             $attribute = $this->getFixturesContext()->getAttribute($data['code']);
             $this->getFixturesContext()->refresh($attribute);
 

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -7,6 +7,7 @@ use Behat\Behat\Context\Step;
 use Context\Spin\SpinCapableTrait;
 use Context\Spin\TimeoutException;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Common\Util\Debug;
 use Doctrine\Common\Util\Inflector;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -171,7 +172,7 @@ class FixturesContext extends PimContext
                 sprintf(
                     'Could not find "%s" with criteria %s',
                     $this->getEntities()[$entityName],
-                    print_r(\Doctrine\Common\Util\Debug::export($criteria, 2), true)
+                    print_r(Debug::export($criteria, 2), true)
                 )
             );
         }

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -69,9 +69,7 @@ class DatabaseCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $driver = $this->getStorageDriver();
-
-        $output->writeln(sprintf('<info>Prepare database schema (driver: %s)</info>', $driver));
+        $output->writeln('<info>Prepare database schema</info>');
 
         // Needs to try if database already exists or not
         $connection = $this->getContainer()->get('doctrine')->getConnection();
@@ -86,12 +84,6 @@ class DatabaseCommand extends ContainerAwareCommand
 
         $this->commandExecutor->runCommand('doctrine:database:create');
 
-        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $driver) {
-            $this->commandExecutor
-                ->runCommand('doctrine:mongodb:schema:drop')
-                ->runCommand('doctrine:mongodb:schema:create');
-        }
-
         // Needs to close connection if always open
         if ($connection->isConnected()) {
             $connection->close();
@@ -103,6 +95,8 @@ class DatabaseCommand extends ContainerAwareCommand
                 'doctrine:schema:update',
                 ['--force' => true, '--no-interaction' => true]
             );
+
+        $this->resetElasticsearchIndex($output);
 
         $this->getEventDispatcher()->dispatch(InstallerEvents::POST_DB_CREATE);
 
@@ -117,6 +111,28 @@ class DatabaseCommand extends ContainerAwareCommand
         $this->launchCommands();
 
         return $this;
+    }
+
+    /**
+     * TODO: TIP-613: This should be done with a command.
+     * TODO: TIP-613: This command should be able to drop/create indexes, and/or re-index products.
+     *
+     * @param OutputInterface $output
+     */
+    protected function resetElasticsearchIndex(OutputInterface $output)
+    {
+        $output->writeln('<info>Reset elasticsearch index</info>');
+
+        $esConfigurationLoader = $this->getContainer()->get('akeneo_elasticsearch.index_configuration.loader');
+        $esClient = $this->getContainer()->get('akeneo_elasticsearch.client');
+
+        $conf = $esConfigurationLoader->load();
+
+        if ($esClient->hasIndex()) {
+            $esClient->deleteIndex();
+        }
+
+        $esClient->createIndex($conf->buildAggregated());
     }
 
     /**

--- a/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -61,7 +61,7 @@ class InstallCommand extends ContainerAwareCommand
             throw new \RuntimeException('Oro Application already installed.');
         } elseif ($forceInstall) {
             // if --force option we have to clear cache and set installed to false
-            $this->updateInstalledFlag($input, $output, false);
+            $this->updateInstalledFlag($output, false);
         }
 
         $output->writeln(sprintf('<info>Installing %s Application.</info>', static::APP_NAME));
@@ -73,9 +73,9 @@ class InstallCommand extends ContainerAwareCommand
             }
 
             $this
-                ->checkStep($input, $output)
-                ->databaseStep($input, $output)
-                ->assetsStep($input, $output);
+                ->checkStep()
+                ->databaseStep()
+                ->assetsStep();
         } catch (\Exception $e) {
             $output->writeln(sprintf('<error>Error during PIM installation. %s</error>', $e->getMessage()));
             $output->writeln('');
@@ -83,7 +83,7 @@ class InstallCommand extends ContainerAwareCommand
             return $e->getCode();
         }
 
-        $this->updateInstalledFlag($input, $output, date('c'));
+        $this->updateInstalledFlag($output, date('c'));
 
         $output->writeln('');
         $output->writeln(sprintf('<info>%s Application has been successfully installed.</info>', static::APP_NAME));
@@ -94,14 +94,11 @@ class InstallCommand extends ContainerAwareCommand
     /**
      * Step where configuration is checked
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @throws \RuntimeException
      *
      * @return InstallCommand
      */
-    protected function checkStep(InputInterface $input, OutputInterface $output)
+    protected function checkStep()
     {
         $this->commandExecutor->runCommand('pim:installer:check-requirements');
 
@@ -111,12 +108,9 @@ class InstallCommand extends ContainerAwareCommand
     /**
      * Step where the database is built, the fixtures loaded and some command scripts launched
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @return InstallCommand
      */
-    protected function databaseStep(InputInterface $input, OutputInterface $output)
+    protected function databaseStep()
     {
         $this->commandExecutor->runCommand('pim:installer:db');
 
@@ -126,12 +120,9 @@ class InstallCommand extends ContainerAwareCommand
     /**
      * Load only assets
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @return InstallCommand
      */
-    protected function assetsStep(InputInterface $input, OutputInterface $output)
+    protected function assetsStep()
     {
         $this->commandExecutor->runCommand('pim:installer:assets');
 
@@ -141,13 +132,12 @@ class InstallCommand extends ContainerAwareCommand
     /**
      * Update installed flag
      *
-     * @param InputInterface  $input
      * @param OutputInterface $output
      * @param bool            $installed
      *
      * @return InstallCommand
      */
-    protected function updateInstalledFlag(InputInterface $input, OutputInterface $output, $installed)
+    protected function updateInstalledFlag(OutputInterface $output, $installed)
     {
         $output->writeln('<info>Updating installed flag.</info>');
 
@@ -155,6 +145,8 @@ class InstallCommand extends ContainerAwareCommand
         $params = $dumper->parse();
         $params['system']['installed'] = $installed;
         $dumper->dump($params);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Description

This PR:
- ensure Doctrine UOW is always cleared before asserting values from the database,
- creates the Elasticsearch index(es) at the start of the installation process, right after MySQL database and tables are.

This fixes 21 Behat scenarios, no new fail. Currently remains 483 failures, listed in the attached file.

[failing-behats-sorted.txt](https://github.com/jjanvier/pim-community-dev/files/889897/failing-behats-sorted.txt)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
