### PR TITLE
TIP-706: Add PQB "is associated" sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1242,7 +1242,6 @@ NOT IN
         ]
     ]
 
-
 Sorting
 ~~~~~~~
 Not supported on that attribute_type
@@ -1799,17 +1798,28 @@ when they belong to this particular list:
 
 Associations
 ************
+
+Data model
+~~~~~~~~~~
+.. code-block:: yaml
+
+    is_associated: true
+
 Filtering
 ~~~~~~~~~
 No filtering expected on associations (no filter on the grid).
 
 Sorting
 ~~~~~~~
+.. code-block:: php
 
-::
-
-  TODO see function score to put product belonging to the associations at first and sort by relevancy
+    sort => [
+        'is_associated' => [
+            'order'   => 'asc',
+            'missing' => '_last',
+        ]
+    ]
 
 Testing
 -------
-All queries above are (or should be) defined as Behat scenarios in the `queries_test` directory relative to this documentation.
+All queries above are (or should be) defined as integration tests under the namespace `Pim\Bundle\CatalogBundle\tests\integration\PQB`.

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/CompletenessSorter.php
@@ -5,6 +5,12 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Sorter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 
 /**
+ * Sorts products by completeness, for a provided locale and channel (it is not
+ * possible to sort without).
+ *
+ * Product without completeness (meaning without family) are always last, no
+ * matter they are sorted ascending or descending.
+ *
  * @author    Damien Carcel (damien.carcel@akeneo.com)
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -291,16 +291,24 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
-    pim_catalog.query.elasticsearch.sorter.metric:
-        class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
-        arguments:
-            - ['pim_catalog_metric']
-        tags:
-            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
-
     pim_catalog.query.elasticsearch.sorter.completeness:
         class: '%pim_catalog.query.elasticsearch.sorter.completeness.class%'
         arguments:
             - ['completeness']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.is_associated:
+        class: '%pim_catalog.query.elasticsearch.sorter.base_field.class%'
+        arguments:
+            - ['is_associated']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    # Attributes sorters
+    pim_catalog.query.elasticsearch.sorter.metric:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
+        arguments:
+            - ['pim_catalog_metric']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -10,6 +10,8 @@ mappings:
                 type: 'boolean'
             groups:
                 type: 'keyword'
+            is_associated:
+                type: 'boolean'
             identifier:
                 type: 'keyword'
                 normalizer: 'varchar_normalizer'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\PQB;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -27,12 +28,25 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
     /**
      * @param string $identifier
      * @param array  $data
+     *
+     * @return ProductInterface
      */
     protected function createProduct($identifier, array $data)
     {
         $family = isset($data['family']) ? $data['family'] : null;
 
         $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $family);
