### PR TITLE
Tip 706 harmonize normalizers

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -45,17 +45,17 @@ services:
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.number:
+    pim_catalog.normalizer.indexing.product.number:
         class: '%pim_catalog.normalizer.indexing.product.number.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.options:
+    pim_catalog.normalizer.indexing.product.options:
         class: '%pim_catalog.normalizer.indexing.product.options.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.dummy:
+    pim_catalog.normalizer.indexing.product.dummy:
         class: '%pim_catalog.normalizer.indexing.product.dummy.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 80 }
@@ -65,34 +65,34 @@ services:
         tags:
             - { name: pim_serializer.normalizer, priority: 100 }
 
-    pim_catalog.normalizer.indexing.text:
+    pim_catalog.normalizer.indexing.product.text:
         class: '%pim_catalog.normalizer.indexing.product.text.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.text_area:
+    pim_catalog.normalizer.indexing.product.text_area:
         class: '%pim_catalog.normalizer.indexing.product.text_area.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.option:
+    pim_catalog.normalizer.indexing.product.option:
         class: '%pim_catalog.normalizer.indexing.product.option.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.price_collection:
+    pim_catalog.normalizer.indexing.product.price_collection:
         class: '%pim_catalog.normalizer.indexing.product.price_collection.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_value'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.metric:
+    pim_catalog.normalizer.indexing.product.metric:
         class: '%pim_catalog.normalizer.indexing.product.metric.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_catalog.normalizer.indexing.media:
+    pim_catalog.normalizer.indexing.product.media:
         class: '%pim_catalog.normalizer.indexing.product.media.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/AbstractPimCatalogIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/AbstractPimCatalogIntegration.php
@@ -20,12 +20,6 @@ abstract class AbstractPimCatalogIntegration extends TestCase
 {
     const DOCUMENT_TYPE = 'pim_catalog_product';
 
-    /** @var Client */
-    private $esClient;
-
-    /** @var Loader */
-    private $esConfigurationLoader;
-
     /**
      * {@inheritdoc}
      */
@@ -44,22 +38,7 @@ abstract class AbstractPimCatalogIntegration extends TestCase
         $this->esClient = $this->get('akeneo_elasticsearch.client');
         $this->esConfigurationLoader = $this->get('akeneo_elasticsearch.index_configuration.loader');
 
-        $this->resetIndex();
         $this->addProducts();
-    }
-
-    /**
-     * Resets the index used for the integration tests query
-     */
-    private function resetIndex()
-    {
-        $conf = $this->esConfigurationLoader->load();
-
-        if ($this->esClient->hasIndex()) {
-            $this->esClient->deleteIndex();
-        }
-
-        $this->esClient->createIndex($conf->buildAggregated());
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ElasticSearch/IndexConfiguration/PimCatalogOptionsIntegration.php
@@ -161,8 +161,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_1',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['black'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['black']
                         ],
                     ],
                 ],
@@ -171,8 +171,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_2',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['yellow', 'blue'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['yellow', 'blue'],
                         ],
                     ],
                 ],
@@ -181,8 +181,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_3',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['black'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['black'],
                         ],
                     ],
                 ],
@@ -191,8 +191,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_4',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['blue', 'yellow'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['blue', 'yellow'],
                         ],
                     ],
                 ],
@@ -201,8 +201,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_5',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['blue', 'black'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['blue', 'black'],
                         ],
                     ],
                 ],
