### PR TITLE
TIP-706-in_group-sorter: Add in group sorter for es

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,6 @@ if (launchIntegrationTests.equals("yes")) {
         tasks["phpunit-7.0-catalog"] = {runIntegrationTest("7.0", "PIM_Catalog_Integration_Test")}
         tasks["phpunit-7.0-completeness"] = {runIntegrationTest("7.0", "PIM_Catalog_Completeness_Integration_Test")}
         tasks["phpunit-7.0-pqb"] = {runIntegrationTest("7.0", "PIM_Catalog_PQB_Integration_Test")}
-        tasks["phpunit-7.0-reference-data-pqb"] = {runIntegrationTest("7.0", "PIM_ReferenceData_Integration_Test")}
 
         tasks["phpunit-7.1-akeneo"] = {runIntegrationTest("7.1", "Akeneo_Integration_Test")}
         tasks["phpunit-7.1-api-base"] = {runIntegrationTest("7.1", "PIM_Api_Base_Integration_Test")}
@@ -124,7 +123,6 @@ if (launchIntegrationTests.equals("yes")) {
         tasks["phpunit-7.1-catalog"] = {runIntegrationTest("7.1", "PIM_Catalog_Integration_Test")}
         tasks["phpunit-7.1-completeness"] = {runIntegrationTest("7.1", "PIM_Catalog_Completeness_Integration_Test")}
         tasks["phpunit-7.1-pqb"] = {runIntegrationTest("7.1", "PIM_Catalog_PQB_Integration_Test")}
-        tasks["phpunit-7.1-reference-data-pqb"] = {runIntegrationTest("7.1", "PIM_ReferenceData_Integration_Test")}
 
         parallel tasks
     }

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -75,10 +75,8 @@
 
         <testsuite name="PIM_Catalog_PQB_Integration_Test">
             <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/PQB</directory>
-        </testsuite>
-
-        <testsuite name="PIM_ReferenceData_Integration_Test">
             <directory suffix="Integration.php">../src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/EnrichBundle/Tests/integration/PQB</directory>
         </testsuite>
 
     </testsuites>

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Field/BaseFieldSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Field/BaseFieldSorter.php
@@ -58,8 +58,8 @@ class BaseFieldSorter implements FieldSorterInterface
                 $sortClause = [
                     $field => [
                         'order'   => 'ASC',
-                        'missing' => '_last'
-                    ]
+                        'missing' => '_last',
+                    ],
                 ];
                 $this->searchQueryBuilder->addSort($sortClause);
 
@@ -68,10 +68,9 @@ class BaseFieldSorter implements FieldSorterInterface
                 $sortClause = [
                     $field => [
                         'order'   => 'DESC',
-                        'missing' => '_last'
-                    ]
+                        'missing' => '_last',
+                    ],
                 ];
-
                 $this->searchQueryBuilder->addSort($sortClause);
 
                 break;

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -160,7 +160,12 @@ mappings:
                     match_mapping_type: 'date'
                     mapping:
                         type: 'date'
