### PR TITLE
TIP-706: Adds entity code check on ES PQB filters

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -127,6 +128,8 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
+     *
+     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
@@ -134,6 +137,11 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
+            if (null === $this->categoryRepository->findOneByIdentifier($value)) {
+                throw new ObjectNotFoundException(
+                    sprintf('Object "category" with code "%s" does not exist', $value)
+                );
+            }
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
@@ -3,9 +3,11 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 
 /**
  * Group filter for an Elasticsearch query
@@ -16,14 +18,20 @@ use Pim\Component\Catalog\Query\Filter\Operators;
  */
 class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
+    /** @var GroupRepositoryInterface */
+    protected $groupRepository;
+
     /**
-     * @param array $supportedFields
-     * @param array $supportedOperators
+     * @param GroupRepositoryInterface $groupRepository
+     * @param array                    $supportedFields
+     * @param array                    $supportedOperators
      */
     public function __construct(
+        GroupRepositoryInterface $groupRepository,
         array $supportedFields = [],
         array $supportedOperators = []
     ) {
+        $this->groupRepository = $groupRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -92,6 +100,8 @@ class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
+     *
+     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
@@ -99,6 +109,11 @@ class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
+            if (null === $this->groupRepository->findOneByIdentifier($value)) {
+                throw new ObjectNotFoundException(
+                    sprintf('Object "groups" with code "%s" does not exist', $value)
+                );
+            }
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -127,6 +127,7 @@ services:
     pim_catalog.query.elasticsearch.filter.group:
         class: '%pim_catalog.query.elasticsearch.filter.group.class%'
         arguments:
+            - '@pim_catalog.repository.group'
             - ['groups', 'variant_group']
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes some ES PQB filter to check if the given entity code exists prior to claquing the request to ES.
- CategoryFilter
- GroupFilter

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
