### PR TITLE
TIP-706: Add a PQB sorter for date attribute type

### DIFF
--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -200,11 +200,6 @@ suites:
         psr4_prefix: Pim\Bundle\VersioningBundle
         spec_path: src/Pim/Bundle/VersioningBundle
         src_path: src/Pim/Bundle/VersioningBundle
-    WebServiceBundle:
-        namespace: Pim\Bundle\WebServiceBundle
-        psr4_prefix: Pim\Bundle\WebServiceBundle
-        spec_path: src/Pim/Bundle/WebServiceBundle
-        src_path: src/Pim/Bundle/WebServiceBundle
 
     ## Oro bundles
     OroFilterBundle:

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -883,6 +883,17 @@ EMPTY
         ]
     ]
 
+Sorting
+~~~~~~~
+.. code-block:: php
+
+    sort => [
+        'values.publishedOn-date.<all_channels>.<all_locales>' => [
+            'order'   => 'asc',
+            'missing' => '_last',
+        ]
+    ]
+
 Decimal
 *******
 :Apply:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -309,13 +309,6 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
-    pim_catalog.query.elasticsearch.sorter.text_area:
-        class: '%pim_catalog.query.elasticsearch.sorter.attribute.text_area.class%'
-        arguments:
-            - ['pim_catalog_textarea']
-        tags:
-            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
-
     pim_catalog.query.elasticsearch.sorter.is_associated:
         class: '%pim_catalog.query.elasticsearch.sorter.base_field.class%'
         arguments:
@@ -331,27 +324,6 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
     # Attributes sorters
-    pim_catalog.query.elasticsearch.sorter.number:
-        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
-        arguments:
-            - ['pim_catalog_number']
-        tags:
-            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
-
-    pim_catalog.query.elasticsearch.sorter.option:
-        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
-        arguments:
-            - ['pim_catalog_simpleselect']
-        tags:
-            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
-
-    pim_catalog.query.elasticsearch.sorter.text:
-        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
-        arguments:
-            - ['pim_catalog_text']
-        tags:
-            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
-
     pim_catalog.query.elasticsearch.sorter.metric:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.metric.class%'
         arguments:
@@ -391,5 +363,12 @@ services:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
         arguments:
             - ['pim_catalog_simpleselect']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.sorter.date:
+        class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'
+        arguments:
+            - ['pim_catalog_date']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -14,6 +14,10 @@ mappings:
                 type: 'keyword'
             is_associated:
                 type: 'boolean'
+            created:
+                type: 'date'
+            updated:
+                type: 'date'
             identifier:
                 type: 'keyword'
                 normalizer: 'varchar_normalizer'
@@ -150,6 +154,12 @@ mappings:
                     match_mapping_type: 'boolean'
                     mapping:
                         type: 'boolean'
+            -
+                date:
+                    path_match: 'values.*-date.*'
+                    match_mapping_type: 'date'
+                    mapping:
+                        type: 'date'
 
 settings:
     analysis:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Boolean;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\Query\Sorter\Directions;

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Boolean;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\AttributeTypes;

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Boolean;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\AttributeTypes;

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Metric;
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Boolean;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
 use Pim\Component\Catalog\AttributeTypes;

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/DateSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/DateSorterIntegration.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Date;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Date sorter integration tests.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DateSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_date', Directions::ASCENDING]]);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_date', Directions::DESCENDING]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_date', 'A_BAD_DIRECTION']]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_date' => [
+                        ['data' => '2017-04-11', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_date' => [
+                        ['data' => '2016-03-10', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_date' => [
+                        ['data' => '2015-02-09', 'locale' => null, 'scope' => null]
+                    ]
+                ]
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Date;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Date sorter integration tests for localizable and scopable attribute.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([[
+            'a_localizable_scopable_date',
+            Directions::ASCENDING,
+            ['locale' => 'fr_FR', 'scope' => 'tablet'],
+        ]]);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product', 'product_four']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([[
+            'a_localizable_scopable_date',
+            Directions::DESCENDING,
+            ['locale' => 'fr_FR', 'scope' => 'tablet']
+        ]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product', 'product_four']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([[
+            'a_localizable_scopable_date',
+            'A_BAD_DIRECTION',
+            ['locale' => 'fr_FR', 'scope' => 'tablet']
+        ]]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_scopable_date',
+                'type'                => AttributeTypes::DATE,
+                'localizable'         => true,
+                'scopable'            => true,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_scopable_date' => [
+                        ['data' => '2017-04-11', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_scopable_date' => [
+                        ['data' => '2016-03-10', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_localizable_scopable_date' => [
+                        ['data' => '2015-02-09', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_four', [
+                'values' => [
+                    'a_localizable_scopable_date' => [
+                        ['data' => '2014-01-08', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Date;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Date sorter integration tests for localizable attribute.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_localizable_date', Directions::ASCENDING, ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_localizable_date', Directions::DESCENDING,  ['locale' => 'fr_FR']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_localizable_date', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_localizable_date',
+                'type'                => AttributeTypes::DATE,
+                'localizable'         => true,
+                'scopable'            => false,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_localizable_date' => [
+                        ['data' => '2017-04-11', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_localizable_date' => [
+                        ['data' => '2016-03-10', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_localizable_date' => [
+                        ['data' => '2015-02-09', 'locale' => 'fr_FR', 'scope' => null],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/ScopableSorterIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Sorter\Date;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+
+/**
+ * Date sorter integration tests for scopable attribute.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function testSorterAscending()
+    {
+        $result = $this->executeSorter([['a_scopable_date', Directions::ASCENDING, ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product']);
+    }
+
+    public function testSorterDescending()
+    {
+        $result = $this->executeSorter([['a_scopable_date', Directions::DESCENDING,  ['scope' => 'ecommerce']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
+     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeSorter([['a_scopable_date', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $this->createAttribute([
+                'code'                => 'a_scopable_date',
+                'type'                => AttributeTypes::DATE,
+                'localizable'         => false,
+                'scopable'            => true,
+            ]);
+
+            $this->createProduct('product_one', [
+                'values' => [
+                    'a_scopable_date' => [
+                        ['data' => '2017-04-11', 'locale' => null, 'scope' => 'ecommerce'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_two', [
+                'values' => [
+                    'a_scopable_date' => [
+                        ['data' => '2016-03-10', 'locale' => null, 'scope' => 'ecommerce'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('product_three', [
+                'values' => [
+                    'a_scopable_date' => [
+                        ['data' => '2015-02-09', 'locale' => null, 'scope' => 'ecommerce'],
+                    ],
+                ],
+            ]);
+
+            $this->createProduct('empty_product', []);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an Elasticsearch sorter to the PQB for date attribute type.

## ES Sorter Checklist

- [x] Add sorter integration tests for the field in the PQB
- [ ] ~Add missing integration to the PimCatalogXIntegration tests for sort~ Not needed
- [x] Add the sorter + specs
- [x] Update the reference documentation

## Bonus stuff

This PR takes the opportunity to remove the declaration of the WebServiceBundle in `phpspec.yml.dist` as this bundle has been removed in 1.7.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
