### PR TITLE
TIP-721: Make the API work again

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -46,6 +46,7 @@
 
 ### Others
 
+- Remove methods `searchAfterOffset`, `searchAfterIdentifier` and `count` of `Pim\Component\Api\Repository\ProductRepositoryInterface`
 - Extract methods `schedule*` of `Pim\Component\Catalog\Completeness\CompletenessGeneratorInterface` into a `Pim\Component\Catalog\Completeness\CompletenessRemoverInterface`. Methods `schedule`, `scheduleForFamily` and `scheduleForChannelAndLocale` have been renamed respectively `removeForProduct`, `removeForFamily` and `removeForChannelAndLocale`.
 - Remove method `findOneById` of `Pim\Component\Catalog\Repository\ProductRepositoryInterface`.
 - Move class `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\DummyFilter` to `Pim\Bundle\EnrichBundle\ProductQueryBuilder\Filter\DummyFilter` as this filter is just for UI concerns

--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -12,6 +12,7 @@
 
 ### Constructors
 
+- Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Pim\Component\Api\Pagination\PaginatorInterface`
 - Change the constructor of `Pim\Component\Catalog\Manager\CompletenessManager` to remove the completeness class.
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/BoundedCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/BoundedCursor.php
@@ -16,8 +16,8 @@ use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
  */
 class BoundedCursor extends Cursor implements CursorInterface
 {
-    /** @var array */
-    protected $searchAfterIdentifier;
+    /** @var string|null */
+    protected $searchAfterUniqueKey;
 
     /** @var int */
     protected $limit;
@@ -29,24 +29,28 @@ class BoundedCursor extends Cursor implements CursorInterface
      * @param Client                        $esClient
      * @param CursorableRepositoryInterface $repository
      * @param array                         $esQuery
+     * @param array                         $searchAfter
      * @param string                        $indexType
      * @param int                           $pageSize
      * @param int                           $limit
-     * @param string|null                   $searchAfterIdentifier
+     * @param string|null                   $searchAfterUniqueKey
      */
     public function __construct(
         Client $esClient,
         CursorableRepositoryInterface $repository,
         array $esQuery,
+        array $searchAfter = [],
         $indexType,
         $pageSize,
         $limit,
-        $searchAfterIdentifier = null
+        $searchAfterUniqueKey = null
     ) {
         $this->limit = $limit;
+        $this->searchAfter = $searchAfter;
+        $this->searchAfterUniqueKey = $searchAfterUniqueKey;
 
-        if (null !== $searchAfterIdentifier) {
-            $this->searchAfter = [$indexType . '#' . $searchAfterIdentifier];
+        if (null !== $searchAfterUniqueKey) {
+            array_push($this->searchAfter, $indexType . '#' . $searchAfterUniqueKey);
         }
 
         parent::__construct($esClient, $repository, $esQuery, $indexType, $pageSize);

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/BoundedCursorFactory.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/BoundedCursorFactory.php
@@ -70,15 +70,18 @@ class BoundedCursorFactory implements CursorFactoryInterface
         }
 
         $pageSize = !isset($options['page_size']) ? $this->pageSize : $options['page_size'];
+        $searchAfter = !isset($options['search_after']) ? [] : $options['search_after'];
+        $searchAfterUniqueKey = !isset($options['search_after_unique_key']) ? null : $options['search_after_unique_key'];
 
         return new $this->cursorClassName(
             $this->searchEngine,
             $repository,
             $queryBuilder,
+            $searchAfter,
             $this->indexType,
             $pageSize,
             $options['limit'],
-            $options['search_after']
+            $searchAfterUniqueKey
         );
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
@@ -32,7 +32,7 @@ class Cursor implements CursorInterface
     protected $items = [];
 
     /** @var array */
-    protected $searchAfter = null;
+    protected $searchAfter = [];
 
     /** @var int */
     protected $pageSize;
@@ -161,7 +161,7 @@ class Cursor implements CursorInterface
 
         $esQuery['sort'] = $sort;
 
-        if (null !== $this->searchAfter) {
+        if (!empty($this->searchAfter)) {
             $esQuery['search_after'] = $this->searchAfter;
         }
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/BoundedCursorSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/BoundedCursorSpec.php
@@ -47,6 +47,7 @@ class BoundedCursorSpec extends ObjectBehavior
             $esClient,
             $repository,
             [],
+            [],
             'pim_catalog_product',
             3,
             2,

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -67,9 +67,6 @@ class ProductController
     protected $productRepository;
 
     /** @var PaginatorInterface */
-    protected $offsetPaginator;
-
-    /** @var PaginatorInterface */
     protected $searchAfterPaginator;
 
     /** @var ParameterValidatorInterface */
@@ -112,7 +109,6 @@ class ProductController
      * @param IdentifiableObjectRepositoryInterface $localeRepository
      * @param AttributeRepositoryInterface          $attributeRepository
      * @param ProductRepositoryInterface            $productRepository
-     * @param PaginatorInterface                    $offsetPaginator
      * @param PaginatorInterface                    $searchAfterPaginator
      * @param ParameterValidatorInterface           $parameterValidator
      * @param ValidatorInterface                    $productValidator
@@ -133,7 +129,6 @@ class ProductController
         IdentifiableObjectRepositoryInterface $localeRepository,
         AttributeRepositoryInterface $attributeRepository,
         ProductRepositoryInterface $productRepository,
-        PaginatorInterface $offsetPaginator,
         PaginatorInterface $searchAfterPaginator,
         ParameterValidatorInterface $parameterValidator,
         ValidatorInterface $productValidator,
@@ -153,7 +148,6 @@ class ProductController
         $this->localeRepository = $localeRepository;
         $this->attributeRepository = $attributeRepository;
         $this->productRepository = $productRepository;
-        $this->offsetPaginator = $offsetPaginator;
         $this->searchAfterPaginator = $searchAfterPaginator;
         $this->parameterValidator = $parameterValidator;
         $this->productValidator = $productValidator;

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -278,9 +278,9 @@ class ProductController
     {
         $data = $this->getDecodedContent($request->getContent());
 
-        $data['identifier'] = array_key_exists('identifier', $data) ? $data['identifier'] : null;
+        $data = $this->populateIdentifierProductValue($data);
 
-        $product = $this->productBuilder->createProduct($data['identifier']);
+        $product = $this->productBuilder->createProduct();
 
         $this->updateProduct($product, $data, 'post_products');
         $this->validateProduct($product);

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -4,9 +4,7 @@ namespace Pim\Bundle\ApiBundle\Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\UnexpectedResultException;
 use Pim\Component\Api\Repository\ProductRepositoryInterface;
-use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface as CatalogProductRepositoryInterface;
 
 /**
@@ -37,66 +35,6 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
     public function findOneByIdentifier($identifier)
     {
         return $this->productRepository->findOneByIdentifier($identifier);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function searchAfterOffset(ProductQueryBuilderInterface $pqb, $limit, $offset)
-    {
-        $qb = clone $pqb->getQueryBuilder();
-
-        $rootAlias = $qb->getRootAliases()[0];
-
-        return $qb
-            ->orderBy(sprintf('%s.id', $rootAlias), 'ASC')
-            ->setMaxResults($limit)
-            ->setFirstResult($offset)
-            ->getQuery()
-            ->execute();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function searchAfterIdentifier(ProductQueryBuilderInterface $pqb, $limit, $searchAfterIdentifier)
-    {
-        $qb = clone $pqb->getQueryBuilder();
-
-        $rootAlias = $qb->getRootAliases()[0];
-
-        if (null !== $searchAfterIdentifier) {
-            $qb->andWhere(sprintf('%s.id > :id', $rootAlias))
-                ->setParameter(':id', $searchAfterIdentifier);
-        }
-
-        return $qb
-            ->orderBy(sprintf('%s.id', $rootAlias), 'ASC')
-            ->setMaxResults($limit)
-            ->getQuery()
-            ->execute();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function count(ProductQueryBuilderInterface $pqb)
-    {
-        try {
-            $qb = clone $pqb->getQueryBuilder();
-
-            $rootAlias = $qb->getRootAliases()[0];
-
-            return (int) $qb
-                ->select(sprintf('COUNT(DISTINCT %s.id)', $rootAlias))
-                ->setMaxResults(null)
-                ->setFirstResult(null)
-                ->resetDQLParts(['orderBy', 'groupBy'])
-                ->getQuery()
-                ->getSingleScalarResult();
-        } catch (UnexpectedResultException $e) {
-            return 0;
-        }
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -105,7 +105,6 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_api.repository.attribute'
             - '@pim_api.repository.product'
-            - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.search_after_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_catalog.validator.product'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -99,7 +99,7 @@ services:
     pim_api.controller.product:
         class: '%pim_api.controller.product.class%'
         arguments:
-            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.query.product_query_builder_bounded_factory'
             - '@pim_serializer'
             - '@pim_api.repository.channel'
             - '@pim_catalog.repository.locale'

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -60,6 +60,7 @@ abstract class ApiTestCase extends WebTestCase
         self::$count++;
 
         if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
+            $this->resetIndex();
             $this->getDatabaseSchemaHandler()->reset();
 
             $fixturesLoader = $this->getFixturesLoader($configuration);
@@ -242,5 +243,20 @@ abstract class ApiTestCase extends WebTestCase
         }
 
         throw new \Exception(sprintf('The fixture "%s" does not exist.', $name));
+    }
+
+    /**
+     * Resets the index used for the integration tests query
+     */
+    private function resetIndex()
+    {
+        $esClient = $this->get('akeneo_elasticsearch.client');
+        $conf = $this->get('akeneo_elasticsearch.index_configuration.loader')->load();
+
+        if ($esClient->hasIndex()) {
+            $esClient->deleteIndex();
+        }
+
+        $esClient->createIndex($conf->buildAggregated());
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\DateSanitizer;
 use Akeneo\Test\Integration\MediaSanitizer;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 
@@ -34,6 +33,8 @@ abstract class AbstractProductTestCase extends ApiTestCase
         $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
         $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client')->refreshIndex();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -116,7 +116,7 @@ class SuccessListProductIntegration extends AbstractProductTestCase
         "self"  : {"href": "http://localhost/api/rest/v1/products?limit=10"},
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=10"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
 		"items": [
             {$standardizedProducts['localizable']},
@@ -146,7 +146,7 @@ JSON;
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
         "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true&search_after=product_china"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "items_count"  : 6,
     "_embedded"    : {
 		"items": [
@@ -240,7 +240,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -345,7 +345,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -461,7 +461,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -565,7 +565,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -628,7 +628,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -748,7 +748,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -868,7 +868,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -979,7 +979,7 @@ JSON;
         "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false&search_before=scopable"},
         "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=simple&with_count=false"}
     },
-    "current_page" : 2,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -1040,7 +1040,7 @@ JSON;
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
         "previous": {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true&search_before="}
     },
-    "current_page" : 2,
+    "current_page" : null,
     "items_count"  : 6,
     "_embedded"    : {
         "items" : []
@@ -1064,7 +1064,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
@@ -1121,7 +1121,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : []
     }
@@ -1144,7 +1144,7 @@ JSON;
         "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
-    "current_page" : 1,
+    "current_page" : null,
     "_embedded"    : {
         "items" : []
     }
@@ -1167,6 +1167,7 @@ JSON;
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"},
         "previous": {"href": "http://localhost/api/rest/v1/products?limit=4&search_before=product_without_category"}
     },
+    "current_page" : null,
     "_embedded"    : {
         "items" : [
             {$standardizedProducts['product_without_category']},

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -119,12 +119,12 @@ class SuccessListProductIntegration extends AbstractProductTestCase
     "current_page" : null,
     "_embedded"    : {
 		"items": [
+            {$standardizedProducts['simple']},
             {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
             {$standardizedProducts['localizable_and_scopable']},
             {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']},
-            {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['product_without_category']}
 		]
     }
 }
@@ -138,21 +138,23 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
+        $nextId = urlencode($this->getEncryptedId('scopable'));
+
         $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3');
         $expected = <<<JSON
 {
     "_links": {
         "self"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true&search_after=product_china"}
+        "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true&search_after={$nextId}"}
     },
     "current_page" : null,
     "items_count"  : 6,
     "_embedded"    : {
 		"items": [
+            {$standardizedProducts['simple']},
             {$standardizedProducts['localizable']},
-            {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['product_china']}
+            {$standardizedProducts['scopable']}
 		]
     }
 }
@@ -169,20 +171,26 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?search_before=product_without_category&limit=2');
+        $ids = [
+            'localizable'              => urlencode($this->getEncryptedId('localizable')),
+            'localizable_and_scopable' => urlencode($this->getEncryptedId('localizable_and_scopable')),
+            'scopable'                 => urlencode($this->getEncryptedId('scopable')),
+        ];
+
+        $client->request('GET', sprintf('api/rest/v1/products?search_before=%s&limit=2', $ids['localizable_and_scopable']));
         $expected = <<<JSON
 {
     "_links": {
-        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=product_without_category"},
+        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['localizable_and_scopable']}"},
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
-        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after=product_china"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=localizable_and_scopable"}
+        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after={$ids['scopable']}"},
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['localizable']}"}
     },
     "current_page" : null,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['product_china']}
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']}
 		]
     }
 }
@@ -199,20 +207,25 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
+        $ids = [
+            'product_china'            => urlencode($this->getEncryptedId('product_china')),
+            'product_without_category' => urlencode($this->getEncryptedId('product_without_category'))
+        ];
+
         $client->request('GET', 'api/rest/v1/products?search_before=&limit=2');
         $expected = <<<JSON
 {
     "_links": {
         "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before="},
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
-        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after=simple"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=scopable"}
+        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after={$ids['product_without_category']}"},
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['product_china']}"}
     },
     "current_page" : null,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
 		]
     }
 }
@@ -243,6 +256,7 @@ JSON;
     "current_page" : null,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -265,25 +279,6 @@ JSON;
                                 }
                             }
                         }
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"}
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -317,7 +312,25 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {$standardizedProducts['simple']}
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            }
         ]
     }
 }
@@ -348,6 +361,7 @@ JSON;
     "current_page" : null,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -388,26 +402,6 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
                 "identifier"    : "scopable",
@@ -433,7 +427,26 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {$standardizedProducts['simple']}
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            }
         ]
     }
 }
@@ -464,6 +477,7 @@ JSON;
     "current_page" : null,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -486,25 +500,6 @@ JSON;
                                 }
                             }
                         }
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -538,7 +533,25 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {$standardizedProducts['simple']}
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            }
         ]
     }
 }
@@ -631,6 +644,7 @@ JSON;
     "current_page" : null,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -671,29 +685,6 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"},
-                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
-                        {"locale" : "zh_CN", "scope" : "ecommerce_china", "data" : "hum..."}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : []
-            },
-            {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']},
-            {
-                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
                 "identifier"    : "scopable",
@@ -728,7 +719,29 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {$standardizedProducts['simple']}
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"},
+                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
+                        {"locale" : "zh_CN", "scope" : "ecommerce_china", "data" : "hum..."}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : []
+            },
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
         ]
     }
 }
@@ -753,6 +766,29 @@ JSON;
         "items" : [
             {
                 "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
+                },
+                "identifier"    : "simple",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_text" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : "Text"
+                        }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
                 },
                 "identifier"    : "localizable",
@@ -760,6 +796,21 @@ JSON;
                 "groups"        : [],
                 "variant_group" : null,
                 "categories"    : ["categoryB"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
+                },
+                "identifier"    : "scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -810,44 +861,6 @@ JSON;
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
-                },
-                "identifier"    : "scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA1", "categoryA2"],
-                "enabled"       : true,
-                "values"        : {},
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
-                },
-                "identifier"    : "simple",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["master"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_text" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : "Text"
-                        }
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
             }
         ]
     }
@@ -873,6 +886,32 @@ JSON;
         "items" : [
             {
                 "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
+                },
+                "identifier"    : "simple",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_metric" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : {
+                                "amount" : "10.0000",
+                                "unit"   : "KILOWATT"
+                            }
+                        }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
                 },
                 "identifier"    : "localizable",
@@ -882,25 +921,6 @@ JSON;
                 "categories"    : ["categoryB"],
                 "enabled"       : true,
                 "values"        : [],
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
-                    ]
-                },
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
@@ -934,24 +954,17 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
                 },
-                "identifier"    : "simple",
+                "identifier"    : "localizable_and_scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master"],
+                "categories"    : ["categoryA", "master_china"],
                 "enabled"       : true,
                 "values"        : {
-                    "a_metric" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : {
-                                "amount" : "10.0000",
-                                "unit"   : "KILOWATT"
-                            }
-                        }
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -970,27 +983,33 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_text&search_after=product_without_category&limit=2&with_count=false');
+        $ids = [
+            'localizable_and_scopable' => urlencode($this->getEncryptedId('localizable_and_scopable')),
+            'product_china'            => urlencode($this->getEncryptedId('product_china')),
+            'product_without_category' => urlencode($this->getEncryptedId('product_without_category')),
+        ];
+
+        $client->request('GET', sprintf('api/rest/v1/products?attributes=a_text&search_after=%s&limit=2&with_count=false', $ids['localizable_and_scopable']));
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=product_without_category&with_count=false"},
+        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after={$ids['localizable_and_scopable']}&with_count=false"},
         "first"    : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
-        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false&search_before=scopable"},
-        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=simple&with_count=false"}
+        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false&search_before={$ids['product_china']}"},
+        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after={$ids['product_without_category']}&with_count=false"}
     },
     "current_page" : null,
     "_embedded"    : {
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_china"}
                 },
-                "identifier"    : "scopable",
+                "identifier"    : "product_china",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["categoryA1", "categoryA2"],
+                "categories"    : ["master_china"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -999,23 +1018,15 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_without_category"}
                 },
-                "identifier"    : "simple",
+                "identifier"    : "product_without_category",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master"],
+                "categories"    : [],
                 "enabled"       : true,
-                "values"        : {
-                    "a_text" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : "Text"
-                        }
-                    ]
-                },
+                "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
@@ -1032,11 +1043,13 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?search_after=simple&with_count=true');
+        $id = urlencode($this->getEncryptedId('product_without_category'));
+
+        $client->request('GET', sprintf('api/rest/v1/products?search_after=%s&with_count=true', $id));
         $expected = <<<JSON
 {
     "_links" : {
-        "self": {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"},
+        "self": {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after={$id}&with_count=true"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
         "previous": {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true&search_before="}
     },
@@ -1159,20 +1172,24 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?limit=4&search_after=product_china');
+        $ids = [
+            'localizable_and_scopable' => urlencode($this->getEncryptedId('localizable_and_scopable')),
+            'product_china'            => urlencode($this->getEncryptedId('product_china')),
+        ];
+
+        $client->request('GET', sprintf('api/rest/v1/products?limit=4&search_after=%s', $ids['localizable_and_scopable']));
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&search_after=product_china"},
+        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&search_after={$ids['localizable_and_scopable']}"},
         "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=4&search_before=product_without_category"}
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=4&search_before={$ids['product_china']}"}
     },
     "current_page" : null,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['product_without_category']},
-            {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
         ]
     }
 }
@@ -1204,6 +1221,19 @@ JSON;
         }
 
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @param string $productIdentifier
+     */
+    private function getEncryptedId($productIdentifier)
+    {
+        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
+        $productRepository = $this->get('pim_catalog.repository.product');
+
+        $product = $productRepository->findOneByIdentifier($productIdentifier);
+
+        return $encrypter->encrypt($product->getId());
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -102,9 +102,9 @@ class SuccessListProductIntegration extends AbstractProductTestCase
     }
 
     /**
-     * Get all products, whatever locale, scope, category with the default pagination type that is with an offset.
+     * Get all products, whatever locale, scope, category
      */
-    public function testDefaultPaginationListProductsWithoutParameter()
+    public function testListProductsWithoutParameter()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
@@ -113,18 +113,18 @@ class SuccessListProductIntegration extends AbstractProductTestCase
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=10"}
     },
     "current_page" : 1,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['simple']},
             {$standardizedProducts['localizable']},
-            {$standardizedProducts['scopable']},
             {$standardizedProducts['localizable_and_scopable']},
             {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']}
+            {$standardizedProducts['product_without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
 		]
     }
 }
@@ -133,7 +133,7 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
-    public function testDefaultPaginationFirstPageListProductsWithCount()
+    public function testFirstPageListProductsWithCount()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
@@ -142,46 +142,17 @@ JSON;
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true&search_after=product_china"}
     },
     "current_page" : 1,
     "items_count"  : 6,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['simple']},
             {$standardizedProducts['localizable']},
-            {$standardizedProducts['scopable']}
-		]
-    }
-}
-JSON;
-
-        $this->assertResponse($client->getResponse(), $expected);
-    }
-
-    public function testDefaultPaginationLastPageListProductsWithCount()
-    {
-        $standardizedProducts = $this->getStandardizedProducts();
-        $client = $this->createAuthenticatedClient();
-
-        $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3&page=2');
-        $expected = <<<JSON
-{
-    "_links": {
-        "self"     : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"},
-        "first"    : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "previous" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "next"     : {"href": "http://localhost/api/rest/v1/products?page=3&with_count=true&pagination_type=page&limit=3"}
-    },
-    "current_page" : 2,
-    "items_count"  : 6,
-    "_embedded"    : {
-		"items": [
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']}
+            {$standardizedProducts['product_china']}
 		]
     }
 }
@@ -196,25 +167,22 @@ JSON;
      *    - scope = "ecommerce"
      *    - locale = "en_US" or null
      * Then only products in "master" tree are returned
-     *
-     * @group test
      */
-    public function testOffsetPaginationListProductsWithEcommerceChannel()
+    public function testListProductsWithEcommerceChannel()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -237,6 +205,25 @@ JSON;
                                 }
                             }
                         }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"}
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -270,25 +257,7 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            }
+            {$standardizedProducts['simple']}
         ]
     }
 }
@@ -304,22 +273,21 @@ JSON;
      *     - locale = "en_US", "fr_FR" or null
      * Then only products in "master" tree are returned
      */
-    public function testOffsetPaginationListProductsWithTabletChannel()
+    public function testListProductsWithTabletChannel()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=tablet&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=tablet');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -360,6 +328,26 @@ JSON;
             },
             {
                 "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
                 "identifier"    : "scopable",
@@ -385,26 +373,7 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            }
+            {$standardizedProducts['simple']}
         ]
     }
 }
@@ -420,22 +389,21 @@ JSON;
      *     - locale = "fr_FR" or null
      * Then only products in "master" tree are returned
      */
-    public function testOffsetPaginationListProductsWithTabletChannelAndFRLocale()
+    public function testListProductsWithTabletChannelAndFRLocale()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -466,6 +434,25 @@ JSON;
             },
             {
                 "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
                 "identifier"    : "scopable",
@@ -491,25 +478,7 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            }
+            {$standardizedProducts['simple']}
         ]
     }
 }
@@ -525,16 +494,16 @@ JSON;
      *     - locale = "en_US", "zh_CN" or null
      * Then only products in "master_china" tree are returned
      */
-    public function testOffsetPaginationListProductsWithEcommerceChinaChannel()
+    public function testListProductsWithEcommerceChinaChannel()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce_china&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce_china');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce_china"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce_china"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -587,22 +556,21 @@ JSON;
      *     - locale = "en_US", "zh_CN" or null
      * Then we return all products (whatever the categories)
      */
-    public function testOffsetPaginationListProductsWithENAndCNLocales()
+    public function testListProductsWithENAndCNLocales()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?locales=en_US,zh_CN&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?locales=en_US,zh_CN');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&locales=en_US%2Czh_CN"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&locales=en_US%2Czh_CN"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['simple']},
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -643,6 +611,29 @@ JSON;
             },
             {
                 "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"},
+                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
+                        {"locale" : "zh_CN", "scope" : "ecommerce_china", "data" : "hum..."}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : []
+            },
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']},
+            {
+                "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
                 "identifier"    : "scopable",
@@ -677,29 +668,7 @@ JSON;
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
-                },
-                "identifier"    : "localizable_and_scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "en_US", "scope" : "ecommerce", "data" : "Big description"},
-                        {"locale" : "en_US", "scope" : "tablet", "data" : "Medium description"},
-                        {"locale" : "zh_CN", "scope" : "ecommerce_china", "data" : "hum..."}
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : []
-            },
-            {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']}
+            {$standardizedProducts['simple']}
         ]
     }
 }
@@ -708,43 +677,20 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
-    public function testOffsetPaginationListProductsWithFilteredAttributes()
+    public function testListProductsWithFilteredAttributes()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_text&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_text');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_text"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_text"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
-                },
-                "identifier"    : "simple",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["master"],
-                "enabled"       : true,
-                "values"        : {
-                    "a_text" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : "Text"
-                        }
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -754,21 +700,6 @@ JSON;
                 "groups"        : [],
                 "variant_group" : null,
                 "categories"    : ["categoryB"],
-                "enabled"       : true,
-                "values"        : {},
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
-                },
-                "identifier"    : "scopable",
-                "family"        : null,
-                "groups"        : [],
-                "variant_group" : null,
-                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -819,29 +750,22 @@ JSON;
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
-            }
-        ]
-    }
-}
-JSON;
-
-        $this->assertResponse($client->getResponse(), $expected);
-    }
-
-    public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area&pagination_type=page');
-        $expected = <<<JSON
-{
-    "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"}
-    },
-    "current_page" : 1,
-    "_embedded"    : {
-        "items" : [
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
+                },
+                "identifier"    : "scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA1", "categoryA2"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
@@ -853,21 +777,40 @@ JSON;
                 "categories"    : ["master"],
                 "enabled"       : true,
                 "values"        : {
-                    "a_metric" : [
+                    "a_text" : [
                         {
                             "locale" : null,
                             "scope"  : null,
-                            "data"   : {
-                                "amount" : "10.0000",
-                                "unit"   : "KILOWATT"
-                            }
+                            "data"   : "Text"
                         }
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
-            },
+            }
+        ]
+    }
+}
+JSON;
+
+        $this->assertResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithChannelLocalesAndAttributesParams()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area');
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
             {
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
@@ -879,6 +822,25 @@ JSON;
                 "categories"    : ["categoryB"],
                 "enabled"       : true,
                 "values"        : [],
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                },
+                "identifier"    : "localizable_and_scopable",
+                "family"        : null,
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
@@ -912,17 +874,24 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
                 },
-                "identifier"    : "localizable_and_scopable",
+                "identifier"    : "simple",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
+                "categories"    : ["master"],
                 "enabled"       : true,
                 "values"        : {
-                    "a_localized_and_scopable_text_area" : [
-                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    "a_metric" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : {
+                                "amount" : "10.0000",
+                                "unit"   : "KILOWATT"
+                            }
+                        }
                     ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -937,31 +906,31 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
-    public function testTheSecondPageOfTheListOfProductsWithOffsetPaginationWithoutCount()
+    public function testTheSecondPageOfTheListOfProductsWithoutCount()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_text&page=2&limit=2&pagination_type=page&with_count=false');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_text&search_after=localizable_and_scopable&limit=2&with_count=false');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"     : {"href" : "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
-        "first"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
-        "previous" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
-        "next"     : {"href" : "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=a_text"}
+        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=localizable_and_scopable&with_count=false"},
+        "first"    : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
+        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
+        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=product_without_category&with_count=false"}
     },
     "current_page" : 2,
     "_embedded"    : {
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_china"}
                 },
-                "identifier"    : "scopable",
+                "identifier"    : "product_china",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["categoryA1", "categoryA2"],
+                "categories"    : ["master_china"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -970,13 +939,13 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_without_category"}
                 },
-                "identifier"    : "localizable_and_scopable",
+                "identifier"    : "product_without_category",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["categoryA", "master_china"],
+                "categories"    : [],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -995,13 +964,13 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?page=2&pagination_type=page&with_count=true');
+        $client->request('GET', 'api/rest/v1/products?search_after=simple&with_count=true');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"        : {"href" : "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=10"},
-        "first"       : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"},
-        "previous"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"}
+        "self"        : {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"},
+        "first"       : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
+        "previous"    : {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"}
     },
     "current_page" : 2,
     "items_count"  : 6,
@@ -1014,18 +983,18 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
-    public function testOffsetPaginationListProductsWithSearch()
+    public function testListProductsWithSearch()
     {
         $client = $this->createAuthenticatedClient();
 
         $search = '{"a_metric":[{"operator":">","value":{"amount":"9","unit":"KILOWATT"}}]}';
-        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
         $searchEncoded = urlencode($search);
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -1071,18 +1040,18 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
-    public function testOffsetPaginationListProductsWithMultiplePQBFilters()
+    public function testListProductsWithMultiplePQBFilters()
     {
         $client = $this->createAuthenticatedClient();
 
         $search = '{"categories":[{"operator":"IN", "value":["categoryB"]}], "a_yes_no":[{"operator":"=","value":true}]}';
-        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
         $searchEncoded = urlencode($search);
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -1104,8 +1073,8 @@ JSON;
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -1116,87 +1085,24 @@ JSON;
 
         $this->assertResponse($client->getResponse(), $expected);
     }
-    /**
-     * Get all products, whatever locale, scope, category with a search after pagination
-     */
-    public function testSearchAfterPaginationListProductsWithoutParameter()
+
+    public function testPaginationLastPageOfTheListOfProducts()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?pagination_type=search_after');
+        $client->request('GET', 'api/rest/v1/products?limit=4&search_after=product_china');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&search_after=product_china"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"}
     },
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['simple']},
-            {$standardizedProducts['localizable']},
+            {$standardizedProducts['product_without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']}
-        ]
-    }
-}
-JSON;
-
-        $this->assertResponse($client->getResponse(), $expected);
-    }
-
-    public function testSearchAfterPaginationListProductsWithNextLink()
-    {
-        $standardizedProducts = $this->getStandardizedProducts();
-        $client = $this->createAuthenticatedClient();
-
-        $id = [
-            'simple'                   => urlencode($this->getEncryptedId('simple')),
-            'localizable_and_scopable' => urlencode($this->getEncryptedId('localizable_and_scopable')),
-        ];
-
-        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=3&search_after=%s', $id['simple']));
-        $expected = <<<JSON
-{
-    "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['simple']}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['localizable_and_scopable']}"}
-    },
-    "_embedded"    : {
-        "items" : [
-            {$standardizedProducts['localizable']},
-            {$standardizedProducts['scopable']},
-            {$standardizedProducts['localizable_and_scopable']}
-        ]
-    }
-}
-JSON;
-
-        $this->assertResponse($client->getResponse(), $expected);
-    }
-
-    public function testSearchAfterPaginationLastPageOfTheListOfProducts()
-    {
-        $standardizedProducts = $this->getStandardizedProducts();
-        $client = $this->createAuthenticatedClient();
-
-        $scopableEncryptedId = urlencode($this->getEncryptedId('scopable'));
-
-        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=4&search_after=%s' , $scopableEncryptedId));
-        $expected = <<<JSON
-{
-    "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4&search_after={$scopableEncryptedId}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4"}
-    },
-    "_embedded"    : {
-        "items" : [
-            {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['product_china']},
-            {$standardizedProducts['product_without_category']}
+            {$standardizedProducts['simple']}
         ]
     }
 }
@@ -1228,19 +1134,6 @@ JSON;
         }
 
         $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @param string $productIdentifier
-     */
-    private function getEncryptedId($productIdentifier)
-    {
-        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
-        $productRepository = $this->get('pim_catalog.repository.product');
-
-        $product = $productRepository->findOneByIdentifier($productIdentifier);
-
-        return $encrypter->encrypt($product->getId());
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -162,6 +162,66 @@ JSON;
     }
 
     /**
+     * Get products with "search_before" parameter.
+     */
+    public function testListProductsWithSearchBeforeParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?search_before=product_without_category&limit=2');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=product_without_category"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
+        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after=product_china"},
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=localizable_and_scopable"}
+    },
+    "current_page" : null,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']}
+		]
+    }
+}
+JSON;
+
+        $this->assertResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * Get the 3 latest products with "search_before" parameter.
+     */
+    public function testLatestProductsWithSearchBeforeParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?search_before=&limit=2');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before="},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
+        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after=simple"},
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before=scopable"}
+    },
+    "current_page" : null,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+		]
+    }
+}
+JSON;
+
+        $this->assertResponse($client->getResponse(), $expected);
+    }
+
+    /**
      * Scope "ecommerce" has only "en_US" activated locale and it category tree linked is "master"
      * So PV are returned only if:
      *    - scope = "ecommerce"
@@ -910,27 +970,27 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_text&search_after=localizable_and_scopable&limit=2&with_count=false');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_text&search_after=product_without_category&limit=2&with_count=false');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=localizable_and_scopable&with_count=false"},
+        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=product_without_category&with_count=false"},
         "first"    : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
-        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
-        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=product_without_category&with_count=false"}
+        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false&search_before=scopable"},
+        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after=simple&with_count=false"}
     },
     "current_page" : 2,
     "_embedded"    : {
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_china"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
-                "identifier"    : "product_china",
+                "identifier"    : "scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_china"],
+                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -939,15 +999,23 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_without_category"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
                 },
-                "identifier"    : "product_without_category",
+                "identifier"    : "simple",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : [],
+                "categories"    : ["master"],
                 "enabled"       : true,
-                "values"        : {},
+                "values"        : {
+                    "a_text" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : "Text"
+                        }
+                    ]
+                },
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
@@ -967,10 +1035,10 @@ JSON;
         $client->request('GET', 'api/rest/v1/products?search_after=simple&with_count=true');
         $expected = <<<JSON
 {
-    "_links"       : {
-        "self"        : {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"},
-        "first"       : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
-        "previous"    : {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"}
+    "_links" : {
+        "self": {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after=simple&with_count=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
+        "previous": {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true&search_before="}
     },
     "current_page" : 2,
     "items_count"  : 6,
@@ -1096,7 +1164,8 @@ JSON;
 {
     "_links": {
         "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&search_after=product_china"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"}
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"},
+        "previous": {"href": "http://localhost/api/rest/v1/products?limit=4&search_before=product_without_category"}
     },
     "_embedded"    : {
         "items" : [

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderBoundedOptionsResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderBoundedOptionsResolver.php
@@ -31,7 +31,8 @@ class ProductQueryBuilderBoundedOptionsResolver implements ProductQueryBuilderOp
     protected function createOptionsResolver()
     {
         $resolver = new OptionsResolver();
-        $resolver->setRequired(['locale', 'scope', 'limit', 'search_after']);
+        $resolver->setDefined(['locale', 'scope', 'limit', 'search_after', 'search_after_unique_key']);
+        $resolver->setRequired(['locale', 'scope', 'limit']);
 
         return $resolver;
     }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderFactory.php
@@ -78,8 +78,12 @@ class ProductQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
             $pqbOptions['limit'] = $options['limit'];
         }
 
-        if (array_key_exists('search_after', $options)) {
+        if (isset($options['search_after'])) {
             $pqbOptions['search_after'] = $options['search_after'];
+        }
+
+        if (isset($options['search_after_unique_key'])) {
+            $pqbOptions['search_after_unique_key'] = $options['search_after_unique_key'];
         }
 
         $pqb = $this->createProductQueryBuilder($pqbOptions);
@@ -148,6 +152,7 @@ class ProductQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
             'default_scope',
             'filters',
             'search_after',
+            'search_after_unique_key',
             'limit'
         ]);
         $resolver->setDefaults([

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
@@ -13,12 +13,6 @@ class IndexingProductIntegration extends TestCase
 {
     const DOCUMENT_TYPE = 'pim_catalog_product';
 
-    /** @var Client */
-    private $esClient;
-
-    /** @var Loader */
-    private $esConfigurationLoader;
-
     /** @var ProductBuilderInterface */
     private $productBuilder;
 
@@ -60,12 +54,8 @@ class IndexingProductIntegration extends TestCase
     {
         parent::setUp();
 
-        $this->esClient = $this->get('akeneo_elasticsearch.client');
-        $this->esConfigurationLoader = $this->get('akeneo_elasticsearch.index_configuration.loader');
         $this->productBuilder = $this->get('pim_catalog.builder.product');
         $this->productUpdater = $this->get('pim_catalog.updater.product');
-
-        $this->resetIndex();
     }
 
     /**
@@ -74,19 +64,5 @@ class IndexingProductIntegration extends TestCase
     protected function getConfiguration()
     {
         return new Configuration([Configuration::getTechnicalCatalogPath()], false);
-    }
-
-    /**
-     * Resets the index used for the integration tests query
-     */
-    private function resetIndex()
-    {
-        $conf = $this->esConfigurationLoader->load();
-
-        if ($this->esClient->hasIndex()) {
-            $this->esClient->deleteIndex();
-        }
-
-        $this->esClient->createIndex($conf->buildAggregated());
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -3,10 +3,10 @@
 namespace Pim\Bundle\VersioningBundle\Doctrine\ORM;
 
 use Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
-use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 
 /**
@@ -18,9 +18,6 @@ use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
  */
 class VersionRepository extends EntityRepository implements VersionRepositoryInterface, CursorableRepositoryInterface
 {
-    /** @var CursorFactoryInterface */
-    protected $cursorFactory;
-
     /**
      * {@inheritdoc}
      */
@@ -129,10 +126,6 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
      */
     public function findPotentiallyPurgeableBy(array $options = [])
     {
-        if (null === $this->cursorFactory) {
-            throw new \RuntimeException('The cursor factory is not initialized');
-        }
-
         $qb = $this->createQueryBuilder('v');
 
         if (isset($options['resource_name'])) {
@@ -149,7 +142,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
             $qb->setParameter('limit_date', $options['limit_date'], Type::DATETIME);
         }
 
-        return $this->cursorFactory->createCursor($qb);
+        return new Paginator($qb);
     }
 
     /**
@@ -192,14 +185,6 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
         }
 
         return $versionId;
-    }
-
-    /**
-     * @param CursorFactoryInterface $cursorFactory
-     */
-    public function setCursorFactory(CursorFactoryInterface $cursorFactory)
-    {
-        $this->cursorFactory = $cursorFactory;
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -69,9 +69,9 @@ class VersionPurger implements VersionPurgerInterface
         $this->configureOptions($optionResolver);
         $options = $optionResolver->resolve($options);
 
-        $versionsCursor = $this->versionRepository->findPotentiallyPurgeableBy($options);
+        $versionsPaginator = $this->versionRepository->findPotentiallyPurgeableBy($options);
 
-        foreach ($versionsCursor as $version) {
+        foreach ($versionsPaginator as $version) {
             $this->eventDispatcher->dispatch(
                 PurgeVersionEvents::PRE_ADVISEMENT,
                 new PreAdvisementVersionEvent($version)
@@ -110,9 +110,9 @@ class VersionPurger implements VersionPurgerInterface
         $this->configureOptions($optionResolver);
         $options = $optionResolver->resolve($options);
 
-        $versionsCursor = $this->versionRepository->findPotentiallyPurgeableBy($options);
+        $versionsPaginator = $this->versionRepository->findPotentiallyPurgeableBy($options);
 
-        return $versionsCursor->count();
+        return $versionsPaginator->count();
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
+++ b/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\VersioningBundle\Repository;
 
-use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\Versioning\Model\Version;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 
 /**
  * Version repository interface
@@ -88,7 +88,7 @@ interface VersionRepositoryInterface
      *
      * @param array $options
      *
-     * @return CursorInterface
+     * @return Paginator
      */
     public function findPotentiallyPurgeableBy(array $options = []);
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -10,8 +10,6 @@ services:
         factory_service: doctrine.orm.entity_manager
         factory_method: getRepository
         arguments: ['%pim_versioning.entity.version.class%']
-        calls:
-            - [ setCursorFactory, ['@pim_versioning.factory.version_cursor']]
         tags:
             - { name: 'pim_repository' }
 

--- a/src/Pim/Component/Api/Normalizer/CollectionNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/CollectionNormalizer.php
@@ -27,11 +27,7 @@ class CollectionNormalizer implements NormalizerInterface, SerializerAwareInterf
         $normalizedElements = [];
 
         foreach ($elements as $element) {
-            // an element can be false in mongo because of a bug in the cursor
-            // TODO: to fix with API-115
-            if (false !== $element) {
-                $normalizedElements[] = $this->serializer->normalize($element, $format, $context);
-            }
+            $normalizedElements[] = $this->serializer->normalize($element, $format, $context);
         }
 
         return $normalizedElements;

--- a/src/Pim/Component/Api/Pagination/SearchAfterHalPaginator.php
+++ b/src/Pim/Component/Api/Pagination/SearchAfterHalPaginator.php
@@ -38,7 +38,6 @@ class SearchAfterHalPaginator implements PaginatorInterface
 
         $this->resolver->setRequired([
             'query_parameters',
-            'search_after',
             'list_route_name',
             'item_route_name',
         ]);
@@ -46,7 +45,6 @@ class SearchAfterHalPaginator implements PaginatorInterface
         $this->resolver->setAllowedTypes('uri_parameters', 'array');
         $this->resolver->setAllowedTypes('item_identifier_key', 'string');
         $this->resolver->setAllowedTypes('query_parameters', 'array');
-        $this->resolver->setAllowedTypes('search_after', 'array');
         $this->resolver->setAllowedTypes('list_route_name', 'string');
         $this->resolver->setAllowedTypes('item_route_name', 'string');
 
@@ -78,8 +76,9 @@ class SearchAfterHalPaginator implements PaginatorInterface
 
         $uriParameters = array_merge($parameters['uri_parameters'], $parameters['query_parameters']);
 
+        $searchAfter = isset($parameters['query_parameters']['search_after']) ? $parameters['query_parameters']['search_after'] : null;
         $links = [
-            $this->createLink($parameters['list_route_name'], $uriParameters, $parameters['search_after']['self'], 'self'),
+            $this->createLink($parameters['list_route_name'], $uriParameters, $searchAfter, 'self'),
             $this->createLink($parameters['list_route_name'], $uriParameters, null, 'first'),
         ];
 
@@ -87,12 +86,17 @@ class SearchAfterHalPaginator implements PaginatorInterface
             $links[] = $this->createLink(
                 $parameters['list_route_name'],
                 $uriParameters,
-                $parameters['search_after']['next'],
+                end($items)[$parameters['item_identifier_key']],
                 'next'
             );
         }
 
-        $collection = new HalResource($links, ['items' => $embedded], []);
+        $data = ['current_page' => null];
+        if (null !== $count) {
+            $data['items_count'] = $count;
+        }
+
+        $collection = new HalResource($links, ['items' => $embedded], $data);
 
         return $collection->toArray();
     }

--- a/src/Pim/Component/Api/Pagination/SearchAfterHalPaginator.php
+++ b/src/Pim/Component/Api/Pagination/SearchAfterHalPaginator.php
@@ -36,10 +36,9 @@ class SearchAfterHalPaginator implements PaginatorInterface
             'item_identifier_key' => 'code',
         ]);
 
-        $this->resolver->setDefined(['previous']);
-
         $this->resolver->setRequired([
             'query_parameters',
+            'search_after',
             'list_route_name',
             'item_route_name',
         ]);
@@ -47,6 +46,7 @@ class SearchAfterHalPaginator implements PaginatorInterface
         $this->resolver->setAllowedTypes('uri_parameters', 'array');
         $this->resolver->setAllowedTypes('item_identifier_key', 'string');
         $this->resolver->setAllowedTypes('query_parameters', 'array');
+        $this->resolver->setAllowedTypes('search_after', 'array');
         $this->resolver->setAllowedTypes('list_route_name', 'string');
         $this->resolver->setAllowedTypes('item_route_name', 'string');
 
@@ -86,15 +86,20 @@ class SearchAfterHalPaginator implements PaginatorInterface
         ];
 
         if (isset($uriParameters['search_after']) || isset($uriParameters['search_before'])) {
-            $searchBefore = !empty($items) ? $items[0][$parameters['item_identifier_key']] : '';
-            $links[] = $this->createLink($parameters['list_route_name'], $uriParameters, null, $searchBefore, 'previous');
+            $links[] = $this->createLink(
+                $parameters['list_route_name'],
+                $uriParameters,
+                null,
+                $parameters['search_after']['previous'],
+                'previous'
+            );
         }
 
         if (count($items) === (int) $parameters['query_parameters']['limit']) {
             $links[] = $this->createLink(
                 $parameters['list_route_name'],
                 $uriParameters,
-                end($items)[$parameters['item_identifier_key']],
+                $parameters['search_after']['next'],
                 null,
                 'next'
             );

--- a/src/Pim/Component/Api/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Component/Api/Repository/ProductRepositoryInterface.php
@@ -3,7 +3,6 @@
 namespace Pim\Component\Api\Repository;
 
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 
 /**
  * Repository interface for product resources
@@ -14,34 +13,4 @@ use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
  */
 interface ProductRepositoryInterface extends IdentifiableObjectRepositoryInterface
 {
-    /**
-     * Find products with offset > $offset
-     *
-     * @param ProductQueryBuilderInterface $pqb
-     * @param int                          $limit
-     * @param int                          $offset
-     *
-     * @return array
-     */
-    public function searchAfterOffset(ProductQueryBuilderInterface $pqb, $limit, $offset);
-
-    /**
-     * Find products with the database identifier (the primary key) > $searchAfterIdentifier.
-     *
-     * @param ProductQueryBuilderInterface $pqb
-     * @param int                          $limit
-     * @param string                       $searchAfterIdentifier
-     *
-     * @return array
-     */
-    public function searchAfterIdentifier(ProductQueryBuilderInterface $pqb, $limit, $searchAfterIdentifier);
-
-    /**
-     * Return the count of products filtered by PQB
-     *
-     * @param ProductQueryBuilderInterface $pqb
-     *
-     * @return int
-     */
-    public function count(ProductQueryBuilderInterface $pqb);
 }

--- a/src/Pim/Component/Api/spec/Pagination/SearchAfterHalPaginatorSpec.php
+++ b/src/Pim/Component/Api/spec/Pagination/SearchAfterHalPaginatorSpec.php
@@ -25,21 +25,13 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $this->shouldImplement('Pim\Component\Api\Pagination\PaginatorInterface');
     }
 
-    function it_paginates_in_hal_format($normalizer, $router)
+    function it_paginates_in_hal_format($router)
     {
         // links
         $router
             ->generate(
                 'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'a_text', 'limit'=> 2],
-                UrlGeneratorInterface::ABSOLUTE_URL
-            )
-            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=a_text');
-
-        $router
-            ->generate(
-                'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null],
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => null, 'search_before' => null, 'limit'=> 2],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2');
@@ -47,20 +39,26 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $router
             ->generate(
                 'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'another_text', 'limit'=> 2],
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null, 'search_before' => null],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
-            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=another_text');
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2');
 
-
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'optionB', 'limit'=> 2, 'search_before' => null],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionB');
 
         // embedded
         $router
-            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionA', 'search_after' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionA', 'search_after' => null, 'search_before' => null], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA');
 
         $router
-            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionB', 'search_after' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionB', 'search_after' => null, 'search_before' => null], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionB');
 
         $standardItems = [
@@ -71,15 +69,16 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $expectedItems = [
             '_links'       => [
                 'self'     => [
-                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=a_text',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2',
                 ],
                 'first'    => [
                     'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2',
                 ],
                 'next'     => [
-                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=another_text',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionB',
                 ],
             ],
+            'current_page' => null,
             '_embedded'    => [
                 'items' => [
                     [
@@ -105,7 +104,7 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $parameters = [
             'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
             'query_parameters'    => ['limit' => 2, 'pagination_type' => 'search_after'],
-            'search_after'        => ['self' => 'a_text', 'next' => 'another_text'],
+            'search_after'        => ['self' => '', 'next' => 'optionB', 'previous' => ''],
             'list_route_name'     => 'attribute_option_list_route',
             'item_route_name'     => 'attribute_option_item_route',
             'item_identifier_key' => 'code',
@@ -114,13 +113,112 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $this->paginate($standardItems, $parameters, null)->shouldReturn($expectedItems);
     }
 
-    function it_paginates_without_next_link_when_last_page($normalizer, $router)
+    function it_paginates_with_previous_and_next_link($router)
     {
         // links
         $router
             ->generate(
                 'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'a_text', 'limit'=> 2],
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'optionD', 'search_before' => null, 'limit'=> 2],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionD');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null, 'search_before' => null],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => null, 'search_before' => 'optionE', 'limit'=> 2],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_before=optionE');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'optionF', 'search_before' => null, 'limit'=> 2],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionF');
+
+        // embedded
+        $router
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionE', 'search_after' => null, 'search_before' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionE');
+
+        $router
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionF', 'search_after' => null, 'search_before' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionF');
+
+        $standardItems = [
+            ['code'   => 'optionE'],
+            ['code'   => 'optionF'],
+        ];
+
+        $expectedItems = [
+            '_links'       => [
+                'self'     => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionD',
+                ],
+                'first'    => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2',
+                ],
+                'previous'     => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_before=optionE',
+                ],
+                'next'     => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=optionF',
+                ],
+            ],
+            'current_page' => null,
+            '_embedded'    => [
+                'items' => [
+                    [
+                        '_links' => [
+                            'self' => [
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionE',
+                            ],
+                        ],
+                        'code'   => 'optionE',
+                    ],
+                    [
+                        '_links' => [
+                            'self' => [
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionF',
+                            ],
+                        ],
+                        'code'   => 'optionF',
+                    ],
+                ],
+            ],
+        ];
+
+        $parameters = [
+            'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
+            'query_parameters'    => ['limit' => 2, 'pagination_type' => 'search_after', 'search_after' => 'optionD'],
+            'search_after'        => ['self' => 'optionD', 'next' => 'optionF', 'previous' => 'optionE'],
+            'list_route_name'     => 'attribute_option_list_route',
+            'item_route_name'     => 'attribute_option_item_route',
+            'item_identifier_key' => 'code',
+        ];
+
+        $this->paginate($standardItems, $parameters, null)->shouldReturn($expectedItems);
+    }
+
+    function it_paginates_without_next_link_when_last_page($router)
+    {
+        // links
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'a_text', 'search_before' => null, 'limit'=> 2],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_after=a_text');
@@ -128,15 +226,26 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $router
             ->generate(
                 'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null],
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null, 'search_before' => 'optionA'],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_before=optionA');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null, 'search_before' => null],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2');
 
-
         // embedded
         $router
-            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionA', 'search_after' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->generate(
+                'attribute_option_item_route',
+                ['attributeCode' => 'a_multi_select', 'code' => 'optionA', 'search_after' => null, 'search_before' => null],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA');
 
         $standardItems = [
@@ -151,7 +260,11 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
                 'first'    => [
                     'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2',
                 ],
+                'previous'    => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2&search_before=optionA',
+                ]
             ],
+            'current_page' => null,
             '_embedded'    => [
                 'items' => [
                     [
@@ -168,22 +281,22 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
 
         $parameters = [
             'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
-            'query_parameters'    => ['limit' => 2, 'pagination_type' => 'search_after'],
-            'search_after'        => ['self' => 'a_text', 'next' => 'another_text'],
+            'query_parameters'    => ['limit' => 2, 'pagination_type' => 'search_after', 'search_after' => 'a_text'],
             'list_route_name'     => 'attribute_option_list_route',
             'item_route_name'     => 'attribute_option_item_route',
             'item_identifier_key' => 'code',
+            'search_after'        => ['self' => 'a_text', 'next' => '', 'previous' => 'optionA'],
         ];
 
         $this->paginate($standardItems, $parameters, null)->shouldReturn($expectedItems);
     }
 
-    function it_paginates_with_one_page_when_total_items_equals_zero($normalizer, $router)
+    function it_paginates_with_one_page_when_total_items_equals_zero($router)
     {
         $router
             ->generate(
                 'attribute_option_list_route',
-                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null],
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'limit'=> 2, 'search_after' => null, 'search_before' => null],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2');
@@ -197,6 +310,7 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
                     'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&limit=2',
                 ],
             ],
+            'current_page' => null,
             '_embedded'    => [
                 'items' => [],
             ],
@@ -205,10 +319,10 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $parameters = [
             'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
             'query_parameters'    => ['limit' => 2, 'pagination_type' => 'search_after'],
-            'search_after'        => ['self' => null, 'next' => null],
             'list_route_name'     => 'attribute_option_list_route',
             'item_route_name'     => 'attribute_option_item_route',
             'item_identifier_key' => 'code',
+            'search_after'        => ['self' => '', 'next' => '', 'previous' => ''],
         ];
 
         $this->paginate([], $parameters, null)->shouldReturn($expectedItems);
@@ -223,5 +337,4 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
     {
         $this->shouldThrow(PaginationParametersException::class)->during('paginate', [[], [], null]);
     }
-
 }

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
@@ -31,8 +31,7 @@ class LengthGuesser implements ConstraintGuesserInterface
             $attribute->getType(),
             [
                 AttributeTypes::TEXT,
-                AttributeTypes::TEXTAREA,
-                AttributeTypes::IDENTIFIER,
+                AttributeTypes::TEXTAREA
             ]
         );
     }

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/NotBlankGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/NotBlankGuesser.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Validator\ConstraintGuesser;
 
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -20,7 +21,12 @@ class NotBlankGuesser implements ConstraintGuesserInterface
      */
     public function supportAttribute(AttributeInterface $attribute)
     {
-        return true;
+        return !in_array(
+            $attribute->getType(),
+            [
+                AttributeTypes::IDENTIFIER
+            ]
+        );
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RegexGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RegexGuesser.php
@@ -25,7 +25,6 @@ class RegexGuesser implements ConstraintGuesserInterface
             $attribute->getType(),
             [
                 AttributeTypes::TEXT,
-                AttributeTypes::IDENTIFIER,
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/LengthGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/LengthGuesserSpec.php
@@ -29,16 +29,15 @@ class LengthGuesserSpec extends ObjectBehavior
         $image->getType()->willReturn('pim_catalog_image');
 
         $this->supportAttribute($text)->shouldReturn(true);
-        $this->supportAttribute($identifier)->shouldReturn(true);
+        $this->supportAttribute($identifier)->shouldReturn(false);
         $this->supportAttribute($textarea)->shouldReturn(true);
 
         $this->supportAttribute($image)->shouldReturn(false);
     }
 
-    function it_enforces_database_length_constraints($text, $identifier, $textarea)
+    function it_enforces_database_length_constraints($text, $textarea)
     {
         $text->getMaxCharacters()->willReturn(null);
-        $identifier->getMaxCharacters()->willReturn(null);
         $textarea->getMaxCharacters()->willReturn(null);
 
         $textConstraints = $this->guessConstraints($text);
@@ -47,12 +46,6 @@ class LengthGuesserSpec extends ObjectBehavior
         $textConstraints[0]->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraints\Length');
         $textConstraints[0]->max->shouldBe(255);
 
-        $identifierConstraints = $this->guessConstraints($identifier);
-
-        $identifierConstraints->shouldHaveCount(1);
-        $identifierConstraints[0]->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraints\Length');
-        $identifierConstraints[0]->max->shouldBe(255);
-
         $textareaConstraints = $this->guessConstraints($textarea);
 
         $textareaConstraints->shouldHaveCount(1);
@@ -60,10 +53,9 @@ class LengthGuesserSpec extends ObjectBehavior
         $textareaConstraints[0]->max->shouldBe(65535);
     }
 
-    function it_enforces_the_max_characters_constraint($text, $identifier, $textarea)
+    function it_enforces_the_max_characters_constraint($text, $textarea)
     {
         $text->getMaxCharacters()->willReturn(100);
-        $identifier->getMaxCharacters()->willReturn(200);
         $textarea->getMaxCharacters()->willReturn(500);
 
         $textConstraints = $this->guessConstraints($text);
@@ -72,13 +64,6 @@ class LengthGuesserSpec extends ObjectBehavior
         $textConstraint = $textConstraints[0];
         $textConstraint->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraints\Length');
         $textConstraint->max->shouldBe(100);
-
-        $identifierConstraints = $this->guessConstraints($identifier);
-
-        $identifierConstraints->shouldHaveCount(1);
-        $identifierConstraint = $identifierConstraints[0];
-        $identifierConstraint->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraints\Length');
-        $identifierConstraint->max->shouldBe(200);
 
         $textareaConstraints = $this->guessConstraints($textarea);
 

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RegexGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RegexGuesserSpec.php
@@ -22,7 +22,7 @@ class RegexGuesserSpec extends ObjectBehavior
         $attribute->getType()
             ->willReturn('pim_catalog_identifier');
         $this->supportAttribute($attribute)
-            ->shouldReturn(true);
+            ->shouldReturn(false);
 
         $attribute->getType()
             ->willReturn('foo');


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

This PR fixs the last integration tests on the API (on Products).

On 1.7, there was 2 pagination system on products list: `offset` and `search_after`.
As it's impossible now with ES to use the `offset` system (due to the limitation on items fetched), the only way to paginate products is with `search_after`.

It's not consider as a BC break to force user to use the `search_after` pagination system, as the structure of the response is the same as before.
... In fact, the structure of the response is the same, but there is something we cannot calculate with the `search_after` system: the current page (it's impossible to calculate your "positition").

Here the (part) of the response when you request products:

| 1.7   | 1.8 |
| -------- | ----------- |
| "_link": {<br> "self": { "href": "http://localhost" },<br> "next": { "href": "http://localhost" },<br>"previous": { "href": "http://localhost" }<br>},<br>"current_page": 2 | "_link": {<br> "self": { "href": "http://localhost" },<br> "next": { "href": "http://localhost" },<br>"previous": { "href": "http://localhost" }<br>},<br>"current_page": null  |

We have to set `current_page` to null, it's not the ideal, but it's acceptable by PO. The most important is to keep the structure. Of course, we should avoid to have to much of this thing, but for this case, there is no other solution :(

About the change on VersionRepository.php, as I added 2 methods on CursorInterface, I realized the old implementation of cursor was still used to purge the versionning rows. As this old implem will be dropped, I use the doctrine Paginator


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