@@ -211,8 +211,8 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
                 'identifier' => 'product_6',
                 'values'     => [
                     'colors-options' => [
-                        '<all_locales>' => [
-                            '<all_channels>' => ['yellow'],
+                        '<all_channels>' => [
+                            '<all_locales>' => ['yellow'],
                         ],
                     ],
                 ],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB;
 
-use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
@@ -15,12 +13,6 @@ use Akeneo\Test\Integration\TestCase;
  */
 abstract class AbstractProductQueryBuilderTestCase extends TestCase
 {
-    /** @var Client */
-    private $esClient;
-
-    /** @var Loader */
-    private $esConfigurationLoader;
-
     /**
      * {@inheritdoc}
      */
@@ -30,17 +22,6 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
             [Configuration::getTechnicalCatalogPath()],
             false
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->esClient = $this->get('akeneo_elasticsearch.client');
-        $this->esConfigurationLoader = $this->get('akeneo_elasticsearch.index_configuration.loader');
     }
 
     /**
@@ -141,19 +122,5 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         }
 
         $this->assertSame($products, $expected);
-    }
-
-    /**
-     * Resets the index used for the integration tests
-     */
-    protected function resetIndex()
-    {
-        $conf = $this->esConfigurationLoader->load();
-
-        if ($this->esClient->hasIndex()) {
-            $this->esClient->deleteIndex();
-        }
-
-        $this->esClient->createIndex($conf->buildAggregated());
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
@@ -20,8 +20,6 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('foo', ['categories' => ['categoryA1', 'categoryB']]);
             $this->createProduct('bar', []);
             $this->createProduct('baz', []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -35,8 +35,6 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $family = $this->get('pim_catalog.factory.family')->create();
             $this->get('pim_catalog.updater.family')->update($family, [
                 'code'                   => 'familyB',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
@@ -20,8 +20,6 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_date' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_date',
                 'type'                => AttributeTypes::DATE,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_date',
                 'type'                => AttributeTypes::DATE,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_date',
                 'type'                => AttributeTypes::DATE,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
@@ -25,8 +25,6 @@ class DateTimeFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             static::$createdDates['before_first'] = new \DateTime('now', new \DateTimeZone('UTC'));
             sleep(2);
             $this->createProduct('foo', []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
@@ -20,8 +20,6 @@ class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $family = $this->get('pim_catalog.factory.family')->create();
             $this->get('pim_catalog.updater.family')->update($family, ['code' => 'familyB']);
             $this->get('pim_catalog.saver.family')->save($family);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
@@ -20,8 +20,6 @@ class GroupsFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $group = $this->get('pim_catalog.factory.group')->create();
             $this->get('pim_catalog.updater.group')->update($group, [
                 'code' => 'groupC',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/IdentifierFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/IdentifierFilterIntegration.php
@@ -20,8 +20,6 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('foo', []);
             $this->createProduct('bar', []);
             $this->createProduct('baz', []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_media',
                 'type'                => AttributeTypes::IMAGE,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
@@ -20,8 +20,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_localizable_scopable_image' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
@@ -20,8 +20,6 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('akeneo', [
                 'values' => [
                     'an_image' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_media',
                 'type'                => AttributeTypes::IMAGE,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_localizable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -20,8 +20,6 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_metric' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_metric',
                 'type'                => AttributeTypes::METRIC,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
@@ -20,8 +20,6 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_number_float_negative' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_simple_select',
                 'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_simple_select',
                 'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
@@ -20,8 +20,6 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttributeOption([
                'attribute' => 'a_simple_select',
                'code'      => 'orange'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_select_scopable_simple_select',
                 'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_multi_select',
                 'type'                => AttributeTypes::OPTION_MULTI_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_multi_select',
                 'type'                => AttributeTypes::OPTION_MULTI_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
@@ -20,8 +20,6 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttributeOption([
                'attribute' => 'a_multi_select',
                'code'      => 'orange'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_multi_select',
                 'type'                => AttributeTypes::OPTION_MULTI_SELECT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code' => 'a_localizable_price',
                 'type' => AttributeTypes::PRICE_COLLECTION,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'             => 'a_scopable_localizable_price',
                 'type'             => AttributeTypes::PRICE_COLLECTION,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
@@ -20,8 +20,6 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_price' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
@@ -20,8 +20,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('product_one', [
                 'values' => [
                     'a_scopable_price' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/StatusFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/StatusFilterIntegration.php
@@ -20,8 +20,6 @@ class StatusFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('foo', ['enabled' => true]);
             $this->createProduct('bar', ['enabled' => false]);
         }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_text',
                 'type'                => AttributeTypes::TEXT,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Text/TextFilterIntegration.php
@@ -20,8 +20,6 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('cat', [
                 'values' => [
                     'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/LocalizableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_text_area',
                 'type'                => AttributeTypes::TEXTAREA,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/LocalizableScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_localizable_scopable_text_area',
                 'type'                => AttributeTypes::TEXTAREA,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
@@ -21,8 +21,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createAttribute([
                 'code'                => 'a_scopable_text_area',
                 'type'                => AttributeTypes::TEXTAREA,

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/TextAreaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/TextAreaFilterIntegration.php
@@ -24,8 +24,6 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('cat', [
                 'values' => [
                     'a_text_area' => [['data' => 'cat', 'locale' => null, 'scope' => null]]

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 
@@ -14,7 +13,7 @@ use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductQueryBuilderIntegration extends TestCase
+class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * Combines several filters and operator to find the product
@@ -106,81 +105,81 @@ class ProductQueryBuilderIntegration extends TestCase
     {
         parent::setUp();
 
-        $product = $this->get('pim_catalog.builder.product')->createProduct('complex_product_1', 'familyA');
-        $this->get('pim_catalog.updater.product')->update(
-            $product,
-            [
-                'values' => [
-                    'a_file' => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => $this->getFixturePath('akeneo.txt'),
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct(
+                'complex_product_1',
+                [
+                    'family' => 'familyA',
+                    'values' => [
+                        'a_file' => [
+                            [
+                                'locale' => null,
+                                'scope'  => null,
+                                'data'   => $this->getFixturePath('akeneo.txt'),
+                            ],
                         ],
-                    ],
 
-                    'a_localizable_image'                => [
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => null,
-                            'data'   => $this->getFixturePath('akeneo.jpg'),
+                        'a_localizable_image'                => [
+                            [
+                                'locale' => 'en_US',
+                                'scope'  => null,
+                                'data'   => $this->getFixturePath('akeneo.jpg'),
+                            ],
+                            [
+                                'locale' => 'fr_FR',
+                                'scope'  => null,
+                                'data'   => $this->getFixturePath('akeneo.jpg'),
+                            ],
                         ],
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => null,
-                            'data'   => $this->getFixturePath('akeneo.jpg'),
+                        'a_regexp'                           => [
+                            [
+                                'locale' => null,
+                                'scope'  => null,
+                                'data'   => '\w+ .*',
+                            ],
                         ],
-                    ],
-                    'a_regexp'                           => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => '\w+ .*',
-                        ],
-                    ],
-                    'a_scopable_price'                   => [
-                        [
-                            'locale' => null,
-                            'scope'  => 'ecommerce',
-                            'data'   => [
-                                [
-                                    'amount'   => 12,
-                                    'currency' => 'EUR',
-                                ],
-                                [
-                                    'amount'   => 14,
-                                    'currency' => 'USD',
+                        'a_scopable_price'                   => [
+                            [
+                                'locale' => null,
+                                'scope'  => 'ecommerce',
+                                'data'   => [
+                                    [
+                                        'amount'   => 12,
+                                        'currency' => 'EUR',
+                                    ],
+                                    [
+                                        'amount'   => 14,
+                                        'currency' => 'USD',
+                                    ],
                                 ],
                             ],
                         ],
+                        'a_localized_and_scopable_text_area' => [
+                            [
+                                'locale' => 'fr_FR',
+                                'scope'  => 'ecommerce',
+                                'data'   => 'Mon textarea localisé et scopable ecommerce',
+                            ],
+                            [
+                                'locale' => 'en_US',
+                                'scope'  => 'ecommerce',
+                                'data'   => null,
+                            ],
+                            [
+                                'locale' => 'fr_FR',
+                                'scope'  => 'tablet',
+                                'data'   => 'Mon textarea localisé et scopable tablet',
+                            ],
+                            [
+                                'locale' => 'en_US',
+                                'scope'  => 'tablet',
+                                'data'   => 'My localizable and scopable textearea tablet',
+                            ],
+                        ],
                     ],
-                    'a_localized_and_scopable_text_area' => [
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => 'ecommerce',
-                            'data'   => 'Mon textarea localisé et scopable ecommerce',
-                        ],
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => 'ecommerce',
-                            'data'   => null,
-                        ],
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => 'tablet',
-                            'data'   => 'Mon textarea localisé et scopable tablet',
-                        ],
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => 'tablet',
-                            'data'   => 'My localizable and scopable textearea tablet',
-                        ],
-                    ],
-                ],
-            ]
-        );
-
-        $this->get('pim_catalog.saver.product')->save($product);
+                ]
+            );
+        }
     }
 
     /**
@@ -189,7 +188,7 @@ class ProductQueryBuilderIntegration extends TestCase
     protected function createPQBWithoutFamilyFilter()
     {
         $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
-        $pqb->addFilter('a_file', Operators::ENDS_WITH, '.txt');
+        $pqb->addFilter('a_file', Operators::STARTS_WITH, 'aken');
         $pqb->addFilter('a_localizable_image', Operators::CONTAINS, 'akeneo', ['locale' => 'en_US']);
         $pqb->addFilter('a_regexp', Operators::CONTAINS, '+', ['locale' => 'en_US']);
         $pqb->addFilter(
@@ -215,7 +214,7 @@ class ProductQueryBuilderIntegration extends TestCase
     {
         $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
         $pqb->addFilter('family', Operators::IN_LIST, ['familyA']);
-        $pqb->addFilter('a_file', Operators::ENDS_WITH, '.txt');
+        $pqb->addFilter('a_file', Operators::STARTS_WITH, 'aken');
         $pqb->addFilter('a_localizable_image', Operators::CONTAINS, 'akeneo', ['locale' => 'en_US']);
         $pqb->addFilter('a_regexp', Operators::CONTAINS, '+', ['locale' => 'en_US']);
         $pqb->addFilter(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/BaseSorterDateTimeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/BaseSorterDateTimeIntegration.php
@@ -20,8 +20,6 @@ class BaseSorterDateTimeIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct('foo', []);
             sleep(2);
             $this->createProduct('bar', []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/BaseSorterDateTimeIntegrationWithDifferentTimezone.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/BaseSorterDateTimeIntegrationWithDifferentTimezone.php
@@ -22,8 +22,6 @@ class BaseSorterDateTimeIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             static::$timezone = ini_get('date.timezone');
 
             ini_set('date.timezone', 'UTC');

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
@@ -21,8 +21,6 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct(
                 'product_one',
                 [

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -21,8 +21,6 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->resetIndex();
-
             $this->createProduct(
                 'product_one',
                 [

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/MetricNormalizer.php
@@ -2,9 +2,7 @@
 
 namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
 
-use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ProductValueInterface;
-use Pim\Component\Catalog\ProductValue\MetricProductValue;
 use Pim\Component\Catalog\ProductValue\MetricProductValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -32,15 +30,15 @@ class MetricNormalizer extends AbstractProductValueNormalizer implements Normali
     {
         $productMetric = $productValue->getData();
 
-        if (null === $productMetric) {
-            return [];
+        if (null !== $productMetric) {
+            return [
+                'data'      => (string)$productMetric->getData(),
+                'base_data' => (string)$productMetric->getBaseData(),
+                'unit'      => $productMetric->getUnit(),
+                'base_unit' => $productMetric->getBaseUnit(),
+            ];
         }
 
-        return [
-            'data'      => (string) $productMetric->getData(),
-            'base_data' => (string) $productMetric->getBaseData(),
-            'unit'      => $productMetric->getUnit(),
-            'base_unit' => $productMetric->getBaseUnit()
-        ];
+        return null;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/NumberNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/NumberNormalizer.php
@@ -17,8 +17,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class NumberNormalizer extends AbstractProductValueNormalizer implements NormalizerInterface
 {
-    const DECIMAL_PRECISION = 4;
-
     /**
      * {@inheritdoc}
      */
@@ -34,6 +32,12 @@ class NumberNormalizer extends AbstractProductValueNormalizer implements Normali
      */
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
-        return (string) $productValue->getData();
+        $number = $productValue->getData();
+
+        if (null !== $number) {
+            return (string) $number;
+        }
+
+        return null;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/OptionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/OptionNormalizer.php
@@ -32,6 +32,7 @@ class OptionNormalizer extends AbstractProductValueNormalizer implements Normali
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
         $data = $productValue->getData();
+
         if ($data instanceof AttributeOptionInterface) {
             return $data->getCode();
         }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PriceCollectionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PriceCollectionNormalizer.php
@@ -32,8 +32,13 @@ class PriceCollectionNormalizer extends AbstractProductValueNormalizer implement
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
         $currencyIndexedPrices = [];
+        $prices = $productValue->getData();
 
-        foreach ($productValue->getData() as $price) {
+        if (null === $prices) {
+            return null;
+        }
+
+        foreach ($prices as $price) {
             $currency = $price->getCurrency();
             if (null !== $currency && '' !== $currency) {
                 $currencyIndexedPrices[$currency] = (string) $price->getData();

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextAreaNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextAreaNormalizer.php
@@ -30,7 +30,13 @@ class TextAreaNormalizer extends AbstractProductValueNormalizer implements Norma
      */
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
-        $cleanedData = str_replace(["\r", "\n"], "", $productValue->getData());
+        $textAreaValue = $productValue->getData();
+
+        if (null === $textAreaValue) {
+            return null;
+        }
+
+        $cleanedData = str_replace(["\r", "\n"], "", $textAreaValue);
         $cleanedData = strip_tags(html_entity_decode($cleanedData));
 
         return $cleanedData;

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
@@ -30,12 +30,6 @@ class TextNormalizer extends AbstractProductValueNormalizer implements Normalize
      */
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
-        $textValue = $productValue->getData();
-
-        if (null !== $textValue) {
-            return $textValue;
-        }
-
-        return null;
+        return $productValue->getData();
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/TextNormalizer.php
@@ -30,6 +30,12 @@ class TextNormalizer extends AbstractProductValueNormalizer implements Normalize
      */
     protected function getNormalizedData(ProductValueInterface $productValue)
     {
-        return $productValue->getData();
+        $textValue = $productValue->getData();
+
+        if (null !== $textValue) {
+            return $textValue;
+        }
+
+        return null;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/MetricNormalizerSpec.php
@@ -56,7 +56,7 @@ class MetricNormalizerSpec extends ObjectBehavior
         $this->normalize($metricValue, 'indexing')->shouldReturn([
             'weight-metric' => [
                 '<all_channels>' => [
-                    '<all_locales>' => [],
+                    '<all_locales>' => null,
                 ],
             ],
         ]);

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/NumberNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/NumberNormalizerSpec.php
@@ -40,6 +40,28 @@ class NumberNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($numberValue, 'indexing')->shouldReturn(true);
     }
 
+    function it_normamlizes_an_empty_number_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $integerValue,
+        AttributeInterface $integerAttribute
+    ) {
+        $integerValue->getAttribute()->willReturn($integerAttribute);
+        $integerValue->getLocale()->willReturn(null);
+        $integerValue->getScope()->willReturn(null);
+        $integerValue->getData()->willReturn(null);
+
+        $integerAttribute->isDecimalsAllowed()->willReturn(false);
+        $integerAttribute->getCode()->willReturn('box_quantity');
+        $integerAttribute->getBackendType()->willReturn('decimal');
+
+        $this->normalize($integerValue, 'indexing')->shouldReturn([
+            'box_quantity-decimal' => [
+                '<all_channels>' => [
+                    '<all_locales>' => null
+                ]
+            ]
+        ]);
+    }
+
     function it_normalize_an_integer_product_value_with_no_locale_and_no_channel(
         ProductValueInterface $integerValue,
         AttributeInterface $integerAttribute

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PriceCollectionNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PriceCollectionNormalizerSpec.php
@@ -42,6 +42,28 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($priceCollectionValue, 'indexing')->shouldReturn(true);
     }
 
+    function it_normalize_an_empty_price_collection_product_value_with_no_locale_and_no_channel(
+        PriceCollectionProductValue $priceCollection,
+        AttributeInterface $priceCollectionAttribute
+    ) {
+
+        $priceCollection->getAttribute()->willReturn($priceCollectionAttribute);
+        $priceCollection->getLocale()->willReturn(null);
+        $priceCollection->getScope()->willReturn(null);
+        $priceCollection->getData()->willReturn(null);
+
+        $priceCollectionAttribute->getCode()->willReturn('a_price');
+        $priceCollectionAttribute->getBackendType()->willReturn('prices');
+
+        $this->normalize($priceCollection, 'indexing')->shouldReturn([
+            'a_price-prices' => [
+                '<all_channels>' => [
+                    '<all_locales>' => null
+                ],
+            ],
+        ]);
+    }
+
     function it_normalize_a_price_collection_product_value_with_no_locale_and_no_channel(
         PriceCollectionProductValue $priceCollection,
         ProductPrice $priceEUR,

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextAreaNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextAreaNormalizerSpec.php
@@ -62,6 +62,27 @@ class TextAreaNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_normalizes_an_empty_simple_text_area(
+        ProductValueInterface $textAreaValue,
+        AttributeInterface $textAreaAttribute
+    ) {
+        $textAreaValue->getAttribute()->willReturn($textAreaAttribute);
+        $textAreaValue->getLocale()->willReturn(null);
+        $textAreaValue->getScope()->willReturn(null);
+        $textAreaValue->getData()->willReturn(null);
+
+        $textAreaAttribute->getCode()->willReturn('name');
+        $textAreaAttribute->getBackendType()->willReturn('text');
+
+        $this->normalize($textAreaValue, 'indexing')->shouldReturn([
+            'name-text' => [
+                '<all_channels>' => [
+                    '<all_locales>' => null
+                ]
+            ]
+        ]);
+    }
+
     function it_normalizes_a_text_area_with_new_lines(
         ProductValueInterface $textAreaValue,
         AttributeInterface $textAreaAttribute

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/TextNormalizerSpec.php
@@ -2,11 +2,10 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
 
+use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\TextNormalizer;
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class TextNormalizerSpec extends ObjectBehavior
@@ -56,9 +55,9 @@ class TextNormalizerSpec extends ObjectBehavior
         $this->normalize($textValue, 'indexing')->shouldReturn([
             'name-varchar' => [
                 '<all_channels>' => [
-                    '<all_locales>' => 'a product name'
-                ]
-            ]
+                    '<all_locales>' => 'a product name',
+                ],
+            ],
         ]);
     }
 
@@ -77,9 +76,30 @@ class TextNormalizerSpec extends ObjectBehavior
         $this->normalize($textValue, 'indexing')->shouldReturn([
             'name-varchar' => [
                 '<all_channels>' => [
-                    '<all_locales>' => '<h1>My <strong>ProDucT</strong> is awesome</h1>'
-                ]
-            ]
+                    '<all_locales>' => '<h1>My <strong>ProDucT</strong> is awesome</h1>',
+                ],
+            ],
+        ]);
+    }
+
+    function it_normalizes_an_empty_text_with_no_locale_and_channel(
+        ProductValueInterface $textValue,
+        AttributeInterface $textAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textValue->getLocale()->willReturn(null);
+        $textValue->getScope()->willReturn(null);
+        $textValue->getData()->willReturn(null);
+
+        $textAttribute->getCode()->willReturn('name');
+        $textAttribute->getBackendType()->willReturn('varchar');
+
+        $this->normalize($textValue, 'indexing')->shouldReturn([
+            'name-varchar' => [
+                '<all_channels>' => [
+                    '<all_locales>' => null,
+                ],
+            ],
         ]);
     }
 
@@ -98,9 +118,9 @@ class TextNormalizerSpec extends ObjectBehavior
         $this->normalize($textValue, 'indexing')->shouldReturn([
             'name-varchar' => [
                 '<all_channels>' => [
-                    'fr_FR' => 'a product name'
-                ]
-            ]
+                    'fr_FR' => 'a product name',
+                ],
+            ],
         ]);
     }
 
@@ -119,9 +139,9 @@ class TextNormalizerSpec extends ObjectBehavior
         $this->normalize($textValue, 'indexing')->shouldReturn([
             'name-varchar' => [
                 'ecommerce' => [
-                    '<all_locales>' => 'a product name'
-                ]
-            ]
+                    '<all_locales>' => 'a product name',
+                ],
+            ],
         ]);
     }
 
@@ -140,9 +160,9 @@ class TextNormalizerSpec extends ObjectBehavior
         $this->normalize($textValue, 'indexing')->shouldReturn([
             'name-varchar' => [
                 'ecommerce' => [
-                    'fr_FR' => 'a product name'
-                ]
-            ]
+                    'fr_FR' => 'a product name',
+                ],
+            ],
         ]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Test\Integration;
 
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -13,6 +15,12 @@ abstract class TestCase extends KernelTestCase
 {
     /** @var int Count of executed tests inside the same test class */
     protected static $count = 0;
+
+    /** @var Client */
+    protected $esClient;
+
+    /** @var Loader */
+    protected $esConfigurationLoader;
 
     /**
      * {@inheritdoc}
@@ -36,13 +44,19 @@ abstract class TestCase extends KernelTestCase
 
         $configuration = $this->getConfiguration();
 
+        $this->esClient = $this->get('akeneo_elasticsearch.client');
+        $this->esConfigurationLoader = $this->get('akeneo_elasticsearch.index_configuration.loader');
+
         self::$count++;
 
         if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
+            $this->resetIndex();
+
             $this->getDatabaseSchemaHandler()->reset();
 
             $fixturesLoader = $this->getFixturesLoader($configuration);
             $fixturesLoader->load();
+
         }
     }
 
@@ -124,5 +138,19 @@ abstract class TestCase extends KernelTestCase
         }
 
         throw new \Exception(sprintf('The fixture "%s" does not exist.', $name));
+    }
+
+    /**
+     * Resets the index used for the integration tests
+     */
+    private function resetIndex()
+    {
+        $conf = $this->esConfigurationLoader->load();
+
+        if ($this->esClient->hasIndex()) {
+            $this->esClient->deleteIndex();
+        }
+
+        $this->esClient->createIndex($conf->buildAggregated());
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- [x] Fixes how normalizers normalizes empty product value (returns null)
- [x] Fixes the resetIndex of the integration tests (moved from `AbstractPimCatalogIntegration` to the `AkeneoTestCase`

- [X] Fixes ProductQueryBuilderIntegration::testComplexQueryX series

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      |
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
