### PR TITLE
TIP-706: Number/Text/Option attribute sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -406,6 +406,35 @@ Same syntax than the contains but must be include in a ``must_not`` boolean occu
         ]
     ]
 
+Sorting
+~~~~~~~
+
+Operators
+.........
+Ascendant
+"""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.name-varchar.<all_channels>.<all_locales>' => [
+            'order'   => 'ASC',
+            'missing' => '_last'
+        ]
+    ]
+
+Descendant
+""""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.name-varchar.<all_channels>.<all_locales>' => [
+            'order'   => 'DESC',
+            'missing' => '_last'
+        ]
+    ]
+
 Identifier
 **********
 :Apply: apply datatype 'keyword' on the 'identifier' field
@@ -1016,15 +1045,32 @@ NOT IN
 
 Sorting
 ~~~~~~~
+Operators
+.........
+Ascendant
+"""""""""
 
 .. code-block:: php
 
     'sort' => [
         'values.color-option.<all_channels>.<all_locales>' => [
-            'order'   => 'asc',
-            'missing' => '_first'
+            'order'   => 'ASC',
+            'missing' => '_last'
         ]
     ]
+
+Descendant
+""""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.color-option.<all_channels>.<all_locales>' => [
+            'order'   => 'DESC',
+            'missing' => '_last'
+        ]
+    ]
+
 
 Simple select reference data
 ****************************
@@ -1305,7 +1351,23 @@ Filtering
 ~~~~~~~~~
 Operators
 .........
-All operators are identical to the one used on numbers.
+
+All operators are identical to the one used on numbers except we filter on the `base_data` value. So the attribute path becomes:
+
+.. code-block:: php
+
+    'values.weight-metric.mobile.fr_FR.base_data'
+
+Sorting
+~~~~~~~
+Operators
+.........
+
+All operators are identical to the one used on numbers except we filter on the `base_data` value. So the attribute path becomes:
+
+.. code-block:: php
+
+    'values.weight-metric.mobile.fr_FR.base_data'
 
 Boolean
 *******
@@ -1337,7 +1399,7 @@ Equals (=)
 
     'filter' => [
         'term' => [
-            'values.description-text.<all_channels>.<all_locales>' => true
+            'values.a_yes_no-boolean.<all_channels>.<all_locales>' => true
         ]
     ]
 
@@ -1349,12 +1411,12 @@ Not Equals (!=)
 
     'must_not' => [
         'term' => [
-            'values.description-text.<all_channels>.<all_locales>' => true
+            'values.a_yes_no-boolean.<all_channels>.<all_locales>' => true
         ]
     ],
     'filter' => [
         'exists' => [
-            'field' => 'values.description-text.<all_channels>.<all_locales>'
+            'field' => 'values.a_yes_no-boolean.<all_channels>.<all_locales>'
         ]
     ]
 
@@ -1473,6 +1535,8 @@ NOT IN CHILDREN
 :Type: filter
 
 Same as above but with a ``must_not`` occured type
+
+
 
 Price
 *****

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -907,6 +907,35 @@ NOT EMPTY
     ]
 
 
+Sorting
+~~~~~~~
+
+Operators
+.........
+Ascendant
+"""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.packet_count-decimal.<all_channels>.<all_locales>' => [
+            'order'   => 'ASC',
+            'missing' => '_last'
+        ]
+    ]
+
+Descendant
+""""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.packet_count-decimal.<all_channels>.<all_locales>' => [
+            'order'   => 'DESC',
+            'missing' => '_last'
+        ]
+    ]
+
 Option
 ******
 :Apply: pim_catalog_simpleselect attributes

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -290,6 +290,13 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.sorter.number:
+        class: '%pim_catalog.query.elasticsearch.sorter.base_attribute.class%'
+        arguments:
+            - ['pim_catalog_number']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
     pim_catalog.query.elasticsearch.sorter.metric:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -303,6 +303,13 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.sorter.text:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
