### PR TITLE
TIP-706: Add PQB Elasticsearch filter on boolean product values

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -17,6 +17,7 @@
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
         <ini name="zend.enable_gc" value="1"/>
+        <ini name="serialize_precision" value="14"/>
     </php>
 
     <testsuites>

--- a/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
@@ -2,20 +2,17 @@
 
 namespace Akeneo\Bundle\ElasticsearchBundle\tests\integration;
 
-use Akeneo\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Elasticsearch\Client;
 
+/**
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class BulkIndexationIntegration extends TestCase
 {
     const DOCUMENT_TYPE = 'pim_catalog_product';
-
-    /** @var Client */
-    private $esClient;
-
-    /** @var Loader */
-    private $esConfigurationLoader;
 
     public function testIndexationOnABulk()
     {
@@ -30,7 +27,7 @@ class BulkIndexationIntegration extends TestCase
         $this->assertCount($count, $indexedProducts['items']);
 
         foreach ($indexedProducts['items'] as $index => $indexedProduct) {
-            $this->assertSame('product_' . $index+=1, $indexedProduct['index']['_id']);
+            $this->assertSame('product_' . ($index + 1), $indexedProduct['index']['_id']);
 
             $result = 'product_1' === $indexedProduct['index']['_id'] ? 'updated' : 'created';
             $version = 'product_1' === $indexedProduct['index']['_id'] ? 2 : 1;
@@ -54,11 +51,6 @@ class BulkIndexationIntegration extends TestCase
     {
         parent::setUp();
 
-        $this->esClient = $this->get('akeneo_elasticsearch.client');
-        $this->esConfigurationLoader = $this->get('akeneo_elasticsearch.index_configuration.loader');
-
-        $this->resetIndex();
-
         $products = [
             [
                 'identifier'       => 'product_1',
@@ -81,19 +73,5 @@ class BulkIndexationIntegration extends TestCase
         }
 
         $this->esClient->refreshIndex();
-    }
-
-    /**
-     * Resets the index used for the integration tests query
-     */
-    private function resetIndex()
-    {
-        $conf = $this->esConfigurationLoader->load();
-
-        if ($this->esClient->hasIndex()) {
-            $this->esClient->deleteIndex();
-        }
-
-        $this->esClient->createIndex($conf->buildAggregated());
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/BooleanFilter.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+/**
+ * Boolean filter for an Elasticsearch query.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param string[]                 $supportedAttributeTypes
+     * @param string[]                 $supportedOperators
+     */
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+        $this->checkValue($attribute, $value);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::EQUALS:
+                $clause = [
+                    'term' => [
+                        $attributePath => $value
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+
+            case Operators::NOT_EQUAL:
+                $mustNotClause = [
+                    'term' => [
+                        $attributePath => $value,
+                    ],
+                ];
+                $filterClause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if the value is valid
+     *
+     * @param AttributeInterface $attribute
+     * @param mixed              $value
+     */
+    protected function checkValue(AttributeInterface $attribute, $value)
+    {
+        if (!is_bool($value)) {
+            throw InvalidPropertyTypeException::booleanExpected($attribute->getCode(), static::class, $value);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -10,6 +10,8 @@ use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
 /**
+ * Media filter for an Elasticsearch query.
+ *
  * @author    Damien Carcel (damien.carcel@akeneo.com)
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -358,8 +358,8 @@ Data model
     [
         'values' => [
             'name-varchar' => [
-                'fr_FR' => [
-                    'mobile' => 'My product name'
+                'mobile' => [
+                    'fr_FR' => 'My product name'
                 ]
             ]
         ]
@@ -529,8 +529,8 @@ Data model
     [
         'values' => [
             'an_image-media' => [
-                'fr_FR' => [
-                    'mobile' => [
+                'mobile' => [
+                    'fr_FR' => [
                         'extension'         => 'jpg',
                         'hash'              => 'the_hash',
                         'key'               => 'the/relative/path/to_akeneo.png',
@@ -550,6 +550,7 @@ Operators
 .........
 STARTS WITH
 """""""""""
+:Type: filter
 :Specific field: original_filename
 
 .. code-block:: php
@@ -563,6 +564,7 @@ STARTS WITH
 
 CONTAINS
 """"""""
+:Type: filter
 :Specific field: original_filename
 
 .. code-block:: php
@@ -576,6 +578,7 @@ CONTAINS
 
 DOES NOT CONTAIN
 """"""""""""""""
+:Type: must_not
 :Specific field: original_filename
 
 Same syntax than the ``contains`` but must be included in a ``must_not`` boolean occured type instead of ``filter``.
@@ -596,7 +599,7 @@ Same syntax than the ``contains`` but must be included in a ``must_not`` boolean
 
 Equals (=)
 """"""""""
-:Type: Filter
+:Type: filter
 :Specific field: original_filename
 
 .. code-block:: php
@@ -609,7 +612,7 @@ Equals (=)
 
 Not Equals (!=)
 """""""""""""""
-:Type: Filter
+:Type: must_not
 :Specific field: original_filename
 
 .. code-block:: php
@@ -627,6 +630,7 @@ Not Equals (!=)
 
 EMPTY
 """""
+:Type: filter
 
 .. code-block:: php
 
@@ -638,6 +642,7 @@ EMPTY
 
 NOT EMPTY
 """""""""
+:Type: filter
 
 .. code-block:: php
 
@@ -1275,26 +1280,54 @@ All operators are identical to the one used on numbers.
 
 Boolean
 *******
-:Apply: pim_catalog_boolean attributes and 'enabled' field
+:Apply: pim_catalog_boolean attributes
 
 Data model
 ~~~~~~~~~~
-.. code-block:: yaml
+.. code-block:: php
 
-    enabled_bool: true
+    [
+        'values' => [
+            'a_yes_no-boolean' => [
+                'mobile' => [
+                    'fr_FR' => true
+                ]
+            ]
+        ]
+    ]
 
 Filtering
 ~~~~~~~~~
 Operators
 .........
 Equals (=)
-~~~~~~~~~~
+""""""""""
 :Type: filter
 
-.. code-block:: yaml
+.. code-block:: php
 
-    term:
-        enabled_bool: true
+    'filter' => [
+        'term' => [
+            'values.description-text.<all_channels>.<all_locales>' => true
+        ]
+    ]
+
+Not Equals (!=)
+"""""""""""""""
+:Type: must_not
+
+.. code-block:: php
+
+    'must_not' => [
+        'term' => [
+            'values.description-text.<all_channels>.<all_locales>' => true
+        ]
+    ],
+    'filter' => [
+        'exists' => [
+            'field' => 'values.description-text.<all_channels>.<all_locales>'
+        ]
+    ]
 
 Completeness
 ************

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -29,6 +29,7 @@ parameters:
     pim_catalog.query.elasticsearch.filter.price.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\PriceFilter
     pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
+    pim_catalog.query.elasticsearch.filter.boolean.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter
     pim_catalog.query.elasticsearch.sorter.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter
 
 services:
@@ -137,6 +138,15 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.status.class%'
         arguments:
             - ['enabled']
+            - ['=', '!=']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.boolean:
+        class: '%pim_catalog.query.elasticsearch.filter.boolean.class%'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_boolean']
             - ['=', '!=']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -14,6 +14,7 @@ parameters:
     pim_catalog.normalizer.indexing.product.price_collection.class: Pim\Component\Catalog\Normalizer\Indexing\Product\PriceCollectionNormalizer
     pim_catalog.normalizer.indexing.product.metric.class: Pim\Component\Catalog\Normalizer\Indexing\Product\MetricNormalizer
     pim_catalog.normalizer.indexing.product.media.class: Pim\Component\Catalog\Normalizer\Indexing\Product\MediaNormalizer
+    pim_catalog.normalizer.indexing.product.boolean.class: Pim\Component\Catalog\Normalizer\Indexing\Product\BooleanNormalizer
 
 services:
     pim_catalog.normalizer.indexing.product:
@@ -94,5 +95,10 @@ services:
 
     pim_catalog.normalizer.indexing.product.media:
         class: '%pim_catalog.normalizer.indexing.product.media.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.indexing.product.boolean:
+        class: '%pim_catalog.normalizer.indexing.product.boolean.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -140,6 +140,13 @@ mappings:
                     match_mapping_type: 'string'
                     mapping:
                         index: 'no'
+            -
+                boolean:
+                    path_match: 'values.*-boolean.*'
+                    match_mapping_type: 'boolean'
+                    mapping:
+                        type: 'boolean'
+
 settings:
     analysis:
         normalizer:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/BooleanFilterSpec.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+
+class BooleanFilterSpec extends ObjectBehavior
+{
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    {
+        $this->beConstructedWith(
+            $attributeValidatorHelper,
+            ['pim_catalog_boolean'],
+            ['=', '!=']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(BooleanFilter::class);
+    }
+
+    function it_is_an_attribute_filter()
+    {
+        $this->shouldImplement(AttributeFilterInterface::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn([
+            '=',
+            '!=',
+        ]);
+        $this->supportsOperator('=')->shouldReturn(true);
+        $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_equals(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($booleanAttribute, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addFilter([
+                'term' => [
+                    'values.boolean-boolean.ecommerce.en_US' => true,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($booleanAttribute, Operators::EQUALS, true, 'en_US', 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_not_equal(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($booleanAttribute, 'ecommerce')->shouldBeCalled();
+
+        $sqb->addMustNot([
+                'term' => [
+                    'values.boolean-boolean.ecommerce.en_US' => false,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addFilter([
+                'exists' => ['field' => 'values.boolean-boolean.ecommerce.en_US'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($booleanAttribute, Operators::NOT_EQUAL, false, 'en_US', 'ecommerce', []);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(
+        AttributeInterface $booleanAttribute
+    ) {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during('addAttributeFilter', [$booleanAttribute, Operators::EQUALS, false, 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_a_boolean(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($booleanAttribute, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::booleanExpected(
+                'boolean',
+                BooleanFilter::class,
+                123
+            )
+        )->during('addAttributeFilter', [$booleanAttribute, Operators::EQUALS, 123, 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->shouldBeCalled();
+        $attributeValidatorHelper->validateScope($booleanAttribute, 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                BooleanFilter::class
+            )
+        )->during('addAttributeFilter', [
+            $booleanAttribute,
+            Operators::IN_CHILDREN_LIST,
+            true,
+            'en_US',
+            'ecommerce', []
+        ]);
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_locale_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+        $booleanAttribute->isLocaleSpecific()->willReturn(true);
+        $booleanAttribute->getAvailableLocaleCodes('fr_FR');
+
+        $e = new \LogicException('Attribute "name" expects a locale, none given.');
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'boolean',
+                BooleanFilter::class,
+                $e
+            )
+        )->during('addAttributeFilter', [$booleanAttribute, Operators::CONTAINS, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+
+    function it_throws_an_exception_when_an_exception_is_thrown_by_the_attribute_validator_on_scope_validation(
+        $attributeValidatorHelper,
+        AttributeInterface $booleanAttribute,
+        SearchQueryBuilder $sqb
+    ) {
+        $booleanAttribute->getCode()->willReturn('boolean');
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+        $booleanAttribute->isScopable()->willReturn(false);
+
+        $e = new \LogicException('Attribute "name" does not expect a scope, "ecommerce" given.');
+        $attributeValidatorHelper->validateLocale($booleanAttribute, 'en_US')->willThrow($e);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::expectedFromPreviousException(
+                'boolean',
+                BooleanFilter::class,
+                $e
+            )
+        )->during('addAttributeFilter', [$booleanAttribute, Operators::CONTAINS, 'Sony', 'en_US', 'ecommerce', []]);
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/BooleanNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/BooleanNormalizer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BooleanNormalizer extends AbstractProductValueNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ProductValueInterface &&
+            AttributeTypes::BACKEND_TYPE_BOOLEAN === $data->getAttribute()->getBackendType() &&
+            'indexing' === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNormalizedData(ProductValueInterface $productValue)
+    {
+        return $productValue->getData();
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/BooleanNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/BooleanNormalizerSpec.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\Product\BooleanNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class BooleanNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(BooleanNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_support_boolean_product_value(
+        ProductValueInterface $textValue,
+        ProductValueInterface $booleanValue,
+        AttributeInterface $textAttribute,
+        AttributeInterface $booleanAttribute
+    ) {
+        $textValue->getAttribute()->willReturn($textAttribute);
+        $textAttribute->getBackendType()->willReturn('text');
+
+        $booleanValue->getAttribute()->willReturn($booleanAttribute);
+        $booleanAttribute->getBackendType()->willReturn('boolean');
+
+        $this->supportsNormalization(new \stdClass(), 'indexing')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+
+        $this->supportsNormalization($booleanValue, 'indexing')->shouldReturn(true);
+        $this->supportsNormalization($textValue, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($textValue, 'indexing')->shouldReturn(false);
+    }
+
+    function it_normalizes_a_boolean_product_value_with_no_locale_and_no_channel(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn(null);
+        $mediaValue->getScope()->willReturn(null);
+        $mediaValue->getData()->willReturn(true);
+
+        $mediaAttribute->getCode()->willReturn('a_yes_no');
+        $mediaAttribute->getBackendType()->willReturn('boolean');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'a_yes_no-boolean' => [
+                '<all_channels>' => [
+                    '<all_locales>' => true
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_boolean_product_value_with_locale_and_no_scope(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn('fr_FR');
+        $mediaValue->getScope()->willReturn(null);
+        $mediaValue->getData()->willReturn(true);
+
+        $mediaAttribute->getCode()->willReturn('a_yes_no');
+        $mediaAttribute->getBackendType()->willReturn('boolean');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'a_yes_no-boolean' => [
+                '<all_channels>' => [
+                    'fr_FR' => true
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_boolean_product_value_with_scope_and_no_locale(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn(null);
+        $mediaValue->getScope()->willReturn('ecommerce');
+        $mediaValue->getData()->willReturn(true);
+
+        $mediaAttribute->getCode()->willReturn('a_yes_no');
+        $mediaAttribute->getBackendType()->willReturn('boolean');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'a_yes_no-boolean' => [
+                'ecommerce' => [
+                    '<all_locales>' => true
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_a_boolean_product_value_with_locale_and_scope(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn('fr_FR');
+        $mediaValue->getScope()->willReturn('ecommerce');
+        $mediaValue->getData()->willReturn(true);
+
+        $mediaAttribute->getCode()->willReturn('a_yes_no');
+        $mediaAttribute->getBackendType()->willReturn('boolean');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'a_yes_no-boolean' => [
+                'ecommerce' => [
+                    'fr_FR' => true
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_an_empty_boolean_product_value(
+        ProductValueInterface $mediaValue,
+        AttributeInterface $mediaAttribute
+    ) {
+        $mediaValue->getAttribute()->willReturn($mediaAttribute);
+        $mediaValue->getLocale()->willReturn(null);
+        $mediaValue->getScope()->willReturn(null);
+        $mediaValue->getData()->willReturn(null);
+
+        $mediaAttribute->getCode()->willReturn('a_yes_no');
+        $mediaAttribute->getBackendType()->willReturn('boolean');
+
+        $this->normalize($mediaValue, 'indexing')->shouldReturn([
+            'a_yes_no-boolean' => [
+                '<all_channels>' => [
+                    '<all_locales>' => null
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -269,7 +269,7 @@ class ProductIndexingIntegration extends TestCase
                 ],
                 'a_yes_no-boolean'                               => [
                     '<all_channels>' => [
-                        '<all_locales>' => null,
+                        '<all_locales>' => true,
                     ],
                 ],
                 'an_image-media'                                 => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,7 +56,6 @@ abstract class TestCase extends KernelTestCase
 
             $fixturesLoader = $this->getFixturesLoader($configuration);
             $fixturesLoader->load();
-
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds the PQB Elasticsearch filters on boolean product values (`pim_catalog_boolean` attribute type).

It also fixes a broken broken test about bulk indexation, and fixes errors on metrics for PHP 7.1

## ES Filter Checklist

- [x] Review the PQB filter integration tests
- [x] Add index mapping integration tests 
- [x] Write the filter & Spec
- [x] Update the documentation in `search_specification.rst`
- [x] Is the PIM installable ?

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed