### PR TITLE
TIP-706: Add ES PQB completeness sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -50,7 +50,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
     /**
      * {@inheritdoc}
      */
-    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
+    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = [])
     {
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the filter.');
@@ -143,7 +143,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
                     Operators::GREATER_THAN,
                     new \DateTime(sprintf('%s days ago', $value), new \DateTimeZone('UTC')),
                     $locale,
-                    $scope,
+                    $channel,
                     $options
                 );
             case Operators::SINCE_LAST_JOB:
@@ -169,7 +169,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
                     Operators::GREATER_THAN,
                     $lastCompletedJobExecution->getStartTime()->setTimezone(new \DateTimeZone('UTC')),
                     $locale,
-                    $scope,
+                    $channel,
                     $options
                 );
             default:
@@ -267,7 +267,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
     protected function getFormattedDate($field, $value)
     {
         $dateTime = $value;
-        
+
         if (!$dateTime instanceof \DateTime) {
             $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $dateTime);
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/FamilyFilter.php
@@ -38,7 +38,7 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
         $operator,
         $value,
         $locale = null,
-        $scope = null,
+        $channel = null,
         $options = []
     ) {
         if (null === $this->searchQueryBuilder) {

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
@@ -38,7 +38,7 @@ class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
         $operator,
         $value,
         $locale = null,
-        $scope = null,
+        $channel = null,
         $options = []
     ) {
         if (null === $this->searchQueryBuilder) {

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
@@ -43,7 +43,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
     /**
      * {@inheritdoc}
      */
-    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
+    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = [])
     {
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the filter.');
@@ -63,7 +63,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
         $operator,
         $value,
         $locale = null,
-        $scope = null,
+        $channel = null,
         $options = []
     ) {
         if (null === $this->searchQueryBuilder) {

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1361,6 +1361,18 @@ Example with the ``>`` operator:
         completeness.print.en_US:
             gt: 4
 
+Sorting
+~~~~~~~
+
+.. code-block:: php
+
+    'sort' => [
+        'completeness.mobile.en_US' => [
+            'order'   => 'asc',
+            'missing' => '_last'
+        ]
+    ]
+
 Category
 ********
 :Apply: apply 'keyword' datatype on 'categories' field

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/AbstractAttributeSorter.php
@@ -34,13 +34,13 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
     /**
      * {@inheritdoc}
      */
-    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $scope = null)
+    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $channel = null)
     {
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the sorter.');
         }
 
-        $attributePath = $this->getAttributePath($attribute, $locale, $scope);
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
 
         $suffix = $this->getAttributePathSuffix();
         if (null !== $suffix) {

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
@@ -47,7 +47,7 @@ class BaseFieldSorter implements FieldSorterInterface
     /**
      * {@inheritdoc}
      */
-    public function addFieldSorter($field, $direction, $locale = null, $scope = null)
+    public function addFieldSorter($field, $direction, $locale = null, $channel = null)
     {
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the sorter.');

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/BaseFieldSorter.php
@@ -57,7 +57,7 @@ class BaseFieldSorter implements FieldSorterInterface
             case Directions::ASCENDING:
                 $sortClause = [
                     $field => [
-                        'order' => 'ASC',
+                        'order'   => 'ASC',
                         'missing' => '_last'
                     ]
                 ];
@@ -67,7 +67,7 @@ class BaseFieldSorter implements FieldSorterInterface
             case Directions::DESCENDING:
                 $sortClause = [
                     $field => [
-                        'order' => 'DESC',
+                        'order'   => 'DESC',
                         'missing' => '_last'
                     ]
                 ];

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CompletenessSorter extends BaseFieldSorter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldSorter($field, $direction, $locale = null, $scope = null)
+    {
+        $this->checkLocaleAndScope($locale, $scope);
+
+        $field .= sprintf('.%s.%s', $scope, $locale);
+
+        parent::addFieldSorter($field, $direction, $locale, $scope);
+    }
+
+    /**
+     * Check if channel and value are valid
+     *
+     * @param string $locale
+     * @param string $scope
+     *
+     * @throws InvalidPropertyException
+     */
+    protected function checkLocaleAndScope($locale, $scope)
+    {
+        if (null === $locale) {
+            throw InvalidPropertyException::valueNotEmptyExpected('locale', static::class);
+        }
+
+        if (null === $scope) {
+            throw InvalidPropertyException::valueNotEmptyExpected('scope', static::class);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
@@ -14,30 +14,30 @@ class CompletenessSorter extends BaseFieldSorter
     /**
      * {@inheritdoc}
      */
-    public function addFieldSorter($field, $direction, $locale = null, $scope = null)
+    public function addFieldSorter($field, $direction, $locale = null, $channel = null)
     {
-        $this->checkLocaleAndScope($locale, $scope);
+        $this->checkLocaleAndChannel($locale, $channel);
 
-        $field .= sprintf('.%s.%s', $scope, $locale);
+        $field .= sprintf('.%s.%s', $channel, $locale);
 
-        parent::addFieldSorter($field, $direction, $locale, $scope);
+        parent::addFieldSorter($field, $direction, $locale, $channel);
     }
 
     /**
      * Check if channel and value are valid
      *
      * @param string $locale
-     * @param string $scope
+     * @param string $channel
      *
      * @throws InvalidPropertyException
      */
-    protected function checkLocaleAndScope($locale, $scope)
+    protected function checkLocaleAndChannel($locale, $channel)
     {
         if (null === $locale) {
             throw InvalidPropertyException::valueNotEmptyExpected('locale', static::class);
         }
 
-        if (null === $scope) {
+        if (null === $channel) {
             throw InvalidPropertyException::valueNotEmptyExpected('scope', static::class);
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -25,14 +25,15 @@ parameters:
     pim_catalog.query.elasticsearch.filter.text.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextFilter
     pim_catalog.query.elasticsearch.filter.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextAreaFilter
     pim_catalog.query.elasticsearch.filter.option.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter
-    pim_catalog.query.elasticsearch.filter.options.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionsFilter
     pim_catalog.query.elasticsearch.filter.price.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\PriceFilter
     pim_catalog.query.elasticsearch.filter.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MetricFilter
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
     pim_catalog.query.elasticsearch.filter.boolean.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter
+
     pim_catalog.query.elasticsearch.sorter.base_field.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseFieldSorter
     pim_catalog.query.elasticsearch.sorter.attribute.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter
     pim_catalog.query.elasticsearch.sorter.attribute.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter
+    pim_catalog.query.elasticsearch.sorter.completeness.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\CompletenessSorter
 
 services:
     pim_catalog.query.product_query_builder_factory:
@@ -294,5 +295,12 @@ services:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
         arguments:
             - ['pim_catalog_metric']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.completeness:
+        class: '%pim_catalog.query.elasticsearch.sorter.completeness.class%'
+        arguments:
+            - ['completeness']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/CompletenessSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/CompletenessSorterSpec.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Sorter;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\CompletenessSorter;
+use Pim\Component\Catalog\Exception\InvalidDirectionException;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
+
+class CompletenessSorterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['completeness']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CompletenessSorter::class);
+    }
+
+    function it_is_a_fieldSorter()
+    {
+        $this->shouldImplement(FieldSorterInterface::class);
+    }
+
+    function it_supports_fields()
+    {
+        $this->supportsField('completeness')->shouldReturn(true);
+        $this->supportsField('a_not_supported_field')->shouldReturn(false);
+    }
+
+    function it_add_ascending_sorter_with_field(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $sqb->addSort(
+            [
+                'completeness.mobile.en_US' => [
+                    "order"   => 'ASC',
+                    "missing" => "_last"
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldSorter('completeness', Directions::ASCENDING, 'en_US', 'mobile');
+    }
+
+    function it_add_descending_sorter_with_field(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $sqb->addSort(
+            [
+                'completeness.mobile.en_US' => [
+                    "order"   => 'DESC',
+                    "missing" => "_last"
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldSorter('completeness', Directions::DESCENDING, 'en_US', 'mobile');
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the sorter.')
+        )->during('addFieldSorter', ['completeness', Directions::ASCENDING, 'en_US', 'mobile']);
+    }
+
+    function it_throws_an_exception_when_the_directions_does_not_exist(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidDirectionException::notSupported(
+                'A_BAD_DIRECTION',
+                CompletenessSorter::class
+            )
+        )->during('addFieldSorter', ['completeness', 'A_BAD_DIRECTION', 'en_US', 'mobile']);
+    }
+
+    function it_throws_an_exception_when_locale_is_null(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::valueNotEmptyExpected(
+                'locale',
+                CompletenessSorter::class
+            )
+        )->during('addFieldSorter', ['completeness', 'A_BAD_DIRECTION', null, 'mobile']);
+    }
+
+    function it_throws_an_exception_when_scope_is_null(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyException::valueNotEmptyExpected(
+                'scope',
+                CompletenessSorter::class
+            )
+        )->during('addFieldSorter', ['completeness', 'A_BAD_DIRECTION', 'en_US', null]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -62,7 +62,7 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
     /**
      * @param array $filters
      *
-     * @return mixed
+     * @return CursorInterface
      */
     protected function executeFilter(array $filters)
     {
@@ -78,12 +78,13 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
 
     /**
      * @param array $sorters
+     * @param array $options
      *
-     * @return mixed
+     * @return CursorInterface
      */
-    protected function executeSorter(array $sorters)
+    protected function executeSorter(array $sorters, $options = [])
     {
-        $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create($options);
 
         foreach ($sorters as $sorter) {
             $context = isset($sorter[2]) ? $sorter[2] : [];

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -13,6 +13,8 @@ use Pim\Component\Catalog\Query\Filter\Operators;
 class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
+     * {@inheritdoc}
+     *
      * +-------------------------------------------------------------------------+
      * |               |   Ecommerce   |     Tablet            | Ecommerce China |
      * |               | fr_FR | en_US | fr_FR | en_US | de_DE | en_US | zh_CN   |

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -130,6 +130,7 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one', 'product_two']);
 
         $result = $this->executeFilter([['a_metric', Operators::GREATER_OR_EQUAL_THAN, ['amount' => 15000, 'unit' => 'WATT']]]);
+        $this->assert($result, ['product_two']);
     }
 
     public function testOperatorEmpty()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -165,9 +165,9 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
                 'values' => [
                     'a_metric' => [
                         [
-                            'data' => ['amount' => 15, 'unit' => 'WATT'],
+                            'data'   => ['amount' => 15, 'unit' => 'WATT'],
                             'locale' => null,
-                            'scope' => null,
+                            'scope'  => null,
                         ],
                     ],
                 ],
@@ -241,9 +241,9 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
                 'values' => [
                     'a_metric' => [
                         [
-                            'data' => ['amount' => 10, 'unit' => 'WATT'],
+                            'data'   => ['amount' => 10, 'unit' => 'WATT'],
                             'locale' => null,
-                            'scope' => null,
+                            'scope'  => null,
                         ],
                     ],
                 ],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSortDescendant()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::DESCENDING]],
+            ['default_locale' => 'en_US', 'default_scope' => 'tablet']
+        );
+        $this->assertOrder($result, ['product_two', 'product_three', 'product_one', 'empty_product', 'no_family']);
+    }
+
+    public function testSortAscendant()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::ASCENDING]],
+            ['default_locale' => 'en_US', 'default_scope' => 'tablet']
+        );
+        $this->assertOrder($result, ['empty_product', 'product_one', 'product_three', 'product_two', 'no_family']);
+    }
+
+    public function testSortDescendantWithLocale()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::DESCENDING, ['locale' => 'fr_FR']]],
+            ['default_locale' => 'en_US', 'default_scope' => 'tablet']
+        );
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product', 'no_family']);
+    }
+
+    public function testSortAscendantWithLocale()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::ASCENDING, ['locale' => 'fr_FR']]],
+            ['default_locale' => 'en_US', 'default_scope' => 'tablet']
+        );
+        $this->assertOrder($result, ['empty_product', 'product_one', 'product_two', 'product_three', 'no_family']);
+    }
+
+    public function testSortDescendantWithChannel()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::DESCENDING, ['scope' => 'tablet']]],
+            ['default_locale' => 'fr_FR', 'default_scope' => 'ecommerce']
+        );
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product', 'no_family']);
+    }
+
+    public function testSortAscendantWithChannel()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::ASCENDING, ['scope' => 'tablet']]],
+            ['default_locale' => 'fr_FR', 'default_scope' => 'ecommerce']
+        );
+        $this->assertOrder($result, ['empty_product', 'product_one', 'product_two', 'product_three', 'no_family']);
+    }
+
+    public function testSortDescendantWithLocaleAndChannel()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::DESCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]],
+            ['default_locale' => 'en_US', 'default_scope' => 'ecommerce']
+        );
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product', 'no_family']);
+    }
+
+    public function testSortAscendantWithLocaleAndChannel()
+    {
+        $result = $this->executeSorter(
+            [['completeness', Directions::ASCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]],
+            ['default_locale' => 'en_US', 'default_scope' => 'ecommerce']
+        );
+        $this->assertOrder($result, ['empty_product', 'product_one', 'product_two', 'product_three', 'no_family']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter(
+            [['completeness', 'A_BAD_DIRECTION']],
+            ['default_locale' => 'en_US', 'default_scope' => 'ecommerce']
+        );
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "locale" does not expect an empty value.
+     */
+    public function testErrorLocaleNotEmpty()
+    {
+        $this->executeSorter(
+            [['completeness', Directions::ASCENDING]],
+            ['default_scope' => 'ecommerce']
+        );
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "scope" does not expect an empty value.
+     */
+    public function testErrorScopeNotEmpty()
+    {
+        $this->executeSorter(
+            [['completeness', Directions::ASCENDING]],
+            ['default_locale' => 'en_US']
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * +-------------------------------------------------------------------------+
+     * |               |   Ecommerce   |     Tablet            | Ecommerce China |
+     * |               | fr_FR | en_US | fr_FR | en_US | de_DE | en_US | zh_CN   |
+     * +---------------+-------+-------+-------+---------------------------------+
+     * | empty_product |   -   |  33%  |  25%  | 25%   |  25%  | 100%  | 100%    |
+     * | product_one   |   -   |  66%  |  50%  | 50%   |  50%  | 100%  | 100%    |
+     * | product_two   |   -   |  66%  |  100% | 100%  |  75%  | 100%  | 100%    |
+     * | product_three |   -   |  66%  |  75%  | 75%   |  75%  | 100%  | 100%    |
+     * | no_family     |   -   |  -    |   -   |   -   |   -   |   -   |   -     |
+     * +-------------------------------------------------------------------------+
+     *
+     * Notes:
+     *      - completeness is not calculated for ecommerce-fr_FR because locale is not activated for this channel
+     *      - "Ecommerce China" is complete because this channel requires only the "sku"
+     *      - completeness is not calculated on "no_family" has it has obviously no family
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $family = $this->get('pim_catalog.factory.family')->create();
+            $this->get('pim_catalog.updater.family')->update($family, [
+                'code'                   => 'familyB',
+                'attributes'             => [
+                    'sku',
+                    'a_metric',
+                    'a_localized_and_scopable_text_area',
+                    'a_scopable_price',
+                ],
+                'attribute_requirements' => [
+                    'tablet'    => ['sku', 'a_metric', 'a_localized_and_scopable_text_area', 'a_scopable_price'],
+                    'ecommerce' => ['sku', 'a_metric', 'a_scopable_price'],
+                ],
+            ]);
+            $this->get('pim_catalog.saver.family')->save($family);
+
+            $this->createProduct('product_one', [
+                'family' => 'familyB',
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'data' => ['amount' => 15, 'unit' => 'WATT'],
+                            'locale' => null,
+                            'scope' => null,
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'family' => 'familyB',
+                'values' => [
+                    'a_metric'                           => [
+                        [
+                            'data'   => ['amount' => 15, 'unit' => 'WATT'],
+                            'locale' => null,
+                            'scope'  => null,
+                        ],
+                    ],
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'data'   => 'text',
+                            'locale' => 'en_US',
+                            'scope'  => 'tablet',
+                        ],
+                    ],
+                    'a_scopable_price'                   => [
+                        [
+                            'data'   => [
+                                ['amount' => 15, 'currency' => 'EUR'],
+                                ['amount' => 15.5, 'currency' => 'USD'],
+                            ],
+                            'locale' => null,
+                            'scope'  => 'tablet',
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_three', [
+                'family' => 'familyB',
+                'values' => [
+                    'a_metric'                           => [
+                        [
+                            'data'   => ['amount' => 15, 'unit' => 'WATT'],
+                            'locale' => null,
+                            'scope'  => null,
+                        ],
+                    ],
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'data'   => 'text',
+                            'locale' => 'fr_FR',
+                            'scope'  => 'tablet',
+                        ],
+                    ],
+                    'a_scopable_price'                   => [
+                        [
+                            'data'   => [
+                                ['amount' => 15, 'currency' => 'EUR'],
+                                ['amount' => 15.5, 'currency' => 'USD'],
+                            ],
+                            'locale' => null,
+                            'scope'  => 'tablet',
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', [
+                'family' => 'familyB',
+            ]);
+
+            $this->createProduct('no_family', [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'data' => ['amount' => 10, 'unit' => 'WATT'],
+                            'locale' => null,
+                            'scope' => null,
+                        ],
+                    ],
+                ],
+            ]);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/DateTimeSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/DateTimeSorterIntegration.php
@@ -10,7 +10,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class BaseSorterDateTimeIntegration extends AbstractProductQueryBuilderTestCase
+class DateTimeSorterIntegration extends AbstractProductQueryBuilderTestCase
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/DateTimeSorterWithDifferentTimezoneIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/DateTimeSorterWithDifferentTimezoneIntegration.php
@@ -10,7 +10,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class BaseSorterDateTimeIntegration extends AbstractProductQueryBuilderTestCase
+class DateTimeSorterWithDifferentTimezoneIntegration extends AbstractProductQueryBuilderTestCase
 {
     public static $timezone;
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/FamilySorterIntegration.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
-use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**

--- a/src/Pim/Component/Catalog/Query/Filter/AttributeFilterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Filter/AttributeFilterInterface.php
@@ -20,7 +20,7 @@ interface AttributeFilterInterface extends FilterInterface
      * @param string             $operator  the used operator
      * @param string|array       $value     the value(s) to filter
      * @param string             $locale    the locale
-     * @param string             $scope     the scope
+     * @param string             $channel   the channel
      * @param array              $options   the filter options
      *
      * @return AttributeFilterInterface
@@ -30,7 +30,7 @@ interface AttributeFilterInterface extends FilterInterface
         $operator,
         $value,
         $locale = null,
-        $scope = null,
+        $channel = null,
         $options = []
     );
 

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
@@ -20,14 +20,14 @@ interface FieldFilterInterface extends FilterInterface
      * @param string       $operator the used operator
      * @param string|array $value    the value(s) to filter
      * @param string       $locale   the locale
-     * @param string       $scope    the scope
+     * @param string       $channel  the channel
      * @param array        $options  the filter options
      *
      * @throws PropertyException
      *
      * @return FieldFilterInterface
      */
-    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = []);
+    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = []);
 
     /**
      * This filter supports the field

--- a/src/Pim/Component/Catalog/Query/Filter/FilterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FilterInterface.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Query\Filter;
 
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+
 /**
  * Filter interface
  *
@@ -14,7 +16,7 @@ interface FilterInterface
     /**
      * Inject the query builder
      *
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\ODM\MongoDB\Query\Builder $queryBuilder
+     * @param SearchQueryBuilder $queryBuilder
      */
     public function setQueryBuilder($queryBuilder);
 

--- a/src/Pim/Component/Catalog/Query/ProductQueryBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Query/ProductQueryBuilderInterface.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Query;
 
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
 
 /**
  * Aims to customize a query builder to add useful shortcuts which allow to easily select, filter or sort a product
@@ -53,14 +54,14 @@ interface ProductQueryBuilderInterface
      *
      * @throws \LogicException in case the query builder has not been configured
      *
-     * @return \Doctrine\ORM\QueryBuilder|\Doctrine\ODM\MongoDB\Query\Builder
+     * @return SearchQueryBuilder
      */
     public function getQueryBuilder();
 
     /**
      * Set query builder
      *
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\ODM\MongoDB\Query\Builder $queryBuilder
+     * @param SearchQueryBuilder
      *
      * @return ProductQueryBuilderInterface
      */

--- a/src/Pim/Component/Catalog/Query/Sorter/AttributeSorterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Sorter/AttributeSorterInterface.php
@@ -19,11 +19,11 @@ interface AttributeSorterInterface extends SorterInterface
      * @param AttributeInterface $attribute the attribute to sort on
      * @param string             $direction the direction to use
      * @param string             $locale    the locale
-     * @param string             $scope     the scope
+     * @param string             $channel   the channel
      *
      * @return AttributeSorterInterface
      */
-    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $scope = null);
+    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $channel = null);
 
     /**
      * This filter supports the attribute

--- a/src/Pim/Component/Catalog/Query/Sorter/FieldSorterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Sorter/FieldSorterInterface.php
@@ -17,11 +17,11 @@ interface FieldSorterInterface extends SorterInterface
      * @param string $field     the field to sort on
      * @param string $direction the direction to use
      * @param string $locale    the locale
-     * @param string $scope     the scope
+     * @param string $channel   the channel
      *
      * @return FieldSorterInterface
      */
-    public function addFieldSorter($field, $direction, $locale = null, $scope = null);
+    public function addFieldSorter($field, $direction, $locale = null, $channel = null);
 
     /**
      * This filter supports the field

--- a/src/Pim/Component/Catalog/Query/Sorter/SorterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Sorter/SorterInterface.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Query\Sorter;
 
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+
 /**
  * Sorter interface
  *
@@ -14,7 +16,7 @@ interface SorterInterface
     /**
      * Inject the query builder
      *
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\ODM\MongoDB\Query\Builder $queryBuilder
+     * @param SearchQueryBuilder $queryBuilder
      */
     public function setQueryBuilder($queryBuilder);
 }


### PR DESCRIPTION
## Description

This PR adds a PQB completeness sorter using Elasticsearch.

## Checklist

- [x] Add sorter integration tests for the field in the PQB
- [ ] Add missing integration to the PimCatalogXIntegration tests for sort
- [x] Add the sorter + specs
- [x] Update the reference documentation

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
