### PR TITLE
TIP-694: Fix completeness removal

### DIFF
--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -73,7 +73,7 @@ Feature: Display the completeness of a product
     When I filter by "scope" with operator "equals" and value "Tablet"
     Then the row "sneakers" should contain:
      | column   | value |
-     | complete | 89%   |
+     | complete | 88%   |
     And the row "sandals" should contain:
      | column   | value |
      | complete | 25%   |
@@ -88,7 +88,7 @@ Feature: Display the completeness of a product
     When I filter by "scope" with operator "equals" and value "Tablet"
     Then the row "sneakers" should contain:
      | column   | value |
-     | complete | 78%   |
+     | complete | 77%   |
     And the row "sandals" should contain:
      | column   | value |
      | complete | 50%   |

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
@@ -45,11 +45,12 @@ class CompletenessRemoverSpec extends ObjectBehavior
         Collection $completenesses,
         Statement $statement
     ) {
-        $product->getIdentifier()->willReturn('foo');
+        $product->getId()->willReturn(42);
         $product->getCompletenesses()->willReturn($completenesses);
         $completenesses->clear()->shouldBeCalled();
 
-        $connection->executeQuery(Argument::any(), ['foo'])->willReturn($statement);
+        $connection->prepare(Argument::any())->willReturn($statement);
+        $statement->bindValue('productId', 42)->shouldBeCalled();
         $statement->execute()->shouldBeCalled();
 
         $indexer->index($product)->shouldBeCalled();
@@ -70,8 +71,8 @@ class CompletenessRemoverSpec extends ObjectBehavior
         CursorInterface $products,
         Statement $statement
     ) {
-        $product1->getIdentifier()->willReturn('foo');
-        $product2->getIdentifier()->willReturn('bar');
+        $product1->getId()->willReturn(21);
+        $product2->getId()->willReturn(42);
 
         $products->rewind()->shouldBeCalled();
         $products->valid()->willReturn(true, true, false);
@@ -91,7 +92,7 @@ class CompletenessRemoverSpec extends ObjectBehavior
         $pqb->execute()->willReturn($products);
 
         $connection->prepare(Argument::any())->willReturn($statement);
-        $statement->bindValue('identifiers', ['foo', 'bar'], Type::SIMPLE_ARRAY)->shouldBeCalled();
+        $statement->bindValue('productIds', [21, 42], Type::SIMPLE_ARRAY)->shouldBeCalled();
         $statement->execute()->shouldBeCalled();
 
         $product1->getCompletenesses()->willReturn($completenesses1);
@@ -119,8 +120,8 @@ class CompletenessRemoverSpec extends ObjectBehavior
         CursorInterface $products,
         Statement $statement
     ) {
-        $product1->getIdentifier()->willReturn('foo');
-        $product2->getIdentifier()->willReturn('bar');
+        $product1->getId()->willReturn(21);
+        $product2->getId()->willReturn(42);
 
         $products->rewind()->shouldBeCalled();
         $products->valid()->willReturn(true, true, false);
@@ -141,7 +142,7 @@ class CompletenessRemoverSpec extends ObjectBehavior
         $pqb->execute()->willReturn($products);
 
         $connection->prepare(Argument::any())->willReturn($statement);
-        $statement->bindValue('identifiers', ['foo', 'bar'], Type::SIMPLE_ARRAY)->shouldBeCalled();
+        $statement->bindValue('productIds', [21, 42], Type::SIMPLE_ARRAY)->shouldBeCalled();
         $statement->execute()->shouldBeCalled();
 
         $product1->getCompletenesses()->willReturn($completenesses1);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/completeness-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/completeness-cell.js
@@ -13,21 +13,20 @@ define(['oro/datagrid/string-cell'],
              * Render the completeness.
              */
             render: function () {
-                var ratio = this.formatter.fromRaw(this.model.get(this.column.get("name")));
+                var ratio = this.formatter.fromRaw(this.model.get(this.column.get('name')));
 
-                if (null === ratio || '' === ratio) {
-                    var completeness = '-';
-                } else {
+                var completeness = '-';
+                if (null !== ratio && '' !== ratio) {
                     var cssClass = '';
-                    if (100 == ratio) {
+                    if (100 === ratio) {
                         cssClass+= 'success';
-                    } else if (0 == ratio) {
+                    } else if (0 === ratio) {
                         cssClass+= 'important';
                     } else {
                         cssClass+= 'warning';
                     }
 
-                    var completeness = '<span class="AknBadge AknBadge--'+ cssClass +'">'+ ratio +'%</span>';
+                    completeness = '<span class="AknBadge AknBadge--'+ cssClass +'">'+ ratio +'%</span>';
                 }
 
                 this.$el.empty().html(completeness);

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
@@ -2,10 +2,7 @@
 
 namespace Pim\Component\Catalog\Completeness;
 
-use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
-use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -113,7 +110,6 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         }
 
         $newCompletenesses = $this->completenessCalculator->calculate($product);
-
         foreach ($newCompletenesses as $completeness) {
             $completenessCollection->add($completeness);
         }


### PR DESCRIPTION
## Description

We are currently facing an issue with completeness. When updating a product, completeness is cleared, then recalculated. Problem is the "clearing" part does not only remove the completeness of the current product, but of all products in database…

This PR fixes this issue by making the SQL query responsible for this clearing using product IDs instead of Identifiers. This prevents to have to join on the product table and avoid destroying other completenesses.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
