### PR TITLE
TIP-706: Convert value in string in PQB metric filter

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -17,7 +17,6 @@
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
         <ini name="zend.enable_gc" value="1"/>
-        <ini name="serialize_precision" value="14"/>
     </php>
 
     <testsuites>

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -234,12 +234,14 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
      * @param AttributeInterface $attribute
      * @param array              $data
      *
-     * @return float
+     * @return string
      */
     protected function convertValue(AttributeInterface $attribute, array $data)
     {
         $this->measureConverter->setFamily($attribute->getMetricFamily());
 
-        return $this->measureConverter->convertBaseToStandard($data['unit'], $data['amount']);
+        $convertedValue = $this->measureConverter->convertBaseToStandard($data['unit'], $data['amount']);
+
+        return (string) $convertedValue;
     }
 }


### PR DESCRIPTION
## Description

In PHP 7.1, floats are sometimes badly handled, for instance `json_encode(0.1055)` resulting in `0.1055000000001`. This is problematic for our PQB metric filter, where the value used in the Elasticsearch query is not exactly the one we asked in the PIM.

This PR proposes to fix this problem by casting the value into string when building the Elasticsearch query, and so avoid having a wrongly conversed value.

## Definition Of Done
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