+        arguments:
+            - ['pim_catalog_text']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
     pim_catalog.query.elasticsearch.sorter.metric:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -25,7 +25,6 @@ parameters:
     pim_catalog.query.elasticsearch.filter.text.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextFilter
     pim_catalog.query.elasticsearch.filter.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextAreaFilter
     pim_catalog.query.elasticsearch.filter.option.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter
-    pim_catalog.query.elasticsearch.filter.options.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionsFilter
     pim_catalog.query.elasticsearch.filter.price.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\PriceFilter
     pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
@@ -291,9 +290,16 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
     pim_catalog.query.elasticsearch.sorter.number:
-        class: '%pim_catalog.query.elasticsearch.sorter.base_attribute.class%'
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
         arguments:
             - ['pim_catalog_number']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.option:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
+        arguments:
+            - ['pim_catalog_simpleselect']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
@@ -270,9 +270,6 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one', 'product_two']);
     }
 
-    /**
-     * @group todo
-     */
     public function testOperatorNotEmptyForCurrency()
     {
         $result = $this->executeFilter([

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -34,7 +34,8 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             $this->createProduct('product_one', [
                 'values' => [
                     'a_localizable_scopable_number' => [
-                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => 'ecommerce']
+                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => '-16', 'locale' => 'fr_FR', 'scope' => 'tablet']
                     ]
                 ]
             ]);
@@ -42,7 +43,8 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             $this->createProduct('product_two', [
                 'values' => [
                     'a_localizable_scopable_number' => [
-                        ['data' => '-16', 'locale' => 'en_US', 'scope' => 'ecommerce']
+                        ['data' => '-16', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => '192.103', 'locale' => 'fr_FR', 'scope' => 'tablet'],
                     ]
                 ]
             ]);
@@ -50,7 +52,7 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             $this->createProduct('product_three', [
                 'values' => [
                     'a_localizable_scopable_number' => [
-                        ['data' => '52', 'locale' => 'fr_FR', 'scope' => 'tablet']
+                        ['data' => '52', 'locale' => 'de_DE', 'scope' => 'tablet']
                     ]
                 ]
             ]);
@@ -61,12 +63,18 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     {
         $result = $this->executeSorter([['a_localizable_scopable_number', Directions::ASCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::ASCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
     }
 
     public function testSorterDescending()
     {
         $result = $this->executeSorter([['a_localizable_scopable_number', Directions::DESCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::DESCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Number;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Number sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_scopable_number',
+                'type'                => AttributeTypes::NUMBER,
+                'localizable'         => true,
+                'scopable'            => true,
+                'negative_allowed'    => true
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_scopable_number' => [
+                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => 'ecommerce']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_scopable_number' => [
+                        ['data' => '-16', 'locale' => 'en_US', 'scope' => 'ecommerce']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_localizable_scopable_number' => [
+                        ['data' => '52', 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::ASCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::DESCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_scopable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -24,35 +24,37 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
             $this->createAttribute([
-                'code'                => 'a_localizable_number',
-                'type'                => AttributeTypes::NUMBER,
-                'localizable'         => true,
-                'scopable'            => false,
-                'negative_allowed'    => true
+                'code'             => 'a_localizable_number',
+                'type'             => AttributeTypes::NUMBER,
+                'localizable'      => true,
+                'scopable'         => false,
+                'negative_allowed' => true,
             ]);
 
             $this->createProduct('product_one', [
                 'values' => [
                     'a_localizable_number' => [
-                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => null]
-                    ]
-                ]
+                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => '-16', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
             ]);
 
             $this->createProduct('product_two', [
                 'values' => [
                     'a_localizable_number' => [
-                        ['data' => '-16', 'locale' => 'en_US', 'scope' => null]
-                    ]
-                ]
+                        ['data' => '-16', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => '192.103', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
             ]);
 
             $this->createProduct('product_three', [
                 'values' => [
                     'a_localizable_number' => [
-                        ['data' => '52', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
-                ]
+                        ['data' => '52', 'locale' => 'de_DE', 'scope' => null],
+                    ],
+                ],
             ]);
         }
     }
@@ -61,12 +63,18 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $result = $this->executeSorter([['a_localizable_number', Directions::ASCENDING, ['locale' => 'en_US']]]);
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
+
+        $result = $this->executeSorter([['a_localizable_number', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
     }
 
     public function testSorterDescending()
     {
         $result = $this->executeSorter([['a_localizable_number', Directions::DESCENDING, ['locale' => 'en_US']]]);
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
+
+        $result = $this->executeSorter([['a_localizable_number', Directions::DESCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/LocalizableSorterIntegration.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Number;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
@@ -12,7 +13,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * @{@inheritdoc}
@@ -22,44 +23,50 @@ class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_number',
+                'type'                => AttributeTypes::NUMBER,
+                'localizable'         => true,
+                'scopable'            => false,
+                'negative_allowed'    => true
+            ]);
+
             $this->createProduct('product_one', [
                 'values' => [
-                    'a_number_float_negative' => [
-                        ['data' => '192.103', 'locale' => null, 'scope' => null]
+                    'a_localizable_number' => [
+                        ['data' => '192.103', 'locale' => 'en_US', 'scope' => null]
                     ]
                 ]
             ]);
 
             $this->createProduct('product_two', [
                 'values' => [
-                    'a_number_float_negative' => [
-                        ['data' => '16', 'locale' => null, 'scope' => null]
+                    'a_localizable_number' => [
+                        ['data' => '-16', 'locale' => 'en_US', 'scope' => null]
                     ]
                 ]
             ]);
 
             $this->createProduct('product_three', [
                 'values' => [
-                    'a_number_float_negative' => [
-                        ['data' => '-162.5654', 'locale' => null, 'scope' => null]
+                    'a_localizable_number' => [
+                        ['data' => '52', 'locale' => 'fr_FR', 'scope' => null]
                     ]
                 ]
             ]);
-
-            $this->createProduct('empty_product', []);
         }
     }
 
     public function testSorterAscending()
     {
-        $result = $this->executeSorter([['a_number_float_negative', Directions::ASCENDING]]);
-        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product']);
+        $result = $this->executeSorter([['a_localizable_number', Directions::ASCENDING, ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
     }
 
     public function testSorterDescending()
     {
-        $result = $this->executeSorter([['a_number_float_negative', Directions::DESCENDING]]);
-        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+        $result = $this->executeSorter([['a_localizable_number', Directions::DESCENDING, ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
     }
 
     /**
@@ -68,6 +75,6 @@ class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
      */
     public function testErrorOperatorNotSupported()
     {
-        $this->executeSorter([['a_number_float_negative', 'A_BAD_DIRECTION']]);
+        $this->executeSorter([['a_localizable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/NumberSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/NumberSorterIntegration.php
@@ -1,0 +1,71 @@
+<?php
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Number sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_number_float_negative' => [
+                        ['data' => '192.103', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_number_float_negative' => [
+                        ['data' => '16', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_number_float_negative' => [
+                        ['data' => '-162.5654', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_number_float_negative', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_number_float_negative', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_number_float_negative', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/NumberSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/NumberSorterIntegration.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/ScopableSorterIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Number;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Number sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_scopable_number',
+                'type'                => AttributeTypes::NUMBER,
+                'localizable'         => false,
+                'scopable'            => true,
+                'negative_allowed'    => true
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_scopable_number' => [
+                        ['data' => '192.103', 'locale' => null, 'scope' => 'ecommerce']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_scopable_number' => [
+                        ['data' => '16', 'locale' => null, 'scope' => 'ecommerce']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_scopable_number', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_scopable_number', Directions::DESCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_scopable_number', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Number/ScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -24,27 +24,29 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 
         if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
             $this->createAttribute([
-                'code'                => 'a_scopable_number',
-                'type'                => AttributeTypes::NUMBER,
-                'localizable'         => false,
-                'scopable'            => true,
-                'negative_allowed'    => true
+                'code'             => 'a_scopable_number',
+                'type'             => AttributeTypes::NUMBER,
+                'localizable'      => false,
+                'scopable'         => true,
+                'negative_allowed' => true,
             ]);
 
             $this->createProduct('product_one', [
                 'values' => [
                     'a_scopable_number' => [
-                        ['data' => '192.103', 'locale' => null, 'scope' => 'ecommerce']
-                    ]
-                ]
+                        ['data' => '192.103', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => '16', 'locale' => null, 'scope' => 'tablet'],
+                    ],
+                ],
             ]);
 
             $this->createProduct('product_two', [
                 'values' => [
                     'a_scopable_number' => [
-                        ['data' => '16', 'locale' => null, 'scope' => 'ecommerce']
-                    ]
-                ]
+                        ['data' => '16', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => '192.103', 'locale' => null, 'scope' => 'tablet'],
+                    ],
+                ],
             ]);
 
             $this->createProduct('empty_product', []);
@@ -55,12 +57,18 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $result = $this->executeSorter([['a_scopable_number', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_number', Directions::ASCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
     public function testSorterDescending()
     {
         $result = $this->executeSorter([['a_scopable_number', Directions::DESCENDING, ['scope' => 'ecommerce']]]);
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_number', Directions::DESCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Option;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Scopable and localizable attribute option sorter integration tests (simple select)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_localizable_scopable_simple_select',
+                'type'        => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'localizable' => true,
+                'scopable'    => true,
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_localizable_scopable_simple_select',
+                'code'      => 'orange',
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_localizable_scopable_simple_select',
+                'code'      => 'black',
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_scopable_simple_select' => [
+                        ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_scopable_simple_select' => [
+                        ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_simple_select',
+                Directions::ASCENDING,
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_simple_select',
+                Directions::ASCENDING,
+                ['locale' => 'fr_FR', 'scope' => 'tablet'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_simple_select',
+                Directions::DESCENDING,
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_simple_select',
+                Directions::DESCENDING,
+                ['locale' => 'fr_FR', 'scope' => 'tablet'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([
+            [
+                'a_localizable_scopable_simple_select',
+                'A_BAD_DIRECTION',
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableSorterIntegration.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Option;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Localizable option attribute sorter integration tests (simple select)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_localizable_simple_select',
+                'type'        => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'localizable' => true,
+                'scopable'    => false,
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_localizable_simple_select',
+                'code'      => 'orange',
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_localizable_simple_select',
+                'code'      => 'black',
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_simple_select' => [
+                        ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_simple_select' => [
+                        ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_simple_select', Directions::ASCENDING, ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_simple_select', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_simple_select',
+                Directions::DESCENDING,
+                ['locale' => 'en_US'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_simple_select',
+                Directions::DESCENDING,
+                ['locale' => 'fr_FR'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_simple_select', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/LocalizableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/OptionSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/OptionSorterIntegration.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class OptionSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/OptionSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/OptionSorterIntegration.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Option;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Option attribute sorter integration tests (simple select)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OptionSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttributeOption([
+                'attribute' => 'a_simple_select',
+                'code'      => 'orange'
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_simple_select',
+                'code'      => 'black'
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_simple_select' => [
+                        ['data' => 'black', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_simple_select' => [
+                        ['data' => 'orange', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_simple_select', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_simple_select', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_simple_select', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/ScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Option/ScopableSorterIntegration.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Option;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Scopable option attribute sorter integration tests (simple select)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_select_scopable_simple_select',
+                'type'        => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'localizable' => false,
+                'scopable'    => true,
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_select_scopable_simple_select',
+                'code'      => 'orange'
+            ]);
+
+            $this->createAttributeOption([
+                'attribute' => 'a_select_scopable_simple_select',
+                'code'      => 'black'
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_select_scopable_simple_select' => [
+                        ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'orange', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_select_scopable_simple_select' => [
+                        ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'black', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::ASCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::DESCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::DESCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_select_scopable_simple_select', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Text;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Scopable and localizable attribute text sorter integration tests (simple select)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_localizable_scopable_text',
+                'type'        => AttributeTypes::TEXT,
+                'localizable' => true,
+                'scopable'    => true,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_scopable_text' => [
+                        ['data' => 'cat is beautiful', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'dog is wonderful', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_scopable_text' => [
+                        ['data' => 'dog is wonderful', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'cat is beautiful', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_text',
+                Directions::ASCENDING,
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_text',
+                Directions::ASCENDING,
+                ['locale' => 'fr_FR', 'scope' => 'tablet'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_text',
+                Directions::DESCENDING,
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_scopable_text',
+                Directions::DESCENDING,
+                ['locale' => 'fr_FR', 'scope' => 'tablet'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([
+            [
+                'a_localizable_scopable_text',
+                'A_BAD_DIRECTION',
+                ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableSorterIntegration.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Text;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Localizable text attribute sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_localizable_text',
+                'type'        => AttributeTypes::TEXT,
+                'localizable' => true,
+                'scopable'    => false,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_text' => [
+                        ['data' => 'cat is beautiful', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'dog is wonderful', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_text' => [
+                        ['data' => 'dog is wonderful', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'cat is beautiful', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_text', Directions::ASCENDING, ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_text', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([
+            [
+                'a_localizable_text',
+                Directions::DESCENDING,
+                ['locale' => 'en_US'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([
+            [
+                'a_localizable_text',
+                Directions::DESCENDING,
+                ['locale' => 'fr_FR'],
+            ],
+        ]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_text', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/LocalizableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/ScopableSorterIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/ScopableSorterIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Text;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Scopable text attribute sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_scopable_text',
+                'type'                => AttributeTypes::TEXT,
+                'localizable'         => false,
+                'scopable'            => true,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_scopable_text' => [
+                        ['data' => 'cat is beautiful', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'dog is wonderful', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_scopable_text' => [
+                        ['data' => 'dog is wonderful', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'cat is beautiful', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_scopable_text', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text', Directions::ASCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_scopable_text', Directions::DESCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text', Directions::DESCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_scopable_text', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/TextSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/TextSorterIntegration.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Text;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Text attribute sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('cat', [
+                'values' => [
+                    'a_text' => [['data' => 'cat is beautiful', 'locale' => null, 'scope' => null]],
+                ],
+            ]);
+
+            $this->createProduct('dog', [
+                'values' => [
+                    'a_text' => [['data' => 'dog is wonderful', 'locale' => null, 'scope' => null]],
+                ],
+            ]);
+
+            // There is no html tags in TEXT attributes usually set in the PIM.
+            // This tests shows that if it's the case they are stored as is and not stripped.
+            $this->createProduct('best_cat', [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'data'   => '<bold>dog</bold> is the most <i>beautiful</i><br/>',
+                            'locale' => null,
+                            'scope'  => null,
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_text', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['best_cat', 'cat', 'dog', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_text', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['dog', 'cat', 'best_cat', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_text', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/TextSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/Text/TextSorterIntegration.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 class TextSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
-     * @{@inheritdoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR contains the number/text/option sorter. They all use the BaseAttributeSorter.
This PR adds the services definition and the integration tests for those sorters.

**ES Sorter Checklist:**
- [X] Add sorter integration tests for the field in the PQB
- [X] Add missing integration to the PimCatalogXIntegration tests for sort
- [X] Add the sorter + specs
- [x] Update the reference documentation

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
