### PR TITLE
TIP-706: Add product status PQB sorter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -345,6 +345,18 @@ Not Equal (!=)
         ]
     ]
 
+Sorting
+~~~~~~~
+
+.. code-block:: php
+
+    'sort' => [
+        'enabled' => [
+            'order'   => 'asc',
+            'missing' => '_last'
+        ]
+    ]
+
 Text
 ****
 
@@ -993,7 +1005,7 @@ Sorting
     'sort' => [
         'values.color-option.<all_channels>.<all_locales>' => [
             'order'   => 'asc',
-            'missing' => '_first'
+            'missing' => '_last'
         ]
     ]
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -305,6 +305,13 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.sorter.status:
+        class: '%pim_catalog.query.elasticsearch.sorter.base_field.class%'
+        arguments:
+            - ['enabled']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
     # Attributes sorters
     pim_catalog.query.elasticsearch.sorter.metric:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/StatusSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/StatusSorterIntegration.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class StatusSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('foo', ['enabled' => false]);
+            $this->createProduct('bar', ['enabled' => true]);
+            $this->createProduct('baz', ['enabled' => false]);
+            $this->createProduct('foobar', ['enabled' => true]);
+            $this->createProduct('foobaz', []);
+        }
+    }
+
+    public function testSortDescendant()
+    {
+        $result = $this->executeSorter([['enabled', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['bar', 'foobar', 'foobaz', 'baz', 'foo']);
+    }
+
+    public function testSortAscendant()
+    {
+        $result = $this->executeSorter([['enabled', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['baz', 'foo', 'bar', 'foobar', 'foobaz']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['enabled', 'A_BAD_DIRECTION']]);
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
 class PropertiesNormalizer extends SerializerAwareNormalizer implements NormalizerInterface
 {
     const FIELD_COMPLETENESS = 'completeness';
+    const FIELD_IS_ASSOCIATED = 'is_associated';
 
     /**
      * {@inheritdoc}
@@ -47,8 +48,7 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data[StandardPropertiesNormalizer::FIELD_CATEGORIES] = $product->getCategoryCodes();
         $data[StandardPropertiesNormalizer::FIELD_GROUPS] = $product->getGroupCodes();
 
-        $data[StandardPropertiesNormalizer::FIELD_IS_ASSOCIATED] = !$product->getAssociations()->isEmpty()
-            ? true : false;
+        $data[self::FIELD_IS_ASSOCIATED] = !$product->getAssociations()->isEmpty();
 
         $data[self::FIELD_COMPLETENESS] = !$product->getCompletenesses()->isEmpty()
             ? $this->serializer->normalize($product->getCompletenesses(), 'indexing', $context) : [];

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
@@ -28,7 +28,6 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
     const FIELD_VALUES = 'values';
     const FIELD_CREATED = 'created';
     const FIELD_UPDATED = 'updated';
-    const FIELD_IS_ASSOCIATED = 'is_associated';
 
     /** @var CollectionFilterInterface */
     private $filter;


### PR DESCRIPTION
## Description

This PR adds a sorter on product status (enabled).

## ES Sorter Checklist

- [x] Add sorter integration tests for the field in the PQB
- [ ] ~Add missing integration to the PimCatalogXIntegration tests for sort~ Not needed
- [x] Add the sorter + specs
- [x] Update the reference documentation

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