+        $this->updateProduct($product, $data);
+
+        return $product;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param array            $data
+     */
+    protected function updateProduct(ProductInterface $product, array $data)
+    {
         $this->get('pim_catalog.updater.product')->update($product, $data);
         $this->get('pim_catalog.saver.product')->save($product);
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/IsAssociatedSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/IsAssociatedSorterIntegration.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class IsAssociatedSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSortDescendant()
+    {
+        $result = $this->executeSorter([['is_associated', Directions::DESCENDING]]);
+        $this->assertOrder($result, [
+            'foo_bar',
+            'foo_bar_baz',
+            'foo_baz',
+            'foo_group_A',
+            'foo_group_B',
+            'foo_groups_AB',
+            'bar',
+            'baz',
+            'foo',
+        ]);
+    }
+
+    public function testSortAscendant()
+    {
+        $result = $this->executeSorter([['is_associated', Directions::ASCENDING]]);
+        $this->assertOrder($result, [
+            'bar',
+            'baz',
+            'foo',
+            'foo_bar',
+            'foo_bar_baz',
+            'foo_baz',
+            'foo_group_A',
+            'foo_group_B',
+            'foo_groups_AB',
+        ]);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['is_associated', 'A_BAD_DIRECTION']]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('foo', []);
+            $this->createProduct('bar', ['groups' => ['groupA']]);
+            $this->createProduct('baz', ['groups' => ['groupB']]);
+
+            $fooBar = $this->createProduct('foo_bar', []);
+            $fooBaz = $this->createProduct('foo_baz', []);
+            $fooBarBaz = $this->createProduct('foo_bar_baz', []);
+            $fooGroupA = $this->createProduct('foo_group_A', []);
+            $fooGroupB = $this->createProduct('foo_group_B', []);
+            $fooGroupsAB = $this->createProduct('foo_groups_AB', []);
+
+            $this->updateProduct($fooBar, [
+                'associations' => [
+                    'PACK' => [
+                        'groups'   => [],
+                        'products' => ['bar'],
+                    ],
+                ],
+            ]);
+
+            $this->updateProduct($fooBaz, [
+                'associations' => [
+                    'PACK' => [
+                        'groups'   => [],
+                        'products' => ['baz'],
+                    ],
+                ],
+            ]);
+
+            $this->updateProduct($fooBarBaz, [
+                'associations' => [
+                    'SUBSTITUTION' => [
+                        'groups'   => [],
+                        'products' => ['bar', 'baz'],
+                    ],
+                ],
+            ]);
+
+            $this->updateProduct($fooGroupA, [
+                'associations' => [
+                    'UPSELL' => [
+                        'groups'   => ['groupA'],
+                        'products' => [],
+                    ],
+                ],
+            ]);
+
+            $this->updateProduct($fooGroupB, [
+                'associations' => [
+                    'UPSELL' => [
+                        'groups'   => ['groupB'],
+                        'products' => [],
+                    ],
+                ],
+            ]);
+
+            $this->updateProduct($fooGroupsAB, [
+                'associations' => [
+                    'X_SELL' => [
+                        'groups'   => ['groupA', 'groupB'],
+                        'products' => [],
+                    ],
+                ],
+            ]);
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -161,7 +161,7 @@ interface ProductInterface extends
     /**
      * Get types of associations
      *
-     * @return AssociationInterface[]|Collection
+     * @return Collection
      */
     public function getAssociations();
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -31,8 +31,14 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data = [];
 
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $product->getIdentifier();
-        $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize($product->getCreated(), $format);
-        $data[StandardPropertiesNormalizer::FIELD_UPDATED] = $this->serializer->normalize($product->getUpdated(), $format);
+        $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
+            $product->getCreated(),
+            $format
+        );
+        $data[StandardPropertiesNormalizer::FIELD_UPDATED] = $this->serializer->normalize(
+            $product->getUpdated(),
+            $format
+        );
 
         $data[StandardPropertiesNormalizer::FIELD_FAMILY] = null !== $product->getFamily()
             ? $product->getFamily()->getCode() : null;
@@ -40,6 +46,9 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data[StandardPropertiesNormalizer::FIELD_ENABLED] = (bool) $product->isEnabled();
         $data[StandardPropertiesNormalizer::FIELD_CATEGORIES] = $product->getCategoryCodes();
         $data[StandardPropertiesNormalizer::FIELD_GROUPS] = $product->getGroupCodes();
+
+        $data[StandardPropertiesNormalizer::FIELD_IS_ASSOCIATED] = !$product->getAssociations()->isEmpty()
+            ? true : false;
 
         $data[self::FIELD_COMPLETENESS] = !$product->getCompletenesses()->isEmpty()
             ? $this->serializer->normalize($product->getCompletenesses(), 'indexing', $context) : [];

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
@@ -28,6 +28,7 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
     const FIELD_VALUES = 'values';
     const FIELD_CREATED = 'created';
     const FIELD_UPDATED = 'updated';
+    const FIELD_IS_ASSOCIATED = 'is_associated';
 
     /** @var CollectionFilterInterface */
     private $filter;

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -37,7 +36,8 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer,
         ProductInterface $product,
         ProductValueCollectionInterface $productValueCollection,
-        Collection $completenesses
+        Collection $completenesses,
+        Collection $associations
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -57,20 +57,24 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $product->getCategoryCodes()->willReturn([]);
         $productValueCollection->isEmpty()->willReturn(true);
 
+        $product->getAssociations()->willReturn($associations);
+        $associations->isEmpty()->willReturn(true);
+
         $product->getCompletenesses()->willReturn($completenesses);
         $completenesses->isEmpty()->willReturn(true);
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
-                'identifier' => 'sku-001',
-                'created'    => $now->format('c'),
-                'updated'    => $now->format('c'),
-                'family'     => null,
-                'enabled'    => false,
-                'categories' => [],
-                'groups'     => [],
-                'completeness' => [],
-                'values'     => [],
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family'        => null,
+                'enabled'       => false,
+                'categories'    => [],
+                'groups'        => [],
+                'is_associated' => false,
+                'completeness'  => [],
+                'values'        => [],
             ]
         );
     }
@@ -79,7 +83,8 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer,
         ProductInterface $product,
         ProductValueCollectionInterface $productValueCollection,
-        Collection $completenesses
+        Collection $completenesses,
+        Collection $associations
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -104,6 +109,9 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $product->getCategoryCodes()->willReturn([]);
         $productValueCollection->isEmpty()->willReturn(true);
 
