### PR TITLE
TIP-706: attribute sort a case with metrics

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
@@ -9,7 +9,7 @@ use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
- * Attribute base sorter for an Elasticsearch query
+ * Abstract attribute sorter for an Elasticsearch query
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
@@ -111,8 +111,12 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
         $channel = (null === $channel) ? '<all_channels>' : $channel;
 
         return 'values.' . $attribute->getCode() . '-' . $attribute->getBackendType() . '.' . $channel . '.' . $locale;
-
     }
 
+    /**
+     * Returns the extra suffix to add to the attribute path
+     *
+     * @return mixed
+     */
     abstract protected function getAttributePathSuffix();
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
@@ -51,8 +51,8 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
             case Directions::ASCENDING:
                 $sortClause = [
                     $attributePath => [
-                        "order"   => $direction,
-                        "missing" => "_last",
+                        'order'   => 'ASC',
+                        'missing' => '_last',
                     ],
                 ];
                 $this->searchQueryBuilder->addSort($sortClause);
@@ -61,8 +61,8 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
             case Directions::DESCENDING:
                 $sortClause = [
                     $attributePath => [
-                        "order"   => $direction,
-                        "missing" => "_last",
+                        'order'   => 'DESC',
+                        'missing' => '_last',
                     ],
                 ];
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
+
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidDirectionException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Attribute base sorter for an Elasticsearch query
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractAttributeSorter implements AttributeSorterInterface
+{
+    /** @var SearchQueryBuilder */
+    protected $searchQueryBuilder;
+
+    /** @var array */
+    protected $supportedAttributeTypes;
+
+    /**
+     * @param array $supportedAttributeTypeCodes
+     */
+    public function __construct(array $supportedAttributeTypeCodes = [])
+    {
+        $this->supportedAttributeTypes = $supportedAttributeTypeCodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $scope = null)
+    {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the sorter.');
+        }
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $scope);
+
+        $suffix = $this->getAttributePathSuffix();
+        if (null !== $suffix) {
+            $attributePath .= '.' . $suffix;
+        }
+
+        switch ($direction) {
+            case Directions::ASCENDING:
+                $sortClause = [
+                    $attributePath => [
+                        "order"   => $direction,
+                        "missing" => "_last",
+                    ],
+                ];
+                $this->searchQueryBuilder->addSort($sortClause);
+
+                break;
+            case Directions::DESCENDING:
+                $sortClause = [
+                    $attributePath => [
+                        "order"   => $direction,
+                        "missing" => "_last",
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addSort($sortClause);
+
+                break;
+            default:
+                throw InvalidDirectionException::notSupported($direction, static::class);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsAttribute(AttributeInterface $attribute)
+    {
+        return in_array($attribute->getType(), $this->supportedAttributeTypes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQueryBuilder($searchQueryBuilder)
+    {
+        if (!$searchQueryBuilder instanceof SearchQueryBuilder) {
+            throw new \InvalidArgumentException(
+                sprintf('Query builder should be an instance of "%s"', SearchQueryBuilder::class)
+            );
+        }
+
+        $this->searchQueryBuilder = $searchQueryBuilder;
+    }
+
+    /**
+     * TODO: TIP-706: Those util functions should definitely be refactored somewhere else
+     *
+     * @param AttributeInterface $attribute
+     * @param string             $locale
+     * @param string             $channel
+     *
+     * @return string
+     */
+    protected function getAttributePath(AttributeInterface $attribute, $locale, $channel)
+    {
+        $locale = (null === $locale) ? '<all_locales>' : $locale;
+        $channel = (null === $channel) ? '<all_channels>' : $channel;
+
+        return 'values.' . $attribute->getCode() . '-' . $attribute->getBackendType() . '.' . $channel . '.' . $locale;
+
+    }
+
+    abstract protected function getAttributePathSuffix();
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/BaseAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/BaseAttributeSorter.php
@@ -12,6 +12,9 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
 class BaseAttributeSorter extends AbstractAttributeSorter
 {
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getAttributePathSuffix()
     {
         return null;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/BaseAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/BaseAttributeSorter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
+
+/**
+ * Attribute base sorter for an Elasticsearch query
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BaseAttributeSorter extends AbstractAttributeSorter
+{
+
+    protected function getAttributePathSuffix()
+    {
+        return null;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/MetricSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/MetricSorter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
+
+/**
+ * Metric sorter for an Elastic search query
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MetricSorter extends AbstractAttributeSorter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAttributePathSuffix()
+    {
+        return 'base_data';
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
@@ -57,8 +57,8 @@ class BaseFieldSorter implements FieldSorterInterface
             case Directions::ASCENDING:
                 $sortClause = [
                     $field => [
-                        "order" => $direction,
-                        "missing" => "_last"
+                        'order' => 'ASC',
+                        'missing' => '_last'
                     ]
                 ];
                 $this->searchQueryBuilder->addSort($sortClause);
@@ -67,8 +67,8 @@ class BaseFieldSorter implements FieldSorterInterface
             case Directions::DESCENDING:
                 $sortClause = [
                     $field => [
-                        "order" => $direction,
-                        "missing" => "_last"
+                        'order' => 'DESC',
+                        'missing' => '_last'
                     ]
                 ];
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
@@ -8,13 +8,13 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
 
 /**
- * Base sorter for an Elasticsearch query
+ * Field base sorter for an Elasticsearch query
  *
  * @author    Anaël Chardan <anael.chardan@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class BaseSorter implements FieldSorterInterface
+class BaseFieldSorter implements FieldSorterInterface
 {
     /** @var SearchQueryBuilder */
     protected $searchQueryBuilder;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -31,8 +31,8 @@ parameters:
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
     pim_catalog.query.elasticsearch.filter.boolean.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter
     pim_catalog.query.elasticsearch.sorter.base_field.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseFieldSorter
-    pim_catalog.query.elasticsearch.sorter.base_attribute.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter
-    pim_catalog.query.elasticsearch.sorter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter
+    pim_catalog.query.elasticsearch.sorter.attribute.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter
+    pim_catalog.query.elasticsearch.sorter.attribute.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter
 
 services:
     pim_catalog.query.product_query_builder_factory:
@@ -291,7 +291,7 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
     pim_catalog.query.elasticsearch.sorter.metric:
-        class: '%pim_catalog.query.elasticsearch.sorter.metric.class%'
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
         arguments:
             - ['pim_catalog_metric']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -30,7 +30,9 @@ parameters:
     pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
     pim_catalog.query.elasticsearch.filter.boolean.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter
-    pim_catalog.query.elasticsearch.sorter.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter
+    pim_catalog.query.elasticsearch.sorter.base_field.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseFieldSorter
+    pim_catalog.query.elasticsearch.sorter.base_attribute.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter
+    pim_catalog.query.elasticsearch.sorter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter
 
 services:
     pim_catalog.query.product_query_builder_factory:
@@ -275,15 +277,22 @@ services:
 
     # Fields sorters
     pim_catalog.query.elasticsearch.sorter.datetime:
-        class: '%pim_catalog.query.elasticsearch.sorter.base.class%'
+        class: '%pim_catalog.query.elasticsearch.sorter.base_field.class%'
         arguments:
             - ['updated', 'created']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
     pim_catalog.query.elasticsearch.sorter.family:
-        class: '%pim_catalog.query.elasticsearch.sorter.base.class%'
+        class: '%pim_catalog.query.elasticsearch.sorter.base_field.class%'
         arguments:
             - ['family']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.metric:
+        class: '%pim_catalog.query.elasticsearch.sorter.metric.class%'
+        arguments:
+            - ['pim_catalog_metric']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attributes/MetricSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attributes/MetricSorterSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
+
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidDirectionException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+class MetricSorterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['pim_catalog_metric']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MetricSorter::class);
+    }
+
+    function it_is_an_attribute_sorter()
+    {
+        $this->shouldImplement(AttributeSorterInterface::class);
+    }
+
+    function it_adds_a_sorter_with_operator_ascendant_no_locale_and_no_scope(
+        AttributeInterface $aMetric,
+        SearchQueryBuilder $sqb
+    ) {
+        $aMetric->getCode()->willReturn('a_metric');
+        $aMetric->getBackendType()->willReturn('metric');
+        $sqb->addSort([
+            'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => [
+                'order' => 'ASC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aMetric, DIRECTIONS::ASCENDING, null, null);
+    }
+
+    function it_adds_a_sorter_with_operator_ascendant_locale_and_scope(
+        AttributeInterface $aMetric,
+        SearchQueryBuilder $sqb
+    ) {
+        $aMetric->getCode()->willReturn('a_metric');
+        $aMetric->getBackendType()->willReturn('metric');
+
+        $sqb->addSort([
+            'values.a_metric-metric.ecommerce.fr_FR.base_data' => [
+                'order' => 'ASC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aMetric, DIRECTIONS::ASCENDING, 'fr_FR', 'ecommerce');
+    }
+
+    function it_adds_a_sorter_with_operator_descendant_locale_and_scope(
+        AttributeInterface $aMetric,
+        SearchQueryBuilder $sqb
+    ) {
+        $aMetric->getCode()->willReturn('a_metric');
+        $aMetric->getBackendType()->willReturn('metric');
+
+        $sqb->addSort([
+            'values.a_metric-metric.ecommerce.fr_FR.base_data' => [
+                'order' => 'DESC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aMetric, DIRECTIONS::DESCENDING, 'fr_FR', 'ecommerce');
+    }
+
+    function it_supports_only_metrics_attribute(
+        AttributeInterface $aMetric,
+        AttributeInterface $aPrice
+    ) {
+        $aMetric->getType()->willReturn('pim_catalog_metric');
+        $aPrice->getType()->willReturn('pim_catalog_price');
+
+        $this->supportsAttribute($aMetric)->shouldReturn(true);
+        $this->supportsAttribute($aPrice)->shouldReturn(false);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(
+        AttributeInterface $aMetric
+    ) {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the sorter.')
+        )->during('addAttributeSorter', [$aMetric, Directions::ASCENDING]);
+    }
+
+    function it_throws_an_exception_when_the_directions_does_not_exist(
+        AttributeInterface $aMetric,
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidDirectionException::notSupported(
+                'A_BAD_DIRECTION',
+                MetricSorter::class
+            )
+        )->during('addAttributeSorter', [$aMetric, 'A_BAD_DIRECTION']);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseFieldSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseFieldSorterSpec.php
@@ -9,7 +9,7 @@ use Pim\Component\Catalog\Exception\InvalidDirectionException;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
 
-class BaseSorterSpec extends ObjectBehavior
+class BaseFieldSorterSpec extends ObjectBehavior
 {
     function let()
     {

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/BaseSorterSpec.php
@@ -4,7 +4,7 @@ namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Sorter;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
-use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseSorter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseFieldSorter;
 use Pim\Component\Catalog\Exception\InvalidDirectionException;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
@@ -18,7 +18,7 @@ class BaseSorterSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(BaseSorter::class);
+        $this->shouldHaveType(BaseFieldSorter::class);
     }
 
     function it_is_a_fieldSorter()
@@ -78,7 +78,7 @@ class BaseSorterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidDirectionException::notSupported(
                 'A_BAD_DIRECTION',
-                BaseSorter::class
+                BaseFieldSorter::class
             )
         )->during('addFieldSorter', ['updated', 'A_BAD_DIRECTION']);
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableScopableSorterIntegration.php
@@ -44,7 +44,7 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             $this->createProduct('product_two', [
                 'values' => [
                     'a_localizable_scopable_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
+                        ['data' => ['amount' => '15000', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
                     ]
                 ]
             ]);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Metric sorter integration tests for localizable and scopable attribute
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_scopable_metric',
+                'type'                => AttributeTypes::METRIC,
+                'localizable'         => true,
+                'scopable'            => true,
+                'decimals_allowed'    => true,
+                'metric_family'       => 'Power',
+                'default_metric_unit' => 'WATT'
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_scopable_metric' => [
+                        ['data' => ['amount' => '10.5', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_scopable_metric' => [
+                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_localizable_scopable_metric' => [
+                        ['data' => ['amount' => '-2.5', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_four', [
+                'values' => [
+                    'a_localizable_scopable_metric' => [
+                        ['data' => ['amount' => '12', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_metric', Directions::ASCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_three', 'product_one', 'product_two', 'product_four']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_metric', Directions::DESCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'product_four']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_scopable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableSorterIntegration.php
@@ -3,16 +3,17 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
- * Metric sorter integration tests
+ * Metric sorter integration tests for localizable attribute
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * @{@inheritdoc}
@@ -22,26 +23,36 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_metric',
+                'type'                => AttributeTypes::METRIC,
+                'localizable'         => true,
+                'scopable'            => false,
+                'decimals_allowed'    => true,
+                'metric_family'       => 'Power',
+                'default_metric_unit' => 'WATT'
+            ]);
+
             $this->createProduct('product_one', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_localizable_metric' => [
+                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
                     ]
                 ]
             ]);
 
             $this->createProduct('product_two', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_localizable_metric' => [
+                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
                     ]
                 ]
             ]);
 
             $this->createProduct('product_three', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_localizable_metric' => [
+                        ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
                     ]
                 ]
             ]);
@@ -52,13 +63,13 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
 
     public function testSorterAscending()
     {
-        $result = $this->executeSorter([['a_metric', Directions::ASCENDING]]);
+        $result = $this->executeSorter([['a_localizable_metric', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
         $this->assertOrder($result, ['product_three', 'product_one', 'product_two', 'empty_product']);
     }
 
     public function testSorterDescending()
     {
-        $result = $this->executeSorter([['a_metric', Directions::DESCENDING]]);
+        $result = $this->executeSorter([['a_localizable_metric', Directions::DESCENDING,  ['locale' => 'fr_FR']]]);
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
     }
 
@@ -68,6 +79,6 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
      */
     public function testErrorOperatorNotSupported()
     {
-        $this->executeSorter([['a_metric', 'A_BAD_DIRECTION']]);
+        $this->executeSorter([['a_localizable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/LocalizableSorterIntegration.php
@@ -44,7 +44,7 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
             $this->createProduct('product_two', [
                 'values' => [
                     'a_localizable_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
+                        ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => 'fr_FR', 'scope' => null]
                     ]
                 ]
             ]);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/MetricSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/MetricSorterIntegration.php
@@ -1,0 +1,70 @@
+<?php
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Metric sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_metric' => [
+                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_metric' => [
+                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_metric' => [
+                        ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_metric', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['product_three', 'product_one', 'product_two', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_metric', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_metric', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/MetricSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/MetricSorterIntegration.php
@@ -33,7 +33,7 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
             $this->createProduct('product_two', [
                 'values' => [
                     'a_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                        ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => null, 'scope' => null]
                     ]
                 ]
             ]);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/ScopableSorterIntegration.php
@@ -44,7 +44,7 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
             $this->createProduct('product_two', [
                 'values' => [
                     'a_scopable_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
+                        ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => null, 'scope' => 'ecommerce']
                     ]
                 ]
             ]);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Metric/ScopableSorterIntegration.php
@@ -3,16 +3,17 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
- * Metric sorter integration tests
+ * Metric sorter integration tests for scopable attribute
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * @{@inheritdoc}
@@ -22,26 +23,36 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_scopable_metric',
+                'type'                => AttributeTypes::METRIC,
+                'localizable'         => false,
+                'scopable'            => true,
+                'decimals_allowed'    => true,
+                'metric_family'       => 'Power',
+                'default_metric_unit' => 'WATT'
+            ]);
+
             $this->createProduct('product_one', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_scopable_metric' => [
+                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
                     ]
                 ]
             ]);
 
             $this->createProduct('product_two', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_scopable_metric' => [
+                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
                     ]
                 ]
             ]);
 
             $this->createProduct('product_three', [
                 'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                    'a_scopable_metric' => [
+                        ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
                     ]
                 ]
             ]);
@@ -52,13 +63,13 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
 
     public function testSorterAscending()
     {
-        $result = $this->executeSorter([['a_metric', Directions::ASCENDING]]);
+        $result = $this->executeSorter([['a_scopable_metric', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_three', 'product_one', 'product_two', 'empty_product']);
     }
 
     public function testSorterDescending()
     {
-        $result = $this->executeSorter([['a_metric', Directions::DESCENDING]]);
+        $result = $this->executeSorter([['a_scopable_metric', Directions::DESCENDING,  ['scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
     }
 
@@ -68,6 +79,6 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
      */
     public function testErrorOperatorNotSupported()
     {
-        $this->executeSorter([['a_metric', 'A_BAD_DIRECTION']]);
+        $this->executeSorter([['a_scopable_metric', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
+class FamilySorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In order to sort on attributes this PR introduces to choice:

1. Your attribute is not really complex (and the attribute path to the data has no extra suffix)
-> You can use the baseAttributeSorter class

2. Your attribute is a bit special and has extra suffix to its attribute path
-> You create a specific class the extends AbstractAttributeSorter and overrides the method: `getAttributePathSuffix`

Now create a single class to override this bit may be heavy, we could also inject the suffix in the BaseAttributeSorter class

**ES Sorter Checklist:**
- [X] Add sorter integration tests for the field in the PQB
- [X] Add missing integration to the PimCatalogXIntegration tests for sort
- [x] Add the sorter + specs
- [x] Update the reference documentation

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
