### PR TITLE
TIP-613: Fix boolean form on PEF association datagrid

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-label-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-label-cell.js
@@ -18,8 +18,8 @@ define(['oro/datagrid/string-cell', 'oro/translator'],
                     return this;
                 }
 
-                var status = 'true' === value ? 'success' : 'important';
-                var label = 'true' === value ? 'Yes' : 'No';
+                var status = (true === value || 'true' === value || '1' === value) ? 'success' : 'important';
+                var label = (true === value || 'true' === value || '1' === value) ? 'Yes' : 'No';
 
                 this.$el.empty().html('<span class="AknBadge AknBadge--' + status +'">' + __(label) + '</span>');
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_group.yml
@@ -19,9 +19,7 @@ datagrid:
             is_associated:
                 label:         Is associated
                 data_name:     is_associated
-                type:          twig
-                template:      PimDataGridBundle:Property:boolean.html.twig
-                frontend_type: html
+                frontend_type: boolean-label
                 primary:       true
             code:
                 label: Code


### PR DESCRIPTION
## Description

This PR fixes boolean field on the PEF association datagrid.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
