### PR TITLE
TIP-613: Fix datagrid option normalizer

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Normalizer/Product/OptionNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/Product/OptionNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Normalizer\Product;
 
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\ProductValue\OptionProductValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -17,9 +18,19 @@ class OptionNormalizer implements NormalizerInterface
      */
     public function normalize($option, $format = null, array $context = [])
     {
-        $locale = isset($context['data_locale']) ? $context['data_locale'] : null;
-        $translation = $option->getData()->getTranslation($locale);
-        $label = null !== $translation->getValue() ? $translation->getValue() : sprintf('[%s]', $option->getData()->getCode());
+        $optionData = $option->getData();
+
+        $label = '';
+        if ($optionData instanceof AttributeOptionInterface) {
+            if (isset($context['data_locale'])) {
+                $optionData->setLocale($context['data_locale']);
+            }
+            $translation = $optionData->getTranslation();
+
+            $label = null !== $translation->getValue() ?
+                $translation->getValue() :
+                sprintf('[%s]', $option->getData()->getCode());
+        }
 
         return [
             'locale' => $option->getLocale(),

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/Product/OptionNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/Product/OptionNormalizerSpec.php
@@ -6,6 +6,7 @@ use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 use Pim\Component\Catalog\ProductValue\OptionProductValueInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class OptionNormalizerSpec extends ObjectBehavior
 {
@@ -33,7 +34,8 @@ class OptionNormalizerSpec extends ObjectBehavior
         AttributeOptionValueInterface $optionValue
     ) {
         $productValue->getData()->willReturn($color);
-        $color->getTranslation('fr_FR')->willReturn($optionValue);
+        $color->setLocale('fr_FR')->shouldBeCalled();
+        $color->getTranslation()->willReturn($optionValue);
         $optionValue->getValue()->willReturn('Violet');
         $productValue->getLocale()->willReturn(null);
         $productValue->getScope()->willReturn(null);
@@ -53,7 +55,8 @@ class OptionNormalizerSpec extends ObjectBehavior
         AttributeOptionValueInterface $optionValue
     ) {
         $productValue->getData()->willReturn($color);
-        $color->getTranslation('fr_FR')->willReturn($optionValue);
+        $color->setLocale('fr_FR')->shouldBeCalled();
+        $color->getTranslation()->willReturn($optionValue);
         $color->getCode()->willReturn('purple');
         $optionValue->getValue()->willReturn(null);
         $optionValue->getValue()->willReturn(null);
@@ -64,6 +67,25 @@ class OptionNormalizerSpec extends ObjectBehavior
             'locale' => null,
             'scope'  => null,
             'data'   => '[purple]',
+        ];
+
+        $this->normalize($productValue, 'datagrid', ['data_locale' => 'fr_FR'])->shouldReturn($data);
+    }
+
+    function it_normalizes_a_simple_select_product_value_without_data(
+        OptionProductValueInterface $productValue,
+        AttributeOptionInterface $color
+    ) {
+        $productValue->getData()->willReturn(null);
+        $color->setLocale(Argument::any())->shouldNotBeCalled();
+        $color->getTranslation()->shouldNotBeCalled();
+        $productValue->getLocale()->willReturn(null);
+        $productValue->getScope()->willReturn(null);
+
+        $data =  [
+            'locale' => null,
+            'scope'  => null,
+            'data'   => '',
         ];
 
         $this->normalize($productValue, 'datagrid', ['data_locale' => 'fr_FR'])->shouldReturn($data);


### PR DESCRIPTION
## Description

Check that option product value contains an attribute option before getting its translation.
Anther thing is: the method `AttributeOptionInterface::getTranslation()` doesn't take any parameter. To use a specified locale, it must be set first in the option.

Fix at least `features/navigation/navigate_using_hash_navigation.feature:42`

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
