### PR TITLE
Tip 706 metrics

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
+use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+/**
+ * Metric filter for an Elasticsearch query
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    const PATH_SUFFIX = 'base_data';
+
+    /** @var MeasureManager */
+    protected $measureManager;
+
+    /** @var MeasureConverter */
+    protected $metricConverter;
+
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param MeasureManager           $measureManager
+     * @param MeasureConverter         $measureConverter
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        MeasureManager $measureManager,
+        MeasureConverter $measureConverter,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->measureManager = $measureManager;
+        $this->metricConverter = $measureConverter;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
+            $this->checkValue($attribute, $value);
+            $value = $this->convertValue($attribute, $value);
+        }
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel) . '.' . self::PATH_SUFFIX;
+
+        switch ($operator) {
+            case Operators::LOWER_THAN:
+                $clause = [
+                    'range' => [
+                        $attributePath => ['lt' => $value]
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::LOWER_OR_EQUAL_THAN:
+                $clause = [
+                    'range' => [
+                        $attributePath => ['lte' => $value]
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::EQUALS:
+                $clause = [
+                    'term' => [
+                        $attributePath => $value
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::NOT_EQUAL:
+                $mustNotClause = [
+                    'term' => [
+                        $attributePath => $value,
+                    ],
+                ];
+                $filterClause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
+            case Operators::GREATER_OR_EQUAL_THAN:
+                $clause = [
+                    'range' => [
+                        $attributePath => ['gte' => $value]
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::GREATER_THAN:
+                $clause = [
+                    'range' => [
+                        $attributePath => ['gt' => $value]
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath
+                    ]
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
+            case Operators::IS_NOT_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if the given value is valid
+     *
+     * @param AttributeInterface $attribute
+     * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
+     */
+    protected function checkValue(AttributeInterface $attribute, $data)
+    {
+        if (!is_array($data)) {
+            throw InvalidPropertyTypeException::arrayExpected($attribute->getCode(), static::class, $data);
+        }
+
+        if (!array_key_exists('amount', $data)) {
+            throw InvalidPropertyTypeException::arrayKeyExpected(
+                $attribute->getCode(),
+                'amount',
+                static::class,
+                $data
+            );
+        }
+
+        if (!array_key_exists('unit', $data)) {
+            throw InvalidPropertyTypeException::arrayKeyExpected(
+                $attribute->getCode(),
+                'unit',
+                static::class,
+                $data
+            );
+        }
+
+        if (null !== $data['amount'] && !is_numeric($data['amount'])) {
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
+                $attribute->getCode(),
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype($data['amount'])),
+                static::class,
+                $data
+            );
+        }
+
+        if (!is_string($data['unit'])) {
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
+                $attribute->getCode(),
+                sprintf('key "unit" has to be a string, "%s" given', gettype($data['unit'])),
+                static::class,
+                $data
+            );
+        }
+
+        if (!array_key_exists(
+            $data['unit'],
+            $this->measureManager->getUnitSymbolsForFamily($attribute->getMetricFamily())
+        )) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                $attribute->getCode(),
+                'unit',
+                sprintf(
+                    'The unit does not exist in the attribute\'s family "%s"',
+                    $attribute->getMetricFamily()
+                ),
+                static::class,
+                $data['unit']
+            );
+        }
+    }
+
+    /**
+     * Converts the given value to the base_unit configured in the family.
+     *
+     * @param AttributeInterface $attribute
+     * @param array              $data
+     *
+     * @return float
+     */
+    protected function convertValue(AttributeInterface $attribute, array $data)
+    {
+        $this->metricConverter->setFamily($attribute->getMetricFamily());
+
+        return $this->metricConverter->convertBaseToStandard($data['unit'], $data['amount']);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -27,7 +27,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected $measureManager;
 
     /** @var MeasureConverter */
-    protected $metricConverter;
+    protected $measureConverter;
 
     /**
      * @param AttributeValidatorHelper $attrValidatorHelper
@@ -45,7 +45,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->measureManager = $measureManager;
-        $this->metricConverter = $measureConverter;
+        $this->measureConverter = $measureConverter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -193,7 +193,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             );
         }
 
-        if (null !== $data['amount'] && !is_numeric($data['amount'])) {
+        if (null === $data['amount'] || !is_numeric($data['amount'])) {
             throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
                 sprintf('key "amount" has to be a numeric, "%s" given', gettype($data['amount'])),
@@ -238,8 +238,8 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
      */
     protected function convertValue(AttributeInterface $attribute, array $data)
     {
-        $this->metricConverter->setFamily($attribute->getMetricFamily());
+        $this->measureConverter->setFamily($attribute->getMetricFamily());
 
-        return $this->metricConverter->convertBaseToStandard($data['unit'], $data['amount']);
+        return $this->measureConverter->convertBaseToStandard($data['unit'], $data['amount']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1053,20 +1053,28 @@ Metric
 ******
 :Apply: pim_catalog_metric attributes
 
-In case of metric, only the data converted to the default metric unit of the family
-must be indexed.
+In case of metric, only the data converted to the default metric unit of the family is indexed, however the unit and data properties are also saved in ES but not indexed.
 
 Data model
 ~~~~~~~~~~
-.. code-block:: yaml
+.. code-block:: php
 
-    weight_metric: 10.5
+    [
+        'values' => [
+            'weight-metric' => [
+                'base_data' => '10.5559',
+                'base_unit' => 'KILOGRAM',
+                'data' => '10555.9',
+                'unit'  => 'GRAM'
+            ]
+        ]
+    ]
 
 Filtering
 ~~~~~~~~~
 Operators
 .........
-All operators are identical to the one used on numbers
+All operators are identical to the one used on numbers.
 
 Boolean
 *******

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1062,10 +1062,14 @@ Data model
     [
         'values' => [
             'weight-metric' => [
-                'base_data' => '10.5559',
-                'base_unit' => 'KILOGRAM',
-                'data' => '10555.9',
-                'unit'  => 'GRAM'
+                '<all_channels>' => [
+                    '<all_locales> => [
+                        'base_data' => '10.5559',
+                        'base_unit' => 'KILOGRAM',
+                        'data' => '10555.9',
+                        'unit'  => 'GRAM'
+                    ]
+                ]
             ]
         ]
     ]

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -21,6 +21,7 @@ parameters:
     pim_catalog.query.elasticsearch.filter.option.class:          Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter
     pim_catalog.query.elasticsearch.filter.options.class:         Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionsFilter
     pim_catalog.query.elasticsearch.filter.price.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\PriceFilter
+    pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
     pim_catalog.query.elasticsearch.sorter.base.class:            Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter
 
 services:
@@ -224,6 +225,17 @@ services:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_catalog.repository.currency'
             - ['pim_catalog_price_collection']
+            - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.metric:
+        class: '%pim_catalog.query.elasticsearch.filter.metric.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - '@akeneo_measure.manager'
+            - '@akeneo_measure.measure_converter'
+            - ['pim_catalog_metric']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -12,6 +12,7 @@ parameters:
     pim_catalog.normalizer.indexing.product.text.class: Pim\Component\Catalog\Normalizer\Indexing\Product\TextNormalizer
     pim_catalog.normalizer.indexing.product.text_area.class: Pim\Component\Catalog\Normalizer\Indexing\Product\TextAreaNormalizer
     pim_catalog.normalizer.indexing.product.price_collection.class: Pim\Component\Catalog\Normalizer\Indexing\Product\PriceCollectionNormalizer
+    pim_catalog.normalizer.indexing.product.metric.class: Pim\Component\Catalog\Normalizer\Indexing\Product\MetricNormalizer
 
 services:
     pim_catalog.normalizer.indexing.product:
@@ -82,5 +83,10 @@ services:
         class: '%pim_catalog.normalizer.indexing.product.price_collection.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_value'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.indexing.metric:
+        class: '%pim_catalog.normalizer.indexing.product.metric.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -66,7 +66,7 @@ mappings:
                 metric_data:
                     match_mapping_type: 'string'
                     mapping:
-                        type: 'double'
+                        index: 'no'
                     path_match: 'values.*-metric.*.data'
             -
                 metric_base_data:
@@ -78,13 +78,13 @@ mappings:
                 metric_unit:
                     match_mapping_type: 'string'
                     mapping:
-                        type: 'keyword'
+                        index: 'no'
                     path_match: 'values.*-metric.*.unit'
             -
                 metric_base_unit:
                     match_mapping_type: 'string'
                     mapping:
-                        type: 'keyword'
+                        index: 'no'
                     path_match: 'values.*-metric.*.base_unit'
 settings:
     analysis:

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -56,13 +56,36 @@ mappings:
                     match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
-
             -
                 prices:
                     match_mapping_type: 'string'
                     mapping:
                         type: 'double'
                     path_match: 'values.*-prices.*'
+            -
+                metric_data:
+                    match_mapping_type: 'string'
+                    mapping:
+                        type: 'double'
+                    path_match: 'values.*-metric.*.data'
+            -
+                metric_base_data:
+                    match_mapping_type: 'string'
+                    mapping:
+                        type: 'double'
+                    path_match: 'values.*-metric.*.base_data'
+            -
+                metric_unit:
+                    match_mapping_type: 'string'
+                    mapping:
+                        type: 'keyword'
+                    path_match: 'values.*-metric.*.unit'
+            -
+                metric_base_unit:
+                    match_mapping_type: 'string'
+                    mapping:
+                        type: 'keyword'
+                    path_match: 'values.*-metric.*.base_unit'
 settings:
     analysis:
         normalizer:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
@@ -1,0 +1,638 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
+use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+class MetricFilterSpec extends ObjectBehavior
+{
+    function let(
+        AttributeValidatorHelper $attributeValidatorHelper,
+        MeasureManager $measureManager,
+        MeasureConverter $measureConverter
+    ) {
+        $this->beConstructedWith(
+            $attributeValidatorHelper,
+            $measureManager,
+            $measureConverter,
+            ['pim_catalog_metric'],
+            ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MetricFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(AttributeFilterInterface::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(
+            [
+                '<',
+                '<=',
+                '=',
+                '>=',
+                '>',
+                'EMPTY',
+                'NOT EMPTY',
+                '!=',
+            ]
+        );
+        $this->supportsOperator('<=')->shouldReturn(true);
+        $this->supportsOperator('DOES NOT CONTAIN')->shouldReturn(false);
+    }
+
+    function it_supports_metric_attribute(AttributeInterface $metric, AttributeInterface $tags)
+    {
+        $metric->getType()->willReturn('pim_catalog_metric');
+        $tags->getType()->willReturn('pim_catalog_multiselect');
+
+        $this->getAttributeTypes()->shouldReturn(
+            [
+                'pim_catalog_metric',
+            ]
+        );
+
+        $this->supportsAttribute($metric)->shouldReturn(true);
+        $this->supportsAttribute($tags)->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_lower_than(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addFilter(
+            [
+                'range' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => ['lt' => 1000],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::LOWER_THAN,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_lower_than_or_equal(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addFilter(
+            [
+                'range' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => ['lte' => 1000],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::LOWER_OR_EQUAL_THAN,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []);
+    }
+
+    function it_adds_a_filter_with_operator_equals(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addFilter(
+            [
+                'term' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => 1000,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::EQUALS,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_not_equals(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addMustNot(
+            [
+                'term' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => 1000,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'values.weight-metric.ecommerce.en_US.base_data',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::NOT_EQUAL,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_greater_than_or_equals(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addFilter(
+            [
+                'range' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => ['gte' => 1000],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::GREATER_OR_EQUAL_THAN,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_greater_than(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $sqb->addFilter(
+            [
+                'range' => [
+                    'values.weight-metric.ecommerce.en_US.base_data' => ['gt' => 1000],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter(
+            $metric,
+            Operators::GREATER_THAN,
+            ['amount' => 1, 'unit' => 'KILOGRAM'],
+            'en_US',
+            'ecommerce',
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_empty(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'exists' => [
+                    'field' => 'values.weight-metric.ecommerce.en_US.base_data',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($metric, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_not_empty(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'values.weight-metric.ecommerce.en_US.base_data',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($metric, Operators::IS_NOT_EMPTY, [], 'en_US', 'ecommerce', []);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(AttributeInterface $metric)
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during('addAttributeFilter',
+            [$metric, Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'GRAM'], 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_an_array(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                'weight',
+                MetricFilter::class,
+                10
+            )
+        )->during('addAttributeFilter', [$metric, Operators::LOWER_THAN, 10, 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_the_given_array_value_has_no_amount(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayKeyExpected(
+                'weight',
+                'amount',
+                MetricFilter::class,
+                ['value' => 10, 'unit_type' => 'kilogram']
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::LOWER_THAN, ['value' => 10, 'unit_type' => 'kilogram'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_array_value_has_no_unit(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayKeyExpected(
+                'weight',
+                'unit',
+                MetricFilter::class,
+                ['amount' => 10, 'unit_type' => 'kilogram']
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::LOWER_THAN, ['amount' => 10, 'unit_type' => 'kilogram'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_amount_is_null(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getCode()->willReturn('weight');
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                'weight',
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype(null)),
+                MetricFilter::class,
+                ['amount' => null, 'unit' => 'kilogram']
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::LOWER_THAN, ['amount' => null, 'unit' => 'kilogram'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_amount_is_not_numeric(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                'weight',
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype('10')),
+                MetricFilter::class,
+                ['amount' => 'NOT_NUMERIC', 'unit' => 'kilogram']
+            )
+        )->during(
+            'addAttributeFilter',
+            [
+                $metric,
+                Operators::LOWER_THAN,
+                ['amount' => 'NOT_NUMERIC', 'unit' => 'kilogram'],
+                'en_US',
+                'ecommerce',
+                [],
+            ]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_unit_is_not_a_string(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                'weight',
+                sprintf('key "unit" has to be a string, "%s" given', gettype(10)),
+                MetricFilter::class,
+                ['amount' => 10, 'unit' => 10]
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::LOWER_THAN, ['amount' => 10, 'unit' => 10], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_unit_is_not_known_of_the_metric_family(
+        $attributeValidatorHelper,
+        $measureManager,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM', 'KILOGRAM']);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'weight',
+                'unit',
+                'The unit does not exist in the attribute\'s family "Weight"',
+                MetricFilter::class,
+                'UNKNOWN_UNIT'
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::LOWER_THAN, ['amount' => 10, 'unit' => 'UNKNOWN_UNIT'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        $attributeValidatorHelper,
+        $measureManager,
+        $measureConverter,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($metric, 'ecommerce')->shouldBeCalled();
+
+        $metric->getMetricFamily()->willReturn('Weight');
+        $measureManager->getUnitSymbolsForFamily('Weight')->willReturn(['GRAM' => 1000, 'KILOGRAM' => 1]);
+
+        $measureConverter->setFamily('Weight')->shouldBeCalled();
+        $measureConverter->convertBaseToStandard('KILOGRAM', 1)->willReturn(1000);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                MetricFilter::class
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::IN_CHILDREN_LIST, ['amount' => 1, 'unit' => 'KILOGRAM'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_locale_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+        $metric->isLocaleSpecific()->willReturn(true);
+        $metric->getAvailableLocaleCodes('fr_FR');
+
+        $e = new \LogicException('Attribute "size" expects a locale, none given.');
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'weight',
+                MetricFilter::class,
+                $e
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::CONTAINS, ['amount' => 10, 'unit' => 'KILOGRAM'], 'en_US', 'ecommerce', []]
+        );
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_scope_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $metric,
+        SearchQueryBuilder $sqb
+    ) {
+        $metric->getCode()->willReturn('weight');
+        $metric->getBackendType()->willReturn('metric');
+        $metric->isScopable()->willReturn(false);
+
+        $e = new \LogicException('Attribute "weight" does not expect a scope, "ecommerce" given.');
+        $attributeValidatorHelper->validateLocale($metric, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'weight',
+                MetricFilter::class,
+                $e
+            )
+        )->during(
+            'addAttributeFilter',
+            [$metric, Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'KILOGRAM'], 'en_US', 'ecommerce', []]
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogMetricIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogMetricIntegration.php
@@ -1,0 +1,456 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
+
+/**
+ * This integration tests checks that given an index configuration with metric data (float and integer values)
+ * the metric research is consistent.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PimCatalogMetricIntegration extends AbstractPimCatalogIntegration
+{
+    public function testLowerThanOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['lt' => 10],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_2', 'product_5', 'product_6']);
+    }
+
+    public function testLowerThanOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['lt' => '10'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_2', 'product_5', 'product_6']);
+    }
+
+    public function testLowerThanOrEqualsOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['lte' => 10],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_2', 'product_5', 'product_6']);
+    }
+
+    public function testLowerThanOrEqualsOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['lte' => '10'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_2', 'product_5', 'product_6']);
+    }
+
+    public function testEqualsOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'term' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => 100.666,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_3']);
+    }
+
+    public function testEqualsOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'term' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => '100.666',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_3']);
+    }
+
+    public function testNotEqualsOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'term' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => 100.666,
+                        ],
+                    ],
+                    'filter'   => [
+                        'exists' => [
+                            'field' => 'values.a_metric-metric.<all_channels>.<all_locales>.base_data',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_1', 'product_2', 'product_4', 'product_5', 'product_6']
+        );
+    }
+
+    public function testNotEqualsOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'term' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => '100.666',
+                        ],
+                    ],
+                    'filter'   => [
+                        'exists' => [
+                            'field' => 'values.a_metric-metric.<all_channels>.<all_locales>.base_data',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_1', 'product_2', 'product_4', 'product_5', 'product_6']
+        );
+    }
+
+    public function testGreaterThanOrEqualsOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['gte' => 10],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_3', 'product_4']);
+    }
+
+    public function testGreaterThanOrEqualsOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['gte' => '10'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_1', 'product_3', 'product_4']);
+    }
+
+    public function testGreaterThanOperatorWithNumberValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['gt' => 10],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_3', 'product_4']);
+    }
+
+    public function testGreaterThanOperatorWithStringValue()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'range' => [
+                            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => ['gt' => '10'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_3', 'product_4']);
+    }
+
+    public function testEmptyOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        'exists' => [
+                            'field' => 'values.a_metric-metric.<all_channels>.<all_locales>.base_data',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts($productsFound, ['product_7']);
+    }
+
+    public function testNotEmptyOperator()
+    {
+        $query = [
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        'exists' => [
+                            'field' => 'values.a_metric-metric.<all_channels>.<all_locales>.base_data',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_1', 'product_2', 'product_3', 'product_4', 'product_5', 'product_6']
+        );
+    }
+
+    public function testSortAscending()
+    {
+        $query = [
+            'query' => [
+                'match_all' => new \stdClass(),
+            ],
+            'sort'  => [
+                [
+                    'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => [
+                        'order'   => 'asc',
+                        'missing' => '_first',
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_7', 'product_2', 'product_5', 'product_6', 'product_1', 'product_4', 'product_3']
+        );
+    }
+
+    public function testSortDescending()
+    {
+        $query = [
+            'query' => [
+                'match_all' => new \stdClass(),
+            ],
+            'sort'  => [
+                [
+                    'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => [
+                        'order'   => 'desc',
+                        'missing' => '_last',
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertProducts(
+            $productsFound,
+            ['product_3', 'product_4', 'product_1', 'product_6', 'product_5', 'product_2', 'product_7']
+        );
+    }
+
+    /**
+     * This method indexes dummy products in elastic search.
+     *
+     * A few information regarding the mapping of numbers and the data indexed in ES below.
+     * We indexed data of different types:
+     *  - integer as a php integer
+     *  - integer as a php string
+     *  - float as a php float
+     *  - float as a php string
+     *
+     * What we want to test is that our ES queries are still correctly working despite those variations (eg, the
+     * resilience of the ES indexing).
+     *
+     * In this precise case, some data might not be catched by our dynamic mapping, but ES is capable of casting them
+     * and the queries are still working.
+     */
+    protected function addProducts()
+    {
+        $products = [
+            [
+                'identifier' => 'product_1',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'base_data' => '10.0',
+                                'data' => '10000',
+                                'base_unit' => 'CELSIUS',
+                                'unit' => 'GRAM',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_2',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'base_data' => -1,
+                                'base_unit' => 'KILOGRAM'
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_3',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'base_data' => '100.666',
+                                'data' => '152',
+                                'base_unit' => 'KILOGRAM'
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_4',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'base_data' => '25.89',
+                                'base_unit' => 'KILOGRAM'
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_5',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [
+                                'base_data' => '-3900',
+                                'base_unit'  => 'KILOGRAM',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_6',
+                'values'     => [
+                    'a_metric-metric' => [
+                        '<all_channels>' => [
+                            '<all_locales>' =>[
+                                'base_data' => '7',
+                                'base_unit'  => 'KILOGRAM',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'identifier' => 'product_7',
+                'values'     => [],
+            ],
+        ];
+
+        $this->indexProducts($products);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_localizable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_scopable_localizable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -20,6 +20,8 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createProduct('product_one', [
                 'values' => [
                     'a_metric' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -50,6 +50,15 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $result = $this->executeFilter([['a_metric', Operators::LOWER_THAN, ['amount' => 16, 'unit' => 'KILOWATT']]]);
         $this->assert($result, ['product_one', 'product_two']);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_THAN, ['amount' => 10550, 'unit' => 'WATT']]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_THAN, ['amount' => 10550.1, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one']);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_THAN, ['amount' => 16000, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one', 'product_two']);
     }
 
     public function testOperatorInferiorOrEquals()
@@ -62,6 +71,15 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $result = $this->executeFilter([['a_metric', Operators::LOWER_OR_EQUAL_THAN, ['amount' => 15, 'unit' => 'KILOWATT']]]);
         $this->assert($result, ['product_one', 'product_two']);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_OR_EQUAL_THAN, ['amount' => 10499.9, 'unit' => 'WATT']]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_OR_EQUAL_THAN, ['amount' => 10550, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one']);
+
+        $result = $this->executeFilter([['a_metric', Operators::LOWER_OR_EQUAL_THAN, ['amount' => 15000, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one', 'product_two']);
     }
 
     public function testOperatorEquals()
@@ -71,6 +89,12 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $result = $this->executeFilter([['a_metric', Operators::EQUALS, ['amount' => 10.55, 'unit' => 'KILOWATT']]]);
         $this->assert($result, ['product_one']);
+
+        $result = $this->executeFilter([['a_metric', Operators::EQUALS, ['amount' => 10550.1, 'unit' => 'WATT']]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['a_metric', Operators::EQUALS, ['amount' => 10550, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one']);
     }
 
     public function testOperatorSuperior()
@@ -79,6 +103,12 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, []);
 
         $result = $this->executeFilter([['a_metric', Operators::GREATER_THAN, ['amount' => 10.4999, 'unit' => 'KILOWATT']]]);
+        $this->assert($result, ['product_one', 'product_two']);
+
+        $result = $this->executeFilter([['a_metric', Operators::GREATER_THAN, ['amount' => 15000, 'unit' => 'WATT']]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['a_metric', Operators::GREATER_THAN, ['amount' => 10499.9, 'unit' => 'WATT']]]);
         $this->assert($result, ['product_one', 'product_two']);
     }
 
@@ -92,6 +122,14 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $result = $this->executeFilter([['a_metric', Operators::GREATER_OR_EQUAL_THAN, ['amount' => 15, 'unit' => 'KILOWATT']]]);
         $this->assert($result, ['product_two']);
+
+        $result = $this->executeFilter([['a_metric', Operators::GREATER_OR_EQUAL_THAN, ['amount' => 15010, 'unit' => 'WATT']]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['a_metric', Operators::GREATER_OR_EQUAL_THAN, ['amount' => 10550, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_one', 'product_two']);
+
+        $result = $this->executeFilter([['a_metric', Operators::GREATER_OR_EQUAL_THAN, ['amount' => 15000, 'unit' => 'WATT']]]);
     }
 
     public function testOperatorEmpty()
@@ -109,6 +147,9 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
     public function testOperatorDifferent()
     {
         $result = $this->executeFilter([['a_metric', Operators::NOT_EQUAL, ['amount' => 15, 'unit' => 'KILOWATT']]]);
+        $this->assert($result, ['product_one']);
+
+        $result = $this->executeFilter([['a_metric', Operators::NOT_EQUAL, ['amount' => 15000, 'unit' => 'WATT']]]);
         $this->assert($result, ['product_one']);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->resetIndex();
+
             $this->createAttribute([
                 'code'                => 'a_scopable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\ProductValue\MetricProductValue;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizer for a text (simple text) product value
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class MetricNormalizer extends AbstractProductValueNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof MetricProductValue &&
+            AttributeTypes::BACKEND_TYPE_METRIC === $data->getAttribute()->getBackendType() &&
+            'indexing' === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNormalizedData(ProductValueInterface $productValue)
+    {
+        $productMetric = $productValue->getData();
+
+        return [
+            'data'      => (string) $productMetric->getData(),
+            'base_data' => (string) $productMetric->getBaseData(),
+            'unit'      => $productMetric->getUnit(),
+            'base_unit' => $productMetric->getBaseUnit()
+        ];
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\ProductValue\MetricProductValue;
+use Pim\Component\Catalog\ProductValue\MetricProductValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -21,9 +22,7 @@ class MetricNormalizer extends AbstractProductValueNormalizer implements Normali
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ProductValueInterface &&
-            AttributeTypes::BACKEND_TYPE_METRIC === $data->getAttribute()->getBackendType() &&
-            'indexing' === $format;
+        return $data instanceof MetricProductValueInterface && 'indexing' === $format;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
@@ -8,7 +8,7 @@ use Pim\Component\Catalog\ProductValue\MetricProductValue;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Normalizer for a text (simple text) product value
+ * Normalizer for a metric product value
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -21,7 +21,7 @@ class MetricNormalizer extends AbstractProductValueNormalizer implements Normali
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof MetricProductValue &&
+        return $data instanceof ProductValueInterface &&
             AttributeTypes::BACKEND_TYPE_METRIC === $data->getAttribute()->getBackendType() &&
             'indexing' === $format;
     }
@@ -32,6 +32,10 @@ class MetricNormalizer extends AbstractProductValueNormalizer implements Normali
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
         $productMetric = $productValue->getData();
+
+        if (null === $productMetric) {
+            return [];
+        }
 
         return [
             'data'      => (string) $productMetric->getData(),

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\MetricInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\Product\MetricNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class MetricNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MetricNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_support_metric_product_value(
+        ProductValueInterface $metricValue,
+        ProductValueInterface $textValue,
+        AttributeInterface $metricAttribute,
+        AttributeInterface $textAttribute
+    ) {
+        $metricValue->getAttribute()->willReturn($metricAttribute);
+        $metricAttribute->getBackendType()->willReturn('metric');
+
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textAttribute->getBackendType()->willReturn('text');
+
+        $this->supportsNormalization(new \stdClass(), 'indexing')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+
+        $this->supportsNormalization($textValue, 'indexing')->shouldReturn(false);
+        $this->supportsNormalization($metricValue, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($metricValue, 'indexing')->shouldReturn(true);
+    }
+
+    function it_normalizes_an_empty_metric_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $metricValue,
+        AttributeInterface $metricAttribute,
+        MetricInterface $metric
+    ) {
+        $metricValue->getAttribute()->willReturn($metricAttribute);
+        $metricValue->getLocale()->willReturn(null);
+        $metricValue->getScope()->willReturn(null);
+        $metricValue->getData()->willReturn(null);
+
+        $metricAttribute->isDecimalsAllowed()->willReturn(false);
+        $metricAttribute->getCode()->willReturn('weight');
+        $metricAttribute->getBackendType()->willReturn('metric');
+
+        $this->normalize($metricValue, 'indexing')->shouldReturn([
+            'weight-metric' => [
+                '<all_channels>' => [
+                    '<all_locales>' => [],
+                ],
+            ],
+        ]);
+    }
+    
+    function it_normalizes_a_metric_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $metricValue,
+        AttributeInterface $metricAttribute,
+        MetricInterface $metric
+    ) {
+        $metric->getData()->willReturn(125.12);
+        $metric->getBaseData()->willReturn(0.12512);
+        $metric->getUnit()->willReturn('GRAM');
+        $metric->getBaseUnit()->willReturn('KILOGRAM');
+
+        $metricValue->getAttribute()->willReturn($metricAttribute);
+        $metricValue->getLocale()->willReturn(null);
+        $metricValue->getScope()->willReturn(null);
+        $metricValue->getData()->willReturn($metric);
+
+        $metricAttribute->isDecimalsAllowed()->willReturn(false);
+        $metricAttribute->getCode()->willReturn('weight');
+        $metricAttribute->getBackendType()->willReturn('metric');
+
+        $this->normalize($metricValue, 'indexing')->shouldReturn([
+            'weight-metric' => [
+                '<all_channels>' => [
+                    '<all_locales>' => [
+                        'data'      => '125.12',
+                        'base_data' => '0.12512',
+                        'unit'      => 'GRAM',
+                        'base_unit' => 'KILOGRAM',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_metric_product_value_with_locale(
+        ProductValueInterface $metricValue,
+        AttributeInterface $metricAttribute,
+        MetricInterface $metric
+    ) {
+        $metric->getData()->willReturn(125.12);
+        $metric->getBaseData()->willReturn(0.12512);
+        $metric->getUnit()->willReturn('GRAM');
+        $metric->getBaseUnit()->willReturn('KILOGRAM');
+
+        $metricValue->getAttribute()->willReturn($metricAttribute);
+        $metricValue->getLocale()->willReturn('en_US');
+        $metricValue->getScope()->willReturn(null);
+        $metricValue->getData()->willReturn($metric);
+
+        $metricAttribute->getCode()->willReturn('weight');
+        $metricAttribute->getBackendType()->willReturn('metric');
+
+        $this->normalize($metricValue, 'indexing')->shouldReturn([
+            'weight-metric' => [
+                '<all_channels>' => [
+                    'en_US' => [
+                        'data'      => '125.12',
+                        'base_data' => '0.12512',
+                        'unit'      => 'GRAM',
+                        'base_unit' => 'KILOGRAM',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_integer_product_value_with_locale_and_channel(
+        ProductValueInterface $metricValue,
+        AttributeInterface $metricAttribute,
+        MetricInterface $metric
+    ) {
+        $metric->getData()->willReturn(125.12);
+        $metric->getBaseData()->willReturn(0.12512);
+        $metric->getUnit()->willReturn('GRAM');
+        $metric->getBaseUnit()->willReturn('KILOGRAM');
+
+        $metricValue->getAttribute()->willReturn($metricAttribute);
+        $metricValue->getLocale()->willReturn('fr_FR');
+        $metricValue->getScope()->willReturn('ecommerce');
+        $metricValue->getData()->willReturn($metric);
+
+        $metricAttribute->isDecimalsAllowed()->willReturn(false);
+        $metricAttribute->getCode()->willReturn('weight');
+        $metricAttribute->getBackendType()->willReturn('metric');
+
+        $this->normalize($metricValue, 'indexing')->shouldReturn([
+            'weight-metric' => [
+                'ecommerce' => [
+                    'fr_FR' => [
+                        'data'      => '125.12',
+                        'base_data' => '0.12512',
+                        'unit'      => 'GRAM',
+                        'base_unit' => 'KILOGRAM',
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
@@ -7,6 +7,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\MetricInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\MetricNormalizer;
+use Pim\Component\Catalog\ProductValue\MetricProductValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class MetricNormalizerSpec extends ObjectBehavior
@@ -22,13 +23,12 @@ class MetricNormalizerSpec extends ObjectBehavior
     }
 
     function it_support_metric_product_value(
-        ProductValueInterface $metricValue,
+        MetricProductValueInterface $metricValue,
         ProductValueInterface $textValue,
         AttributeInterface $metricAttribute,
         AttributeInterface $textAttribute
     ) {
         $metricValue->getAttribute()->willReturn($metricAttribute);
-        $metricAttribute->getBackendType()->willReturn('metric');
 
         $textValue->getAttribute()->willReturn($textAttribute);
         $textAttribute->getBackendType()->willReturn('text');
@@ -42,16 +42,14 @@ class MetricNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_an_empty_metric_product_value_with_no_locale_and_no_channel(
-        ProductValueInterface $metricValue,
-        AttributeInterface $metricAttribute,
-        MetricInterface $metric
+        MetricProductValueInterface $metricValue,
+        AttributeInterface $metricAttribute
     ) {
         $metricValue->getAttribute()->willReturn($metricAttribute);
         $metricValue->getLocale()->willReturn(null);
         $metricValue->getScope()->willReturn(null);
         $metricValue->getData()->willReturn(null);
 
-        $metricAttribute->isDecimalsAllowed()->willReturn(false);
         $metricAttribute->getCode()->willReturn('weight');
         $metricAttribute->getBackendType()->willReturn('metric');
 
@@ -63,7 +61,7 @@ class MetricNormalizerSpec extends ObjectBehavior
             ],
         ]);
     }
-    
+
     function it_normalizes_a_metric_product_value_with_no_locale_and_no_channel(
         ProductValueInterface $metricValue,
         AttributeInterface $metricAttribute,
@@ -79,7 +77,6 @@ class MetricNormalizerSpec extends ObjectBehavior
         $metricValue->getScope()->willReturn(null);
         $metricValue->getData()->willReturn($metric);
 
-        $metricAttribute->isDecimalsAllowed()->willReturn(false);
         $metricAttribute->getCode()->willReturn('weight');
         $metricAttribute->getBackendType()->willReturn('metric');
 

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -114,44 +114,40 @@ class ProductIndexingIntegration extends TestCase
                 'a_metric-metric'                                => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'amount'    => '987654321987.1234',
-                            'unit'      => 'KILOWATT',
-                            'base_data' => '9.8765432198712e+14',
+                            'base_data' => '9.8765432198712E+14',
                             'base_unit' => 'WATT',
-                            'family'    => 'Power',
+                            'data'      => '987654321987.1234',
+                            'unit'      => 'KILOWATT',
                         ],
                     ],
                 ],
                 'a_metric_negative-metric'                       => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'amount'    => '-25.5000',
-                            'unit'      => 'CELSIUS',
                             'base_data' => '252.65',
                             'base_unit' => 'KELVIN',
-                            'family'    => 'Temperature',
+                            'data'      => '-20.5000',
+                            'unit'      => 'CELSIUS',
                         ],
                     ],
                 ],
                 'a_metric_without_decimal-metric'                => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'amount'    => '98',
-                            'unit'      => 'CENTIMETER',
                             'base_data' => '0.98',
+                            'data'    => '98',
                             'base_unit' => 'METER',
-                            'family'    => 'Length',
+                            'unit'      => 'CENTIMETER',
                         ],
                     ],
                 ],
                 'a_metric_without_decimal_negative-metric'       => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'amount'    => '-20',
-                            'unit'      => 'CELSIUS',
                             'base_data' => '253.15',
+                            'data'    => '-20',
                             'base_unit' => 'KELVIN',
-                            'family'    => 'Temperature',
+                            'unit'      => 'CELSIUS',
                         ],
                     ],
                 ],

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -113,22 +113,46 @@ class ProductIndexingIntegration extends TestCase
                 ],
                 'a_metric-metric'                                => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'amount'    => '987654321987.1234',
+                            'unit'      => 'KILOWATT',
+                            'base_data' => '9.8765432198712e+14',
+                            'base_unit' => 'WATT',
+                            'family'    => 'Power',
+                        ],
                     ],
                 ],
                 'a_metric_negative-metric'                       => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'amount'    => '-25.5000',
+                            'unit'      => 'CELSIUS',
+                            'base_data' => '252.65',
+                            'base_unit' => 'KELVIN',
+                            'family'    => 'Temperature',
+                        ],
                     ],
                 ],
                 'a_metric_without_decimal-metric'                => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'amount'    => '98',
+                            'unit'      => 'CENTIMETER',
+                            'base_data' => '0.98',
+                            'base_unit' => 'METER',
+                            'family'    => 'Length',
+                        ],
                     ],
                 ],
                 'a_metric_without_decimal_negative-metric'       => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => [
+                            'amount'    => '-20',
+                            'unit'      => 'CELSIUS',
+                            'base_data' => '253.15',
+                            'base_unit' => 'KELVIN',
+                            'family'    => 'Temperature',
+                        ],
                     ],
                 ],
                 'a_multi_select-options'                         => [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**ES Filter Checklist:**
- [X] Add ES metric normalizer
- [X] Review the PQB filter integration tests
- [X] Add index mapping integration tests 
- [x] Write the filter & Spec
- [x] Update the documentation in `search_specification.rst`
- [x] Is the PIM installable ?

Overall, the ES queries work just like the NumberFilter works. The Filter is provided with the data and the unit and does a `on-the-fly` conversion to the base_unit for filtering in ES.

Considering the metrics we store all data (base_data, base_unit, data, base_unit) but we index only base_data because that's the only property use for filtering (see in the mapping `index: 'no'`. 

I am considering adding the metric family (not indexed) in ES but I'm not sure about that yet.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
