### PR TITLE
TIP-706: Add family sorter integration tests and service definition

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -25,7 +25,7 @@ parameters:
     # installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
     # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set
-    installer_data:       PimInstallerBundle:icecat_demo_dev
+    installer_data:       PimInstallerBundle:minimal
 
     uservoice_key:                 ~
     max_products_category_removal: 100

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -25,7 +25,7 @@ parameters:
     # installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
     # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set
-    installer_data:       PimInstallerBundle:minimal
+    installer_data:       PimInstallerBundle:icecat_demo_dev
 
     uservoice_key:                 ~
     max_products_category_removal: 100

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseSorter.php
@@ -58,7 +58,7 @@ class BaseSorter implements FieldSorterInterface
                 $sortClause = [
                     $field => [
                         "order" => $direction,
-                        "missing" => "_first"
+                        "missing" => "_last"
                     ]
                 ];
                 $this->searchQueryBuilder->addSort($sortClause);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -274,9 +274,16 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 
     # Fields sorters
-    pim_catalog.query.elasticsearch.sorter.base:
+    pim_catalog.query.elasticsearch.sorter.datetime:
         class: '%pim_catalog.query.elasticsearch.sorter.base.class%'
         arguments:
             - ['updated', 'created']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.family:
+        class: '%pim_catalog.query.elasticsearch.sorter.base.class%'
+        arguments:
+            - ['family']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseSorterSpec.php
@@ -40,7 +40,7 @@ class BaseSorterSpec extends ObjectBehavior
             [
                 'updated' => [
                     "order" => 'ASC',
-                    "missing" => "_first"
+                    "missing" => "_last"
                 ]
             ]
         )->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $familyB = $this->get('pim_catalog.factory.family')->create();
+            $family1 = $this->get('pim_catalog.factory.family')->create();
+            $family2 = $this->get('pim_catalog.factory.family')->create();
+
+            $this->get('pim_catalog.updater.family')->update($familyB, ['code' => 'familyB']);
+            $this->get('pim_catalog.updater.family')->update($family1, ['code' => 'family1']);
+            $this->get('pim_catalog.updater.family')->update($family2, ['code' => 'family2']);
+
+            $this->get('pim_catalog.saver.family')->saveAll([$familyB, $family1, $family2]);
+
+            $this->createProduct('fooA', ['family' => 'familyA']);
+            $this->createProduct('fooB', ['family' => 'familyB']);
+            $this->createProduct('foo1', ['family' => 'family1']);
+            $this->createProduct('foo2', ['family' => 'family2']);
+            $this->createProduct('baz', []);
+        }
+    }
+
+    public function testSortDescendant()
+    {
+        $result = $this->executeSorter([['family', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['fooB', 'fooA', 'foo2', 'foo1', 'baz']);
+    }
+
+    public function testSortAscendant()
+    {
+        $result = $this->executeSorter([['family', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['foo1', 'foo2', 'fooA', 'fooB', 'baz']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['family', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
@@ -7,14 +7,14 @@ use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
- * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

[x] Add PQB integration tests for family sorter
[x] Family sorter is a service mapped to the BaseSorter class
[x] Changed the behavior of the sorter by putting the 'empty' results at the end of the sort (always independant of the Operator) seen with delphine.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