+        $product->getAssociations()->willReturn($associations);
+        $associations->isEmpty()->willReturn(true);
+
         $product->getCompletenesses()->willReturn($completenesses);
         $completenesses->isEmpty()->willReturn(false);
 
@@ -111,15 +119,16 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
-                'identifier' => 'sku-001',
-                'created'    => $now->format('c'),
-                'updated'    => $now->format('c'),
-                'family'     => null,
-                'enabled'    => false,
-                'categories' => [],
-                'groups'     => [],
-                'completeness' => ['the completenesses'],
-                'values'     => [],
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family'        => null,
+                'enabled'       => false,
+                'categories'    => [],
+                'groups'        => [],
+                'is_associated' => false,
+                'completeness'  => ['the completenesses'],
+                'values'        => [],
             ]
         );
     }
@@ -129,7 +138,8 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         ProductInterface $product,
         ProductValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
-        ArrayCollection $completenessCollection
+        Collection $completenessCollection,
+        Collection $associations
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -157,6 +167,9 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'second_category',
             ]
         );
+
+        $product->getAssociations()->willReturn($associations);
+        $associations->isEmpty()->willReturn(false);
 
         $completenessCollection->isEmpty()->willReturn(false);
         $product->getCompletenesses()->willReturn($completenessCollection);
@@ -188,21 +201,22 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
-                'identifier' => 'sku-001',
-                'created'    => $now->format('c'),
-                'updated'    => $now->format('c'),
-                'family'     => 'a_family',
-                'enabled'    => true,
-                'categories' => ['first_category', 'second_category'],
-                'groups'         => ['first_group', 'second_group'],
-                'completeness' => [
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family'        => 'a_family',
+                'enabled'       => true,
+                'categories'    => ['first_category', 'second_category'],
+                'groups'        => ['first_group', 'second_group'],
+                'is_associated' => true,
+                'completeness'  => [
                     'ecommerce' => [
                         'en_US' => [
                             66,
                         ],
                     ],
                 ],
-                'values'     => [
+                'values'        => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -31,15 +31,16 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'identifier'   => 'bar',
-            'created'      => $date->format('c'),
-            'updated'      => $date->format('c'),
-            'family'       => null,
-            'enabled'      => false,
-            'categories'   => [],
-            'groups'       => [],
-            'completeness' => [],
-            'values'       => [],
+            'identifier'    => 'bar',
+            'created'       => $date->format('c'),
+            'updated'       => $date->format('c'),
+            'family'        => null,
+            'enabled'       => false,
+            'categories'    => [],
+            'groups'        => [],
+            'is_associated' => false,
+            'completeness'  => [],
+            'values'        => [],
         ];
 
         $this->assertIndexingFormat('bar', $expected);
@@ -54,15 +55,16 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'identifier'   => 'baz',
-            'created'      => $date->format('c'),
-            'updated'      => $date->format('c'),
-            'family'       => null,
-            'enabled'      => true,
-            'categories'   => [],
-            'groups'       => [],
-            'completeness' => [],
-            'values'       => [],
+            'identifier'    => 'baz',
+            'created'       => $date->format('c'),
+            'updated'       => $date->format('c'),
+            'family'        => null,
+            'enabled'       => true,
+            'categories'    => [],
+            'groups'        => [],
+            'is_associated' => false,
+            'completeness'  => [],
+            'values'        => [],
         ];
 
         $this->assertIndexingFormat('baz', $expected);
@@ -77,18 +79,19 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'identifier'   => 'foo',
-            'created'      => $date->format('c'),
-            'updated'      => $date->format('c'),
-            'family'       => 'familyA',
-            'enabled'      => true,
-            'categories'   => ['categoryA1', 'categoryB'],
-            'groups'       => ['groupA', 'groupB', 'variantA'],
-            'completeness' => [
+            'identifier'    => 'foo',
+            'created'       => $date->format('c'),
+            'updated'       => $date->format('c'),
+            'family'        => 'familyA',
+            'enabled'       => true,
+            'categories'    => ['categoryA1', 'categoryB'],
+            'groups'        => ['groupA', 'groupB', 'variantA'],
+            'is_associated' => true,
+            'completeness'  => [
                 'ecommerce' => ['en_US' => 100],
                 'tablet'    => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100],
             ],
-            'values'       => [
+            'values'        => [
                 'a_date-date'                                    => [
                     '<all_channels>' => [
                         '<all_locales>' => '2016-06-13',


### PR DESCRIPTION
## Description

This PR adds a sorter on product associations.

## ES Sorter Checklist

- [x] Add sorter integration tests for the field in the PQB
- [ ] ~Add missing integration to the PimCatalogXIntegration tests for sort~ Not needed
- [x] Add the sorter + specs
- [x] Update the reference documentation

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