-
+            -
+                in_group:
+                    path_match: 'in_group.*'
+                    match_mapping_type: 'boolean'
+                    mapping:
+                        type: 'boolean'
 settings:
     analysis:
         normalizer:

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/Sorter/InGroupSorter.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/Sorter/InGroupSorter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Elasticsearch\Sorter;
+
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Field\BaseFieldSorter;
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
+use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
+
+/**
+ * InGroup sorter for an Elasticsearch query used for variant-group and group product grid
+ *
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class InGroupSorter extends BaseFieldSorter implements FieldSorterInterface
+{
+    /** @var GroupRepositoryInterface */
+    protected $groupRepository;
+
+    /**
+     * @param GroupRepositoryInterface $groupRepository
+     * @param array                    $supportedFields
+     */
+    public function __construct(
+        GroupRepositoryInterface $groupRepository,
+        array $supportedFields = []
+    ) {
+        parent::__construct($supportedFields);
+        $this->groupRepository = $groupRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldSorter($field, $direction, $locale = null, $channel = null)
+    {
+        $groupId = str_replace('in_group_', '', $field);
+
+        $group = null;
+        if (null !== $groupId) {
+            $group = $this->groupRepository->find($groupId);
+        }
+
+        if (null === $group) {
+            throw new InvalidArgumentException(
+                self::class,
+                sprintf('Unsupported field "%s" for InGroupSorter.', $field)
+            );
+        }
+
+        $field = sprintf('%s.%s', 'in_group', $group->getCode());
+        parent::addFieldSorter($field, $direction, $locale, $channel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsField($field)
+    {
+        return (strpos($field, 'in_group_') !== false);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -1,7 +1,9 @@
 parameters:
     pim_enrich.product_query_builder.filter.dummy.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\Filter\DummyFilter
+    pim_enrich.query.elasticsearch.sorter.in_group.class: Pim\Bundle\EnrichBundle\Elasticsearch\Sorter\InGroupSorter
 
 services:
+    # Filters
     pim_enrich.product_query_builder.filter.dummy:
         class: '%pim_enrich.product_query_builder.filter.dummy.class%'
         arguments:
@@ -10,3 +12,11 @@ services:
             - ['ALL']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    # Sorters
+    pim_catalog.query.elasticsearch.sorter.in_group:
+        class: '%pim_enrich.query.elasticsearch.sorter.in_group.class%'
+        arguments:
+            - '@pim_catalog.repository.group'
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\PQB\Sorter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSortDescendant()
+    {
+        $result = $this->executeSorter([['in_group_4', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['bar', 'foo', 'baz', 'empty']);
+    }
+
+    public function testSortAscendant()
+    {
+        $result = $this->executeSorter([['in_group_4', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['bar', 'foo', 'baz', 'empty']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['in_group_4', 'A_BAD_DIRECTION']]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $group = $this->get('pim_catalog.factory.group')->create();
+            $this->get('pim_catalog.updater.group')->update(
+                $group,
+                [
+                    'code' => 'groupC',
+                    'type' => 'RELATED',
+                ]
+            );
+            $this->get('pim_catalog.saver.group')->save($group);
+
+            $this->createProduct('foo', ['groups' => ['groupA', 'groupB']]);
+            $this->createProduct('bar', ['groups' => ['groupB']]);
+            $this->createProduct('baz', ['groups' => ['groupC']]);
+            $this->createProduct('empty', []);
+        }
+    }
+
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/Sorter/InGroupSorterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/Sorter/InGroupSorterSpec.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch\Sorter;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Field\BaseFieldSorter;
+use Pim\Bundle\CatalogBundle\Entity\Group;
+use Pim\Bundle\EnrichBundle\Elasticsearch\Sorter\InGroupSorter;
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Exception\InvalidDirectionException;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
+use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
+
+class InGroupSorterSpec extends ObjectBehavior
+{
+    function let(
+        GroupRepositoryInterface $groupRepository
+    ) {
+        $this->beConstructedWith($groupRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(BaseFieldSorter::class);
+    }
+
+    function it_is_a_fieldSorter()
+    {
+        $this->shouldImplement(FieldSorterInterface::class);
+    }
+
+    function it_supports_fields()
+    {
+        $this->supportsField('in_group_4')->shouldReturn(true);
+        $this->supportsField('a_not_supported_field')->shouldReturn(false);
+    }
+
+    function it_add_ascending_sorter_with_field(
+        $groupRepository,
+        SearchQueryBuilder $sqb,
+        Group $group
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $groupRepository->find(1)->willReturn($group);
+        $group->getId()->willReturn(1);
+        $group->getCode()->willReturn('group_code');
+
+        $sqb->addSort(
+            [
+                'in_group.group_code' => [
+                    "order"   => 'ASC',
+                    "missing" => "_last",
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldSorter('in_group_1', Directions::ASCENDING);
+    }
+
+    function it_add_descending_sorter_with_field(
+        $groupRepository,
+        SearchQueryBuilder $sqb,
+        Group $group
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $groupRepository->find(1)->willReturn($group);
+        $group->getId()->willReturn(1);
+        $group->getCode()->willReturn('group_code');
+
+        $sqb->addSort(
+            [
+                'in_group.group_code' => [
+                    "order"   => 'DESC',
+                    "missing" => "_last",
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldSorter('in_group_1', Directions::DESCENDING);
+    }
+
+    function it_throws_an_exception_when_group_is_null()
+    {
+        $this->shouldThrow(
+            new InvalidArgumentException(
+                InGroupSorter::class,
+                'Unsupported field "in_group_bad_identifier" for InGroupSorter.'
+            )
+        )->during('addFieldSorter', ['in_group_bad_identifier', Directions::ASCENDING]);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(
+        $groupRepository,
+        Group $group
+    ) {
+        $groupRepository->find(1)->willReturn($group);
+        $group->getId()->willReturn(1);
+        $group->getCode()->willReturn('group_code');
+
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the sorter.')
+        )->during('addFieldSorter', ['in_group_1', Directions::ASCENDING]);
+    }
+
+    function it_throws_an_exception_when_the_directions_does_not_exist(
+        $groupRepository,
+        SearchQueryBuilder $sqb,
+        Group $group
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $groupRepository->find(1)->willReturn($group);
+        $group->getId()->willReturn(1);
+        $group->getCode()->willReturn('group_code');
+
+        $this->shouldThrow(
+            InvalidDirectionException::notSupported(
+                'A_BAD_DIRECTION',
+                InGroupSorter::class
+            )
+        )->during('addFieldSorter', ['in_group_1', 'A_BAD_DIRECTION']);
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -19,6 +19,7 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
 {
     const FIELD_COMPLETENESS = 'completeness';
     const FIELD_IS_ASSOCIATED = 'is_associated';
+    const FIELD_IN_GROUP = 'in_group';
 
     /**
      * {@inheritdoc}
@@ -55,6 +56,10 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data[StandardPropertiesNormalizer::FIELD_GROUPS] = $groups;
         $data[StandardPropertiesNormalizer::FIELD_VARIANT_GROUP] = null !== $product->getVariantGroup()
             ? $product->getVariantGroup()->getCode() : null;
+
+        foreach ($product->getGroupCodes() as $groupCode) {
+            $data[self::FIELD_IN_GROUP][$groupCode] = true;
+        }
 
         $data[self::FIELD_IS_ASSOCIATED] = !$product->getAssociations()->isEmpty();
 

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -217,6 +217,11 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'categories'    => ['first_category', 'second_category'],
                 'groups'        => ['first_group', 'second_group'],
                 'variant_group' => 'a_variant_group',
+                'in_group' => [
+                    'first_group'     => true,
+                    'second_group'    => true,
+                    'a_variant_group' => true,
+                ],
                 'is_associated' => true,
                 'completeness'  => [
                     'ecommerce' => [

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -89,6 +89,11 @@ class ProductIndexingIntegration extends TestCase
             'categories'    => ['categoryA1', 'categoryB'],
             'groups'        => ['groupA', 'groupB'],
             'variant_group' => 'variantA',
+            'in_group'      => [
+                'groupA'   => true,
+                'groupB'   => true,
+                'variantA' => true,
+            ],
             'is_associated' => true,
             'completeness'  => [
                 'ecommerce' => ['en_US' => 100],


### PR DESCRIPTION
Index group and variant group in an array ['in_group']['group_code'].
Add InGroupSorter for variant group product grid, the datagrid send 'in_group_<group_id>' to the PQB, to sort.

Inspire by [InGroupSorter](https://github.com/jjanvier/pim-community-dev/blob/TIP-613-unified/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/InGroupSorter.php)

** ES Sorter Checklist:**
- [x] Add sorter integration tests for the field in the PQB
- [ ] Add missing integration to the PimCatalogXIntegration tests for sort
- [x] Add the sorter + specs
- [ ] Update the reference documentation

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
