### PR TITLE
TIP-706: Add PQB filter for media product values

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,6 +184,9 @@ def runPhpUnitTest(phpVersion) {
 def runIntegrationTest(phpVersion, testSuiteName) {
     node('docker') {
         deleteDir()
+        sh "docker stop \$(docker ps -a -q) || true"
+        sh "docker rm \$(docker ps -a -q) || true"
+
         try {
             docker.image("elasticsearch:5.2").withRun("--name elasticsearch -e ES_JAVA_OPTS=\"-Xms256m -Xmx256m\"") {
                 docker.image("mysql:5.7").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -55,7 +55,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
         }
 
         $attributePath = $this->getAttributePath($attribute, $locale, $channel);
-        $indexedAttributePath = $attributePath.'.'.static::PATH_SUFFIX;
+        $indexedAttributePath = $attributePath . '.' . static::PATH_SUFFIX;
 
         switch ($operator) {
             case Operators::STARTS_WITH:

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    const PATH_SUFFIX = 'original_filename';
+
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
+            $this->checkValue($attribute, $value);
+        }
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+        $indexedAttributePath = $attributePath.'.'.static::PATH_SUFFIX;
+
+        switch ($operator) {
+            case Operators::STARTS_WITH:
+                $clause = [
+                    'query_string' => [
+                        'default_field' => $indexedAttributePath,
+                        'query'         => $value . '*',
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::CONTAINS:
+                $clause = [
+                    'query_string' => [
+                        'default_field' => $indexedAttributePath,
+                        'query'         => '*' . $value . '*',
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::DOES_NOT_CONTAIN:
+                $mustNotClause = [
+                    'query_string' => [
+                        'default_field' => $indexedAttributePath,
+                        'query'         => '*' . $value . '*',
+                    ],
+                ];
+                $filterClause = [
+                    'exists' => ['field' => $attributePath],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
+            case Operators::EQUALS:
+                $clause = [
+                    'term' => [
+                        $indexedAttributePath => $value,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::NOT_EQUAL:
+                $mustNotClause = [
+                    'term' => [
+                        $indexedAttributePath => $value,
+                    ],
+                ];
+
+                $filterClause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
+            case Operators::IS_NOT_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks if the value is valid.
+     *
+     * @param AttributeInterface $attribute
+     * @param mixed              $value
+     */
+    protected function checkValue(AttributeInterface $attribute, $value)
+    {
+        FieldFilterHelper::checkString($attribute->getCode(), $value, self::class);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -516,30 +516,134 @@ Not In list
 
 Media
 *****
+
 :Apply:
-  pim_catalog_image and pim_catalog_file attributes
+    pim_catalog_image and pim_catalog_file attributes
 
 Data model
 ~~~~~~~~~~
-.. code-block:: yaml
+.. code-block:: php
 
-  my_image-media: "/images/test-image.jpg"
+    [
+        'values' => [
+            'an_image-media' => [
+                'fr_FR' => [
+                    'mobile' => [
+                        'extension'         => 'jpg',
+                        'hash'              => 'the_hash',
+                        'key'               => 'the/relative/path/to_akeneo.png',
+                        'mime_type'         => 'image/jpeg',
+                        'original_filename' => 'akeneo.jpg',
+                        'size'              => 42,
+                        'storage'           => 'catalogStorage',
+                    ]
+                ]
+            ]
+        ]
+    ]
 
 Filtering
 ~~~~~~~~~
 Operators
 .........
+STARTS WITH
+"""""""""""
+:Specific field: original_filename
 
-For STARTS WITH, ENDS WITH, CONTAINS, DOES NOT CONTAIN and =, same as identifier
+.. code-block:: php
+
+    'filter' => [
+        'query_string' => [
+            'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+            'query' => "ak*"
+        ]
+    ]
+
+CONTAINS
+""""""""
+:Specific field: original_filename
+
+.. code-block:: php
+
+    'filter' => [
+        'query_string' => [
+            'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+            'query' => '*neo*'
+        ]
+    ]
+
+DOES NOT CONTAIN
+""""""""""""""""
+:Specific field: original_filename
+
+Same syntax than the ``contains`` but must be included in a ``must_not`` boolean occured type instead of ``filter``.
+
+.. code-block:: php
+
+    'bool' => [
+        'must_not' => [
+            'query_string' => [
+                'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+                'query' => '*ziggy*'
+            ]
+        ],
+        'filter' => [
+            'exists' => ['field' => 'values.an_image-media.<all_channels>.<all_locales>'
+        ]
+    ]
+
+Equals (=)
+""""""""""
+:Type: Filter
+:Specific field: original_filename
+
+.. code-block:: php
+
+    'filter' => [
+        'term' => [
+            'values.an_image-media.<all_channels>.<all_locales>.original_filename' => 'akeneo.jpg'
+        ]
+    ]
+
+Not Equals (!=)
+"""""""""""""""
+:Type: Filter
+:Specific field: original_filename
+
+.. code-block:: php
+
+    'must_not' => [
+        'term' => [
+            'values.an_image-media.<all_channels>.<all_locales>.original_filename' => 'ziggy.png'
+        ]
+    ],
+    'filter' => [
+        'exists' => [
+            'field' => 'values.an_image-media.<all_channels>.<all_locales>'
+        ]
+    ]
 
 EMPTY
 """""
-:Type: filter
 
-.. code-block:: yaml
+.. code-block:: php
 
-    missing:
-        field: "my_image-media"
+    'must_not' => [
+        'exists => [
+            'field' => 'values.an_image-media.<all_channels>.<all_locales>'
+        ]
+    ]
+
+NOT EMPTY
+"""""""""
+
+.. code-block:: php
+
+    'filter' => [
+        'exists => [
+            'field' => 'values.an_image-media.<all_channels>.<all_locales>'
+        ]
+    ]
 
 Date
 ****

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -7,22 +7,24 @@ parameters:
     pim_catalog.query.filter.attribute_dumper.class:              Pim\Bundle\CatalogBundle\Command\ProductQueryHelp\AttributeFilterDumper
     pim_catalog.doctrine.query.filter.object_id_resolver.class:   Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver
     pim_catalog.doctrine.query.filter.object_code_resolver.class: Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver
-    pim_catalog.query.elasticsearch.filter.identifier.class:      Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter
-    pim_catalog.query.elasticsearch.filter.family.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\FamilyFilter
-    pim_catalog.query.elasticsearch.filter.category.class:        Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CategoryFilter
-    pim_catalog.query.elasticsearch.filter.group.class:           Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\GroupFilter
-    pim_catalog.query.elasticsearch.filter.status.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\StatusFilter
-    pim_catalog.query.elasticsearch.filter.datetime.class:        Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\DateTimeFilter
+
+    pim_catalog.query.elasticsearch.filter.identifier.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter
+    pim_catalog.query.elasticsearch.filter.family.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\FamilyFilter
+    pim_catalog.query.elasticsearch.filter.category.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CategoryFilter
+    pim_catalog.query.elasticsearch.filter.group.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\GroupFilter
+    pim_catalog.query.elasticsearch.filter.status.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\StatusFilter
+    pim_catalog.query.elasticsearch.filter.datetime.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\DateTimeFilter
     pim_catalog.query.elasticsearch.filter.completeness.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CompletenessFilter
-    pim_catalog.query.elasticsearch.filter.date.class:            Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\DateFilter
-    pim_catalog.query.elasticsearch.filter.number.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\NumberFilter
+    pim_catalog.query.elasticsearch.filter.date.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\DateFilter
+    pim_catalog.query.elasticsearch.filter.number.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\NumberFilter
     pim_catalog.query.elasticsearch.filter.text.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextFilter
     pim_catalog.query.elasticsearch.filter.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextAreaFilter
-    pim_catalog.query.elasticsearch.filter.option.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter
-    pim_catalog.query.elasticsearch.filter.options.class:         Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionsFilter
+    pim_catalog.query.elasticsearch.filter.option.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter
+    pim_catalog.query.elasticsearch.filter.options.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionsFilter
     pim_catalog.query.elasticsearch.filter.price.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\PriceFilter
     pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
-    pim_catalog.query.elasticsearch.sorter.base.class:            Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter
+    pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
+    pim_catalog.query.elasticsearch.sorter.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter
 
 services:
     pim_catalog.query.product_query_builder_factory:
@@ -196,7 +198,7 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - ['pim_catalog_text']
-            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 
@@ -205,7 +207,7 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - ['pim_catalog_textarea']
-            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 
@@ -237,6 +239,15 @@ services:
             - '@akeneo_measure.measure_converter'
             - ['pim_catalog_metric']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.media:
+        class: '%pim_catalog.query.elasticsearch.filter.media.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_file', 'pim_catalog_image']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -13,6 +13,7 @@ parameters:
     pim_catalog.normalizer.indexing.product.text_area.class: Pim\Component\Catalog\Normalizer\Indexing\Product\TextAreaNormalizer
     pim_catalog.normalizer.indexing.product.price_collection.class: Pim\Component\Catalog\Normalizer\Indexing\Product\PriceCollectionNormalizer
     pim_catalog.normalizer.indexing.product.metric.class: Pim\Component\Catalog\Normalizer\Indexing\Product\MetricNormalizer
+    pim_catalog.normalizer.indexing.product.media.class: Pim\Component\Catalog\Normalizer\Indexing\Product\MediaNormalizer
 
 services:
     pim_catalog.normalizer.indexing.product:
@@ -88,5 +89,10 @@ services:
 
     pim_catalog.normalizer.indexing.metric:
         class: '%pim_catalog.normalizer.indexing.product.metric.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.indexing.media:
+        class: '%pim_catalog.normalizer.indexing.product.media.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -58,10 +58,10 @@ mappings:
                         type: 'keyword'
             -
                 prices:
+                    path_match: 'values.*-prices.*'
                     match_mapping_type: 'string'
                     mapping:
                         type: 'double'
-                    path_match: 'values.*-prices.*'
             -
                 metric_data:
                     match_mapping_type: 'string'
@@ -70,22 +70,64 @@ mappings:
                     path_match: 'values.*-metric.*.data'
             -
                 metric_base_data:
+                    path_match: 'values.*-metric.*.base_data'
                     match_mapping_type: 'string'
                     mapping:
                         type: 'double'
-                    path_match: 'values.*-metric.*.base_data'
             -
                 metric_unit:
+                    path_match: 'values.*-metric.*.unit'
                     match_mapping_type: 'string'
                     mapping:
                         index: 'no'
-                    path_match: 'values.*-metric.*.unit'
             -
                 metric_base_unit:
+                    path_match: 'values.*-metric.*.base_unit'
                     match_mapping_type: 'string'
                     mapping:
                         index: 'no'
-                    path_match: 'values.*-metric.*.base_unit'
+            -
+                media_extension:
+                    path_match: 'values.*-media.*.extension'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
+            -
+                media_key:
+                    path_match: 'values.*-media.*.key'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
+            -
+                media_hash:
+                    path_match: 'values.*-media.*.hash'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
+            -
+                media_mime_type:
+                    path_match: 'values.*-media.*.mime_type'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
+            -
+                media_original_filename:
+                    path_match: 'values.*-media.*.original_filename'
+                    match_mapping_type: 'string'
+                    mapping:
+                        type: 'keyword'
+            -
+                media_size:
+                    path_match: 'values.*-media.*.size'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
+            -
+                media_storage:
+                    path_match: 'values.*-media.*.storage'
+                    match_mapping_type: 'string'
+                    mapping:
+                        index: 'no'
 settings:
     analysis:
         normalizer:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+class MediaFilterSpec extends ObjectBehavior
+{
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    {
+        $this->beConstructedWith(
+            $attributeValidatorHelper,
+            ['pim_catalog_file', 'pim_catalog_image'],
+            ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MediaFilter::class);
+    }
+
+    function it_is_an_attribute_filter()
+    {
+        $this->shouldImplement(AttributeFilterInterface::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn([
+            'STARTS WITH',
+            'CONTAINS',
+            'DOES NOT CONTAIN',
+            '=',
+            '!=',
+            'EMPTY',
+            'NOT EMPTY',
+        ]);
+        $this->supportsOperator('STARTS WITH')->shouldReturn(true);
+        $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_starts_with(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'query_string' => [
+                    'default_field' => 'values.an_image-media.ecommerce.en_US.original_filename',
+                    'query'         => 'sony*',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::STARTS_WITH, 'sony', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_contains(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'query_string' => [
+                    'default_field' => 'values.an_image-media.ecommerce.en_US.original_filename',
+                    'query'         => '*sony*',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::CONTAINS, 'sony', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_does_not_contain(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'query_string' => [
+                    'default_field' => 'values.an_image-media.ecommerce.en_US.original_filename',
+                    'query'         => '*sony*',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'values.an_image-media.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::DOES_NOT_CONTAIN, 'sony', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_equals(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'term' => [
+                    'values.an_image-media.ecommerce.en_US.original_filename' => 'Sony',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::EQUALS, 'Sony', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_not_equal(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'term' => [
+                    'values.an_image-media.ecommerce.en_US.original_filename' => 'Sony',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => ['field' => 'values.an_image-media.ecommerce.en_US'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::NOT_EQUAL, 'Sony', 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_empty(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'exists' => [
+                    'field' => 'values.an_image-media.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_not_empty(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'values.an_image-media.ecommerce.en_US',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($name, Operators::IS_NOT_EMPTY, null, 'en_US', 'ecommerce', []);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(AttributeInterface $name)
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_a_string(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'an_image',
+                MediaFilter::class,
+                123
+            )
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, 123, 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($name, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                MediaFilter::class
+            )
+        )->during('addAttributeFilter', [$name, Operators::IN_CHILDREN_LIST, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_locale_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+        $name->isLocaleSpecific()->willReturn(true);
+        $name->getAvailableLocaleCodes('fr_FR');
+
+        $e = new \LogicException('Attribute "name" expects a locale, none given.');
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'an_image',
+                MediaFilter::class,
+                $e
+            )
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_scope_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+        $name->isScopable()->willReturn(false);
+
+        $e = new \LogicException('Attribute "name" does not expect a scope, "ecommerce" given.');
+        $attributeValidatorHelper->validateLocale($name, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'an_image',
+                MediaFilter::class,
+                $e
+            )
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogMediaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogMediaIntegration.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\ElasticSearch\IndexConfiguration;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class PimCatalogMediaIntegration extends AbstractPimCatalogIntegration
+{
+    public function testStartWithOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'query_string' => [
+                            'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+                            'query'         => 'yet*',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_3', 'product_6']);
+    }
+
+    public function testContainsOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'query_string' => [
+                            'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+                            'query'         => '*jpeg*',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_2', 'product_3']);
+    }
+
+    public function testDoesNotContainOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'query_string' => [
+                            'default_field' => 'values.an_image-media.<all_channels>.<all_locales>.original_filename',
+                            'query'         => '*another*',
+                        ],
+                    ],
+                    'filter' => [
+                        'exists' => [
+                            'field' => 'values.an_image-media.<all_channels>.<all_locales>',
+                        ]
+                    ]
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_4', 'product_7']);
+    }
+
+    public function testEqualsOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'term' => [
+                            'values.an_image-media.<all_channels>.<all_locales>.original_filename' => 'i_have_no_imagination.jpg',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_7']);
+    }
+
+    public function testDoesNotEqualOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'term' => [
+                            'values.an_image-media.<all_channels>.<all_locales>.original_filename' => 'i_have_no_imagination.jpg',
+                        ],
+                    ],
+                    'filter'   => [
+                        'exists' => ['field' => 'values.an_image-media.<all_channels>.<all_locales>'],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_1', 'product_2', 'product_3', 'product_4', 'product_5', 'product_6']
+        );
+    }
+
+    public function testEmptyOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'exists' => ['field' => 'values.an_image-media.<all_channels>.<all_locales>'],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_8']);
+    }
+
+    public function testIsNotEmptyOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'exists' => ['field' => 'values.an_image-media.<all_channels>.<all_locales>'],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_1', 'product_2', 'product_3', 'product_4', 'product_5', 'product_6', 'product_7']
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function addProducts()
+    {
+        $products = [
+            [
+                'identifier' => 'product_1',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'jpg',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_a_jpeg_image.jpg',
+                                'mime_type'         => 'image/jpeg',
+                                'original_filename' => 'a_jpeg_image.jpg',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_2',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'jpg',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_another_jpeg_image.jpg',
+                                'mime_type'         => 'image/jpeg',
+                                'original_filename' => 'another_jpeg_image.jpg',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_3',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'jpg',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_yet_another_jpeg_image.jpg',
+                                'mime_type'         => 'image/jpeg',
+                                'original_filename' => 'yet_another_jpeg_image.jpg',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_4',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'png',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_a_png_image.png',
+                                'mime_type'         => 'image/png',
+                                'original_filename' => 'a_png_image.png',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_5',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'png',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_another_png_image.png',
+                                'mime_type'         => 'image/png',
+                                'original_filename' => 'another_png_image.png',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_6',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'png',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_yet_another_png_image.png',
+                                'mime_type'         => 'image/png',
+                                'original_filename' => 'yet_another_png_image.png',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_7',
+                'values'     => [
+                    'an_image-media' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'extension'         => 'jpg',
+                                'hash'              => 'a_hash',
+                                'key'               => 'my/relative/path/to_i_have_no_imagination.jpg',
+                                'mime_type'         => 'image/jpeg',
+                                'original_filename' => 'i_have_no_imagination.jpg',
+                                'size'              => 42,
+                                'storage'           => 'catalogStorage',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_8',
+            ],
+        ];
+
+        $this->indexProducts($products);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogNumberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogNumberIntegration.php
@@ -348,7 +348,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      *
      * A few information regarding the mapping of numbers and the data indexed in ES below.
      * We indexed data of different types:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionIntegration.php
@@ -142,7 +142,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      */
     protected function addProducts()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionsIntegration.php
@@ -152,7 +152,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      */
     protected function addProducts()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
@@ -319,7 +319,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      *
      * A few information regarding the mapping of prices and the data indexed in ES below.
      *

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
@@ -201,7 +201,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      */
     protected function addProducts()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogTextIntegration.php
@@ -250,7 +250,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
     }
 
     /**
-     * This method indexes dummy products in elastic search.
+     * {@inheritdoc}
      */
     protected function addProducts()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_localizable_media',
                 'type'                => AttributeTypes::IMAGE,
@@ -56,18 +58,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one']);
 
         $result = $this->executeFilter([['a_localizable_image', Operators::STARTS_WITH, 'aken', ['locale' => 'fr_FR']]]);
-        $this->assert($result, []);
-    }
-
-    public function testOperatorEndWith()
-    {
-        $result = $this->executeFilter([['a_localizable_image', Operators::ENDS_WITH, 'ziggy.png', ['locale' => 'en_US']]]);
-        $this->assert($result, ['product_two']);
-
-        $result = $this->executeFilter([['a_localizable_image', Operators::ENDS_WITH, 'ziggy.png', ['locale' => 'fr_FR']]]);
-        $this->assert($result, ['product_one', 'product_two']);
-
-        $result = $this->executeFilter([['a_localizable_image', Operators::ENDS_WITH, 'ziggy', ['locale' => 'fr_FR']]]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
@@ -20,6 +20,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createProduct('product_one', [
                 'values' => [
                     'a_localizable_scopable_image' => [
@@ -51,18 +53,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['product_one']);
 
         $result = $this->executeFilter([['a_localizable_scopable_image', Operators::STARTS_WITH, 'aken', ['locale' => 'fr_FR', 'scope' => 'ecommerce']]]);
-        $this->assert($result, []);
-    }
-
-    public function testOperatorEndWith()
-    {
-        $result = $this->executeFilter([['a_localizable_scopable_image', Operators::ENDS_WITH, 'ziggy.png', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
-        $this->assert($result, ['product_two']);
-
-        $result = $this->executeFilter([['a_localizable_scopable_image', Operators::ENDS_WITH, 'ziggy.png', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
-        $this->assert($result, ['product_one']);
-
-        $result = $this->executeFilter([['a_localizable_scopable_image', Operators::ENDS_WITH, 'ziggy', ['locale' => 'fr_FR', 'scope' => 'ecommerce']]]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
@@ -20,6 +20,8 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createProduct('akeneo', [
                 'values' => [
                     'an_image' => [
@@ -46,15 +48,6 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['akeneo']);
 
         $result = $this->executeFilter([['an_image', Operators::STARTS_WITH, 'keneo']]);
-        $this->assert($result, []);
-    }
-
-    public function testOperatorEndWith()
-    {
-        $result = $this->executeFilter([['an_image', Operators::ENDS_WITH, 'ziggy.png']]);
-        $this->assert($result, ['ziggy']);
-
-        $result = $this->executeFilter([['an_image', Operators::ENDS_WITH, 'akeneo']]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_localizable_media',
                 'type'                => AttributeTypes::IMAGE,
@@ -56,18 +58,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one']);
 
         $result = $this->executeFilter([['a_scopable_image', Operators::STARTS_WITH, 'aken', ['scope' => 'tablet']]]);
-        $this->assert($result, []);
-    }
-
-    public function testOperatorEndWith()
-    {
-        $result = $this->executeFilter([['a_scopable_image', Operators::ENDS_WITH, 'ziggy.png', ['scope' => 'ecommerce']]]);
-        $this->assert($result, ['product_two']);
-
-        $result = $this->executeFilter([['a_scopable_image', Operators::ENDS_WITH, 'ziggy.png', ['scope' => 'tablet']]]);
-        $this->assert($result, ['product_one', 'product_two']);
-
-        $result = $this->executeFilter([['a_scopable_image', Operators::ENDS_WITH, 'ziggy', ['scope' => 'tablet']]]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MediaNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MediaNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Akeneo\Component\FileStorage\Model\FileInfoInterface;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\ProductValue\MediaProductValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class MediaNormalizer extends AbstractProductValueNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof MediaProductValueInterface && 'indexing' === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNormalizedData(ProductValueInterface $productValue)
+    {
+        $data = $productValue->getData();
+
+        if (null !== $data) {
+            $normalizedMedia = [];
+
+            $normalizedMedia['extension'] = $data->getExtension();
+            $normalizedMedia['key'] = $data->getKey();
+            $normalizedMedia['hash'] = $data->getHash();
+            $normalizedMedia['mime_type'] = $data->getMimeType();
+            $normalizedMedia['original_filename'] = $data->getOriginalFilename();
+            $normalizedMedia['size'] = $data->getSize();
+            $normalizedMedia['storage'] = $data->getStorage();
+
+            return $normalizedMedia;
+        }
+
+        return null;
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MediaNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MediaNormalizerSpec.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Akeneo\Component\FileStorage\Model\FileInfoInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\Product\MediaNormalizer;
+use Pim\Component\Catalog\ProductValue\MediaProductValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class MediaNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MediaNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_support_media_product_value(
+        ProductValueInterface $numberValue,
+        MediaProductValueInterface $mediaValue,
+        AttributeInterface $numberAttribute,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $numberValue->getAttribute()->willReturn($numberAttribute);
+
+        $this->supportsNormalization(new \stdClass(), 'indexing')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+
+        $this->supportsNormalization($mediaValue, 'indexing')->shouldReturn(true);
+        $this->supportsNormalization($numberValue, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($numberValue, 'indexing')->shouldReturn(false);
+    }
+
+    function it_normalizes_a_media_product_value_with_no_locale_and_no_channel(
+        MediaProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute,
+        FileInfoInterface $fileInfo
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn(null);
+        $mediaValue->getScope()->willReturn(null);
+        $mediaValue->getData()->willReturn($fileInfo);
+
+        $fileInfo->getExtension()->willReturn('jpg');
+        $fileInfo->getKey()->willReturn('a/relative/path/to/akeneo.jpg');
+        $fileInfo->getHash()->willReturn('a_hash_key');
+        $fileInfo->getMimeType()->willReturn('image/jpeg');
+        $fileInfo->getOriginalFilename()->willReturn('akeneo.jpg');
+        $fileInfo->getSize()->willReturn('42');
+        $fileInfo->getStorage()->willReturn('catalogStorage');
+
+        $mediaAttribute->getCode()->willReturn('an_image');
+        $mediaAttribute->getBackendType()->willReturn('media');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'an_image-media' => [
+                '<all_channels>' => [
+                    '<all_locales>' => [
+                        'extension'         => 'jpg',
+                        'key'               => 'a/relative/path/to/akeneo.jpg',
+                        'hash'              => 'a_hash_key',
+                        'mime_type'         => 'image/jpeg',
+                        'original_filename' => 'akeneo.jpg',
+                        'size'              => '42',
+                        'storage'           => 'catalogStorage',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_media_product_value_with_locale_and_no_scope(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute,
+        FileInfoInterface $fileInfo
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn('fr_FR');
+        $mediaValue->getScope()->willReturn(null);
+        $mediaValue->getData()->willReturn($fileInfo);
+
+        $fileInfo->getExtension()->willReturn('jpg');
+        $fileInfo->getKey()->willReturn('a/relative/path/to/akeneo.jpg');
+        $fileInfo->getHash()->willReturn('a_hash_key');
+        $fileInfo->getMimeType()->willReturn('image/jpeg');
+        $fileInfo->getOriginalFilename()->willReturn('akeneo.jpg');
+        $fileInfo->getSize()->willReturn('42');
+        $fileInfo->getStorage()->willReturn('catalogStorage');
+
+        $mediaAttribute->getCode()->willReturn('an_image');
+        $mediaAttribute->getBackendType()->willReturn('media');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'an_image-media' => [
+                '<all_channels>' => [
+                    'fr_FR' => [
+                        'extension'         => 'jpg',
+                        'key'               => 'a/relative/path/to/akeneo.jpg',
+                        'hash'              => 'a_hash_key',
+                        'mime_type'         => 'image/jpeg',
+                        'original_filename' => 'akeneo.jpg',
+                        'size'              => '42',
+                        'storage'           => 'catalogStorage',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_media_product_value_with_scope_and_no_locale(
+        MediaProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute,
+        FileInfoInterface $fileInfo
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn(null);
+        $mediaValue->getScope()->willReturn('ecommerce');
+        $mediaValue->getData()->willReturn($fileInfo);
+
+        $fileInfo->getExtension()->willReturn('jpg');
+        $fileInfo->getKey()->willReturn('a/relative/path/to/akeneo.jpg');
+        $fileInfo->getHash()->willReturn('a_hash_key');
+        $fileInfo->getMimeType()->willReturn('image/jpeg');
+        $fileInfo->getOriginalFilename()->willReturn('akeneo.jpg');
+        $fileInfo->getSize()->willReturn('42');
+        $fileInfo->getStorage()->willReturn('catalogStorage');
+
+        $mediaAttribute->getCode()->willReturn('an_image');
+        $mediaAttribute->getBackendType()->willReturn('media');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'an_image-media' => [
+                'ecommerce' => [
+                    '<all_locales>' => [
+                        'extension'         => 'jpg',
+                        'key'               => 'a/relative/path/to/akeneo.jpg',
+                        'hash'              => 'a_hash_key',
+                        'mime_type'         => 'image/jpeg',
+                        'original_filename' => 'akeneo.jpg',
+                        'size'              => '42',
+                        'storage'           => 'catalogStorage',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_media_product_value_with_locale_and_scope(
+        MediaProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute,
+        FileInfoInterface $fileInfo
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn('fr_FR');
+        $mediaValue->getScope()->willReturn('ecommerce');
+        $mediaValue->getData()->willReturn($fileInfo);
+
+        $fileInfo->getExtension()->willReturn('jpg');
+        $fileInfo->getKey()->willReturn('a/relative/path/to/akeneo.jpg');
+        $fileInfo->getHash()->willReturn('a_hash_key');
+        $fileInfo->getMimeType()->willReturn('image/jpeg');
+        $fileInfo->getOriginalFilename()->willReturn('akeneo.jpg');
+        $fileInfo->getSize()->willReturn('42');
+        $fileInfo->getStorage()->willReturn('catalogStorage');
+
+        $mediaAttribute->getCode()->willReturn('an_image');
+        $mediaAttribute->getBackendType()->willReturn('media');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'an_image-media' => [
+                'ecommerce' => [
+                    'fr_FR' => [
+                        'extension'         => 'jpg',
+                        'key'               => 'a/relative/path/to/akeneo.jpg',
+                        'hash'              => 'a_hash_key',
+                        'mime_type'         => 'image/jpeg',
+                        'original_filename' => 'akeneo.jpg',
+                        'size'              => '42',
+                        'storage'           => 'catalogStorage',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_should_normalize_an_empty_product_value(
+        MediaProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn('fr_FR');
+        $mediaValue->getScope()->willReturn('ecommerce');
+        $mediaValue->getData()->willReturn(null);
+
+        $mediaAttribute->getCode()->willReturn('an_image');
+        $mediaAttribute->getBackendType()->willReturn('media');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'an_image-media' => [
+                'ecommerce' => [
+                    'fr_FR' => null,
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
@@ -104,7 +104,7 @@ class TextNormalizerSpec extends ObjectBehavior
         ]);
     }
 
-    function it_normalizes_a_text_product_value_with_no_scope_and_no_locale(
+    function it_normalizes_a_text_product_value_with_scope_and_no_locale(
         ProductValueInterface $textValue,
         AttributeInterface $textAttribute
     ) {

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -11,6 +11,9 @@ use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
  */
 class ProductIndexingIntegration extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
         return new Configuration(
@@ -93,13 +96,38 @@ class ProductIndexingIntegration extends TestCase
                 ],
                 'a_file-media'                                   => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'extension'         => 'txt',
+                            'hash'              => '6545089471ba53d660d22d7b8dc8dd67904b1e28',
+                            'key'               => '8/b/5/c/8b5cf9bfd2e7e4725fd581e03251133ada1b2c99_fileA.txt',
+                            'mime_type'         => 'text/plain',
+                            'original_filename' => 'fileA.txt',
+                            'size'              => 1048576,
+                            'storage'           => 'catalogStorage',
+
+                        ],
                     ],
                 ],
                 'a_localizable_image-media'                      => [
                     '<all_channels>' => [
-                        'en_US' => null,
-                        'fr_FR' => null,
+                        'en_US' => [
+                            'extension'         => 'jpg',
+                            'hash'              => '16850b6741c6e0d7622edb29465488571a2e63df',
+                            'key'               => '7/1/3/3/713380965740f8838834cd58505aa329fcf448a5_imageB_en_US.jpg',
+                            'mime_type'         => 'image/jpeg',
+                            'original_filename' => 'imageB-en_US.jpg',
+                            'size'              => 1048576,
+                            'storage'           => 'catalogStorage',
+                        ],
+                        'fr_FR' => [
+                            'extension'         => 'jpg',
+                            'hash'              => '058c6f380b0888afadf7341f8baaf58b538e5774',
+                            'key'               => '0/5/1/9/05198fcf21b2b0d4596459f172e2e62b1a70bfd0_imageB_fr_FR.jpg',
+                            'mime_type'         => 'image/jpeg',
+                            'original_filename' => 'imageB-fr_FR.jpg',
+                            'size'              => 1048576,
+                            'storage'           => 'catalogStorage',
+                        ],
                     ],
                 ],
                 'a_localized_and_scopable_text_area-text'        => [
@@ -243,7 +271,16 @@ class ProductIndexingIntegration extends TestCase
                 ],
                 'an_image-media'                                 => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'extension'         => 'jpg',
+                            'hash'              => 'a9453e6ce89dbfd776ecae609e1c23e9cfad8277',
+                            'key'               => '3/b/5/5/3b5548f9764c0535db2ac92f047fa448cb7cea76_imageA.jpg',
+                            'mime_type'         => 'image/jpeg',
+                            'original_filename' => 'imageA.jpg',
+                            'size'              => 1048576,
+                            'storage'           => 'catalogStorage',
+
+                        ],
                     ],
                 ],
             ],

--- a/tests/catalog/technical_sql/050_common.sql
+++ b/tests/catalog/technical_sql/050_common.sql
@@ -37,7 +37,7 @@ INSERT INTO `acme_reference_data_fabric` VALUES (5,'fabricA',1,'fabricA',NULL),(
 --
 
 /*!40000 ALTER TABLE `akeneo_file_storage_file_info` DISABLE KEYS */;
-INSERT INTO `akeneo_file_storage_file_info` VALUES (35,'8/b/5/c/8b5cf9bfd2e7e4725fd581e03251133ada1b2c99_fileA.txt','fileA.txt','text/plain',1048576,'txt','6545089471ba53d660d22d7b8dc8dd67904b1e28','catalogStorage'),(36,'3/b/5/5/3b5548f9764c0535db2ac92f047fa448cb7cea76_imageA.jpg','imageA.jpg','text/plain',1048576,'jpg','a9453e6ce89dbfd776ecae609e1c23e9cfad8277','catalogStorage'),(37,'7/1/3/3/713380965740f8838834cd58505aa329fcf448a5_imageB_en_US.jpg','imageB-en_US.jpg','text/plain',1048576,'jpg','16850b6741c6e0d7622edb29465488571a2e63df','catalogStorage'),(38,'0/5/1/9/05198fcf21b2b0d4596459f172e2e62b1a70bfd0_imageB_fr_FR.jpg','imageB-fr_FR.jpg','text/plain',1048576,'jpg','058c6f380b0888afadf7341f8baaf58b538e5774','catalogStorage');
+INSERT INTO `akeneo_file_storage_file_info` VALUES (35,'8/b/5/c/8b5cf9bfd2e7e4725fd581e03251133ada1b2c99_fileA.txt','fileA.txt','text/plain',1048576,'txt','6545089471ba53d660d22d7b8dc8dd67904b1e28','catalogStorage'),(36,'3/b/5/5/3b5548f9764c0535db2ac92f047fa448cb7cea76_imageA.jpg','imageA.jpg','image/jpeg',1048576,'jpg','a9453e6ce89dbfd776ecae609e1c23e9cfad8277','catalogStorage'),(37,'7/1/3/3/713380965740f8838834cd58505aa329fcf448a5_imageB_en_US.jpg','imageB-en_US.jpg','image/jpeg',1048576,'jpg','16850b6741c6e0d7622edb29465488571a2e63df','catalogStorage'),(38,'0/5/1/9/05198fcf21b2b0d4596459f172e2e62b1a70bfd0_imageB_fr_FR.jpg','imageB-fr_FR.jpg','image/jpeg',1048576,'jpg','058c6f380b0888afadf7341f8baaf58b538e5774','catalogStorage');
 /*!40000 ALTER TABLE `akeneo_file_storage_file_info` ENABLE KEYS */;
 
 --


### PR DESCRIPTION
## Description

This PR adds the PQB  Elasticsearch filters on media product values (`pim_catalog_image` and `pim_catalog_file` attribute types).

It also solves a recurring error in CI `Container whatever already exists`, by deleting every container on the Jenkins slaves before running integration tests.

## ES Filter Checklist
- [x] Review the PQB filter integration tests
- [x] Add index mapping integration tests 
- [x] Write the filter + normalizer & respective phpspec
- [x] Update the documentation in `search_specification.rst`
- [x] Is the PIM installable?

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed