### PR TITLE
TIP-706: Add reference data simple select sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1090,11 +1090,29 @@ Sorting
 ~~~~~~~
 Sorting will be done on the localized label:
 
+Operators
+.........
+ASCENDANT
+"""""""""
+
+
 .. code-block:: php
 
     'sort' => [
         'values.brand-reference_data_option.<all_channels>.<all_locales>' => [
             'order'   => 'asc',
+            'missing' => '_last'
+        ]
+    ]
+
+DESCENDANT
+""""""""""
+
+.. code-block:: php
+
+    'sort' => [
+        'values.brand-reference_data_option.<all_channels>.<all_locales>' => [
+            'order'   => 'desc',
             'missing' => '_last'
         ]
     ]

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/query_builders.yml
@@ -12,3 +12,10 @@ services:
             - ['IN', 'EMPTY', 'NOT EMPTY', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim.reference_data.query.sorter.attribute.reference_data:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
+        arguments:
+            - ['pim_reference_data_simpleselect']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
@@ -7,6 +7,8 @@ use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTe
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
+ * Sorter for reference data simple select attributes.
+ *
  * @author    Samir Boulil <samir.boulil@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\ReferenceDataBundle\tests\integration\PQB\Sorter\ReferenceData;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Samir Boulil <samir.boulil@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ReferenceDataSimpleSelectSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct(
+                'product_one',
+                [
+                    'values' => [
+                        'a_ref_data_simple_select' => [
+                            ['data' => 'acid-green', 'scope' => null, 'locale' => null],
+                        ],
+                    ],
+                ]
+            );
+
+            $this->createProduct(
+                'product_two',
+                [
+                    'values' => [
+                        'a_ref_data_simple_select' => [
+                            ['data' => 'blue', 'scope' => null, 'locale' => null],
+                        ],
+                    ],
+                ]
+            );
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+
+    public function testOperatorAscendant()
+    {
+        $result = $this->executeSorter([['a_ref_data_simple_select', Directions::ASCENDING]]);
+        $this->assert($result, ['product_one', 'product_two', 'empty_product']);
+    }
+
+    public function testOperatorDescendant()
+    {
+        $result = $this->executeSorter([['a_ref_data_simple_select', Directions::DESCENDING]]);
+        $this->assert($result, ['product_two', 'product_one', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_ref_data_simple_select', 'A_BAD_DIRECTION']]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath(), Configuration::getReferenceDataFixtures()],
+            false
+        );
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Defines a new sorter service in the referenceDataBundle that uses the BaseAttributeSorter class.

**ES Sorter Checklist:**
- [X] Add sorter integration tests for the field in the PQB
- [ ] Add missing integration to the PimCatalogXIntegration tests for sort
- [X] Add the sorter + specs
- [X] Update the reference documentation


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
