### PR TITLE
TIP-706: Add Text area sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -18,8 +18,6 @@ use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
  */
 class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    const PREPROCESSED_FIELD = 'preprocessed';
-
     /**
      * @param AttributeValidatorHelper $attrValidatorHelper
      * @param array                    $supportedAttributeTypes
@@ -61,7 +59,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
 
         switch ($operator) {
             case Operators::STARTS_WITH:
-                $attributePath .= '.' . self::PREPROCESSED_FIELD;
+                $attributePath .= '.preprocessed';
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -72,7 +70,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::CONTAINS:
-                $attributePath .= '.' . self::PREPROCESSED_FIELD;
+                $attributePath .= '.preprocessed';
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -83,7 +81,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::DOES_NOT_CONTAIN:
-                $attributePath .= '.' . self::PREPROCESSED_FIELD;
+                $attributePath .= '.preprocessed';
                 $mustNotClause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -100,7 +98,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::EQUALS:
-                $attributePath .= '.' . self::PREPROCESSED_FIELD;
+                $attributePath .= '.preprocessed';
                 $clause = [
                     'term' => [
                         $attributePath => $value,
@@ -110,7 +108,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::NOT_EQUAL:
-                $attributePath .= '.' . self::PREPROCESSED_FIELD;
+                $attributePath .= '.preprocessed';
                 $mustNotClause = [
                     'term' => [
                         $attributePath => $value,

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -18,6 +18,8 @@ use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
  */
 class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
+    const PREPROCESSED_FIELD = 'preprocessed';
+
     /**
      * @param AttributeValidatorHelper $attrValidatorHelper
      * @param array                    $supportedAttributeTypes
@@ -59,7 +61,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
 
         switch ($operator) {
             case Operators::STARTS_WITH:
-                $attributePath .= '.raw';
+                $attributePath .= '.' . self::PREPROCESSED_FIELD;
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -70,7 +72,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::CONTAINS:
-                $attributePath .= '.raw';
+                $attributePath .= '.' . self::PREPROCESSED_FIELD;
                 $clause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -81,7 +83,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::DOES_NOT_CONTAIN:
-                $attributePath .= '.raw';
+                $attributePath .= '.' . self::PREPROCESSED_FIELD;
                 $mustNotClause = [
                     'query_string' => [
                         'default_field' => $attributePath,
@@ -98,7 +100,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::EQUALS:
-                $attributePath .= '.raw';
+                $attributePath .= '.' . self::PREPROCESSED_FIELD;
                 $clause = [
                     'term' => [
                         $attributePath => $value,
@@ -108,7 +110,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 break;
 
             case Operators::NOT_EQUAL:
-                $attributePath .= '.raw';
+                $attributePath .= '.' . self::PREPROCESSED_FIELD;
                 $mustNotClause = [
                     'term' => [
                         $attributePath => $value,

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -145,7 +145,7 @@ In this case, the sort becomes:
 .. code-block:: php
 
     'sort' => [
-        'name-text.<all_channels>.<all_locales>.raw' => 'asc'
+        'name-text.<all_channels>.<all_locales>.preprocessed' => 'asc'
     ]
 
 Text area
@@ -188,7 +188,7 @@ STARTS WITH
 
     'filter' => [
         'query_string' => [
-            'default_field' => 'values.description-text.<all_channels>.<all_locales>.raw',
+            'default_field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed',
             'query' => "My*"
         ]
     ]
@@ -202,7 +202,7 @@ Example:
 
     'filter' => [
         'query_string' => [
-            'default_field' => 'values.description-text.<all_channels>.<all_locales>.raw',
+            'default_field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed',
             'query' => 'My\\ description*'
         ]
     ]
@@ -216,7 +216,7 @@ CONTAINS
 
     'filter' => [
         'query_string' => [
-            'default_field' => 'values.description-text.<all_channels>.<all_locales>.raw',
+            'default_field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed',
             'query' => '*cool\\ product*'
         ]
     ]
@@ -232,12 +232,12 @@ Same syntax than the ``contains`` but must be included in a ``must_not`` boolean
     'bool' => [
         'must_not' => [
             'query_string' => [
-                'default_field' => 'values.description-text.<all_channels>.<all_locales>.raw',
+                'default_field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed',
                 'query' => '*cool\\ product*'
             ]
         ],
         'filter' => [
-            'exists' => ['field' => 'values.description-text.<all_channels>.<all_locales>.raw'
+            'exists' => ['field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed'
         ]
     ]
 
@@ -252,7 +252,7 @@ Equals (=)
 
     'filter' => [
         'term' => [
-            'values.description-text.<all_channels>.<all_locales>.raw' => 'My full lookup text'
+            'values.description-text.<all_channels>.<all_locales>.preprocessed' => 'My full lookup text'
         ]
     ]
 
@@ -267,12 +267,12 @@ Not Equals (!=)
 
     'must_not' => [
         'term' => [
-            'values.description-text.<all_channels>.<all_locales>.raw' => 'My full lookup text'
+            'values.description-text.<all_channels>.<all_locales>.preprocessed' => 'My full lookup text'
         ]
     ],
     'filter' => [
         'exists' => [
-            'field' => 'values.description-text.<all_channels>.<all_locales>.raw'
+            'field' => 'values.description-text.<all_channels>.<all_locales>.preprocessed'
         ]
     ]
 
@@ -295,6 +295,38 @@ NOT EMPTY
     'filter' => [
         'exists => [
             'field' => 'values.description-text.<all_channels>.<all_locales>'
+        ]
+    ]
+
+Sorting
+~~~~~~~
+
+The sorting operation is made on the preprocessed version of the text.
+
+Operators
+.........
+ASCENDANT
+"""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.description-text.<all_channels>.<all_locales>.preprocessed' => [
+            'order' => 'ASC',
+            'missing' => '_last'
+        ]
+    ]
+
+
+DESCENDANT
+""""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.description-text.<all_channels>.<all_locales>.preprocessed' => [
+            'order' => 'DESC',
+            'missing' => '_last'
         ]
     ]
 
@@ -369,7 +401,7 @@ Filtering
 ~~~~~~~~~
 Operators
 .........
-All operators except CONTAINS and DOES NOT CONTAINS are the same than with the text_area attributes but apply on the field directly instead of the ``.raw`` subfield.
+All operators except CONTAINS and DOES NOT CONTAINS are the same than with the text_area attributes but apply on the field directly instead of the ``.preprocessed`` subfield.
 
 CONTAINS
 """"""""

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/TextAreaSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attributes/TextAreaSorter.php
@@ -3,19 +3,19 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
 
 /**
- * Metric sorter for an Elastic search query
+ * Text area sorter for an Elastic search query
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MetricSorter extends AbstractAttributeSorter
+class TextAreaSorter extends AbstractAttributeSorter
 {
     /**
      * {@inheritdoc}
      */
     protected function getAttributePathSuffix()
     {
-        return 'base_data';
+        return 'preprocessed';
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -33,6 +33,7 @@ parameters:
     pim_catalog.query.elasticsearch.sorter.base_field.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\BaseFieldSorter
     pim_catalog.query.elasticsearch.sorter.attribute.base.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\BaseAttributeSorter
     pim_catalog.query.elasticsearch.sorter.attribute.metric.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\MetricSorter
+    pim_catalog.query.elasticsearch.sorter.attribute.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\TextAreaSorter
     pim_catalog.query.elasticsearch.sorter.completeness.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\CompletenessSorter
 
 services:
@@ -302,5 +303,12 @@ services:
         class: '%pim_catalog.query.elasticsearch.sorter.completeness.class%'
         arguments:
             - ['completeness']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.text_area:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.text_area.class%'
+        arguments:
+            - ['pim_catalog_textarea']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -20,7 +20,7 @@ mappings:
                     match_mapping_type: 'string'
                     mapping:
                         fields:
-                            raw:
+                            preprocessed:
                                 type: 'keyword'
                                 normalizer: 'text_normalizer'
                         type: 'text'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
@@ -66,7 +66,7 @@ class TextAreaFilterSpec extends ObjectBehavior
         $sqb->addFilter(
             [
                 'term' => [
-                    'values.name-varchar.ecommerce.en_US.raw' => 'Sony',
+                    'values.name-varchar.ecommerce.en_US.preprocessed' => 'Sony',
                 ],
             ]
         )->shouldBeCalled();
@@ -89,14 +89,14 @@ class TextAreaFilterSpec extends ObjectBehavior
         $sqb->addMustNot(
             [
                 'term' => [
-                    'values.name-varchar.ecommerce.en_US.raw' => 'Sony',
+                    'values.name-varchar.ecommerce.en_US.preprocessed' => 'Sony',
                 ],
             ]
         )->shouldBeCalled();
 
         $sqb->addFilter(
             [
-                'exists' => ['field' => 'values.name-varchar.ecommerce.en_US.raw'],
+                'exists' => ['field' => 'values.name-varchar.ecommerce.en_US.preprocessed'],
             ]
         )->shouldBeCalled();
 
@@ -164,7 +164,7 @@ class TextAreaFilterSpec extends ObjectBehavior
         $sqb->addFilter(
             [
                 'query_string' => [
-                    'default_field' => 'values.name-varchar.ecommerce.en_US.raw',
+                    'default_field' => 'values.name-varchar.ecommerce.en_US.preprocessed',
                     'query'         => '*sony*',
                 ],
             ]
@@ -188,7 +188,7 @@ class TextAreaFilterSpec extends ObjectBehavior
         $sqb->addMustNot(
             [
                 'query_string' => [
-                    'default_field' => 'values.name-varchar.ecommerce.en_US.raw',
+                    'default_field' => 'values.name-varchar.ecommerce.en_US.preprocessed',
                     'query'         => '*sony*',
                 ],
             ]
@@ -196,7 +196,7 @@ class TextAreaFilterSpec extends ObjectBehavior
 
         $sqb->addFilter([
                 'exists' => [
-                    'field' => 'values.name-varchar.ecommerce.en_US.raw',
+                    'field' => 'values.name-varchar.ecommerce.en_US.preprocessed',
                 ],
             ]
         )->shouldBeCalled();
@@ -219,7 +219,7 @@ class TextAreaFilterSpec extends ObjectBehavior
         $sqb->addFilter(
             [
                 'query_string' => [
-                    'default_field' => 'values.name-varchar.ecommerce.en_US.raw',
+                    'default_field' => 'values.name-varchar.ecommerce.en_US.preprocessed',
                     'query'         => 'sony*',
                 ],
             ]

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attributes/TextAreaSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attributes/TextAreaSorterSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes;
+
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attributes\TextAreaSorter;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidDirectionException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+use Prophecy\Argument;
+
+class TextAreaSorterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['pim_catalog_textarea']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TextAreaSorter::class);
+    }
+
+    function it_is_an_attribute_sorter()
+    {
+        $this->shouldImplement(AttributeSorterInterface::class);
+    }
+
+    function it_adds_a_sorter_with_operator_ascendant_no_locale_and_no_scope(
+        AttributeInterface $aTextArea,
+        SearchQueryBuilder $sqb
+    ) {
+        $aTextArea->getCode()->willReturn('a_text_area');
+        $aTextArea->getBackendType()->willReturn('text');
+        $sqb->addSort([
+            'values.a_text_area-text.<all_channels>.<all_locales>.preprocessed' => [
+                'order' => 'ASC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aTextArea, DIRECTIONS::ASCENDING, null, null);
+    }
+
+    function it_adds_a_sorter_with_operator_ascendant_locale_and_scope(
+        AttributeInterface $aTextArea,
+        SearchQueryBuilder $sqb
+    ) {
+        $aTextArea->getCode()->willReturn('a_text_area');
+        $aTextArea->getBackendType()->willReturn('text');
+
+        $sqb->addSort([
+            'values.a_text_area-text.ecommerce.fr_FR.preprocessed' => [
+                'order' => 'ASC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aTextArea, DIRECTIONS::ASCENDING, 'fr_FR', 'ecommerce');
+    }
+
+    function it_adds_a_sorter_with_operator_descendant_locale_and_scope(
+        AttributeInterface $aTextArea,
+        SearchQueryBuilder $sqb
+    ) {
+        $aTextArea->getCode()->willReturn('a_text_area');
+        $aTextArea->getBackendType()->willReturn('text');
+
+        $sqb->addSort([
+            'values.a_text_area-text.ecommerce.fr_FR.preprocessed' => [
+                'order' => 'DESC',
+                'missing' => '_last'
+            ]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeSorter($aTextArea, DIRECTIONS::DESCENDING, 'fr_FR', 'ecommerce');
+    }
+
+    function it_supports_only_text_area_attribute(
+        AttributeInterface $aTextArea,
+        AttributeInterface $aPrice
+    ) {
+        $aTextArea->getType()->willReturn('pim_catalog_textarea');
+        $aPrice->getType()->willReturn('pim_catalog_price');
+
+        $this->supportsAttribute($aTextArea)->shouldReturn(true);
+        $this->supportsAttribute($aPrice)->shouldReturn(false);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(
+        AttributeInterface $aTextArea
+    ) {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the sorter.')
+        )->during('addAttributeSorter', [$aTextArea, Directions::ASCENDING]);
+    }
+
+    function it_throws_an_exception_when_the_directions_does_not_exist(
+        AttributeInterface $aTextArea,
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidDirectionException::notSupported(
+                'A_BAD_DIRECTION',
+                TextAreaSorter::class
+            )
+        )->during('addAttributeSorter', [$aTextArea, 'A_BAD_DIRECTION']);
+    }
+
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter\TextArea;
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/TextArea/ScopableFilterIntegration.php
@@ -5,7 +5,6 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter\TextArea;
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\TextArea;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Text area sorter integration tests for localizable and scopable attribute
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_scopable_text_area',
+                'type'                => AttributeTypes::TEXTAREA,
+                'localizable'         => true,
+                'scopable'            => true,
+            ]);
+
+            $this->createProduct('cat', [
+                'values' => [
+                    'a_localizable_scopable_text_area' => [
+                        ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
+                        ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                        ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('cattle', [
+                'values' => [
+                    'a_localizable_scopable_text_area' => [
+                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
+                        ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                        ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('dog', [
+                'values' => [
+                    'a_localizable_scopable_text_area' => [
+                        ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
+                        ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                        ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::ASCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['cattle', 'cat', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::ASCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::DESCENDING, ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+        $this->assertOrder($result, ['dog', 'cat', 'cattle', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::DESCENDING, ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['dog', 'cattle', 'cat', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_scopable_text_area', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/LocalizableSorterIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\TextArea;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Text area sorter integration tests for localizable attribute
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'        => 'a_localizable_text_area',
+                'type'        => AttributeTypes::TEXTAREA,
+                'localizable' => true,
+                'scopable'    => false,
+            ]);
+
+            $this->createProduct('cat', [
+                'values' => [
+                    'a_localizable_text_area' => [
+                        ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'chat <b>noir</b>', 'locale' => 'fr_FR', 'scope' => null],
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('cattle', [
+                'values' => [
+                    'a_localizable_text_area' => [
+                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => '<h1>cattle</h1>', 'locale' => 'fr_FR', 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('dog', [
+                'values' => [
+                    'a_localizable_text_area' => [
+                        ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
+                        ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['cattle', 'cat', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::ASCENDING, ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::DESCENDING,  ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['dog', 'cat', 'cattle', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::DESCENDING,  ['locale' => 'en_US']]]);
+        $this->assertOrder($result, ['dog', 'cattle', 'cat', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_text_area', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/ScopableSorterIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\TextArea;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Text area sorter integration tests for scopable attribute
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_scopable_text_area',
+                'type'                => AttributeTypes::TEXTAREA,
+                'localizable'         => false,
+                'scopable'            => true,
+            ]);
+
+            $this->createProduct('cat', [
+                'values' => [
+                    'a_scopable_text_area' => [
+                        ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'red cat', 'locale' => null, 'scope' => 'tablet'],
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('cattle', [
+                'values' => [
+                    'a_scopable_text_area' => [
+                        ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('dog', [
+                'values' => [
+                    'a_scopable_text_area' => [
+                        ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
+                        ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::ASCENDING, ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['cattle', 'dog', 'cat', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::DESCENDING,  ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['dog', 'cattle', 'cat', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::DESCENDING,  ['scope' => 'tablet']]]);
+        $this->assertOrder($result, ['cat', 'dog', 'cattle', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_scopable_text_area', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/TextAreaSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/TextAreaSorterIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\TextArea;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Text area sorter integration tests
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TextAreaSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /** @var string Test newlines in TextArea data */
+    private $superDog = "my dog
+ is the best";
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('cat', [
+                'values' => [
+                    'a_text_area' => [['data' => 'cat', 'locale' => null, 'scope' => null]],
+                ],
+            ]);
+
+
+            $this->createProduct('best_cat', [
+                'values' => [
+                    'a_text_area' => [
+                        [
+                            'data'   => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
+                            'locale' => null,
+                            'scope'  => null,
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('super_dog', [
+                'values' => [
+                    'a_text_area' => [
+                        [
+                            'data'   => $this->superDog,
+                            'locale' => null,
+                            'scope'  => null,
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('best_dog', [
+                'values' => [
+                    'a_text_area' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_text_area', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['cat', 'best_cat', 'super_dog', 'best_dog', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_text_area', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['best_dog', 'super_dog', 'best_cat', 'cat', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_text_area', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/TextAreaSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Attributes/TextArea/TextAreaSorterIntegration.php
@@ -32,7 +32,6 @@ class TextAreaSorterIntegration extends AbstractProductQueryBuilderTestCase
                 ],
             ]);
 
-
             $this->createProduct('best_cat', [
                 'values' => [
                     'a_text_area' => [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Renames the '.raw' dynamic field to 'preprocessed' and updates the filter in consequence
- Adds the TextArea sorter

**ES Sorter Checklist:**
- [X] Add sorter integration tests for the field in the PQB
- [X] Add missing integration to the PimCatalogXIntegration tests for sort
- [x] Add the sorter + specs
- [X] Update the reference documentation

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
