### PR TITLE
TIP-706: product ID PQB filter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/IdFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/IdFilter.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Id filter for an Elasticsearch query
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IdFilter extends AbstractFieldFilter
+{
+    /**
+     * @param array $supportedFields
+     * @param array $supportedOperators
+     */
+    public function __construct(
+        array $supportedFields = [],
+        array $supportedOperators = []
+    ) {
+        $this->supportedFields = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter(
+        $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkValue($operator, $value);
+
+        if (is_array($value)) {
+            $value = array_map(
+                function ($value) {
+                    return (string)$value;
+                },
+                $value
+            );
+        } else {
+            $value = (string)$value;
+        }
+
+        switch ($operator) {
+            case Operators::EQUALS:
+                $clause = [
+                    'term' => [
+                        'id' => $value
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+            case Operators::NOT_EQUAL:
+                $mustNotClause = [
+                    'term' => [
+                        'id' => $value,
+                    ],
+                ];
+                $filterClause = [
+                    'exists' => [
+                        'field' => 'id',
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+            case Operators::IN_LIST:
+                $clause = [
+                    'terms' => [
+                        'id' => $value,
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+            case Operators::NOT_IN_LIST:
+                $clause = [
+                    'terms' => [
+                        'id' => $value,
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks that the value is a number.
+     *
+     * @param string $operator
+     * @param mixed  $value
+     */
+    protected function checkValue($operator, $value)
+    {
+        if (in_array($operator, [Operators::EQUALS, Operators::NOT_EQUAL])) {
+            FieldFilterHelper::checkString('id', $value, static::class);
+        } else {
+            FieldFilterHelper::checkArray('id', $value, static::class);
+            foreach ($value as $oneValue) {
+                if (!is_string($oneValue)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        'id',
+                        'one of the value is not string',
+                        static::class,
+                        $value
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1954,38 +1954,72 @@ Example for the ``>`` operator:
 
 Product id
 **********
-:Apply: id field
 
-Product system ids coming from DB (autoincrement in ORM or MongoDBRef in MongoDB) are used as
-the Elasticsearch ``"_id"`` field
+:Apply: apply datatype 'keyword' on the 'id' field
 
-.. code-block:: yaml
+Unique ID of the product. This field is also used as the Elasticsearch ``"_id"`` field.
 
-  _id: "54f96c28c1ad880c308b4b90"
+Data model
+~~~~~~~~~~
+.. code-block:: php
+
+    [
+        'id' => '4f3fcfec-2448-11e7-93ae-92361f002671'
+    ]
 
 Filtering
 ~~~~~~~~~
 Operators
 .........
+
 Equals (=)
-~~~~~~~~~~
+""""""""""
 
-.. code-block:: yaml
+.. code-block:: php
 
-    ids:
-        values: ["54f96c28c1ad880c308b4b66"]
+    'filter' => [
+        'term' => [
+            'id' => '4f3fcfec-2448-11e7-93ae-92361f002671'
+        ]
+    ]
 
-IN
-~~
+Not Equal (!=)
+""""""""""""""
 
-    ::
-        ids:
-            values: ["54f96c28c1ad880c308b4b66","54f96c28c1ad880c308b4b7b"]
+.. code-block:: php
 
-NOT IN
-~~~~~~
+    'must_not' => [
+        'term' => [
+            'id' => '4f3fcfec-2448-11e7-93ae-92361f002671'
+        ]
+    ],
+    'filter' => [
+        'exists' => [
+            'field' => 'id'
+        ]
+    ]
 
-Same as ``IN``, but with the ``must_not`` occured type
+In list
+"""""""
+
+.. code-block:: php
+
+    'filter' => [
+        'terms' => [
+            'id' => ['4f3fcfec-2448-11e7-93ae-92361f002671', '5f61fd3c-2448-11e7-93ae-92361f002671']
+        ]
+    ]
+
+Not In list
+"""""""""""
+
+.. code-block:: php
+
+    'must_not' => [
+        'terms' => [
+            'id' => ['4f3fcfec-2448-11e7-93ae-92361f002671', '5f61fd3c-2448-11e7-93ae-92361f002671']
+        ]
+    ]
 
 Family
 ******

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -14,6 +14,7 @@ parameters:
     pim_catalog.doctrine.query.filter.object_code_resolver.class: Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver
 
     pim_catalog.query.elasticsearch.filter.identifier.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter
+    pim_catalog.query.elasticsearch.filter.id.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\IdFilter
     pim_catalog.query.elasticsearch.filter.family.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\FamilyFilter
     pim_catalog.query.elasticsearch.filter.category.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CategoryFilter
     pim_catalog.query.elasticsearch.filter.group.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\GroupFilter
@@ -112,6 +113,14 @@ services:
             - ['identifier']
             - ['pim_catalog_identifier']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.id:
+        class: '%pim_catalog.query.elasticsearch.filter.id.class%'
+        arguments:
+            - ['id']
+            - ['IN', 'NOT IN', '=', '!=']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -7,6 +7,8 @@ mappings:
             family.code:
                     type: 'keyword'
             # family labels are handled by the "family" dynamic template
+            id:
+                type: 'keyword'
             enabled:
                 type: 'boolean'
             groups:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/IdFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/IdFilterSpec.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\IdFilter;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Prophecy\Argument;
+
+class IdFilterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(
+            ['id'],
+            ['IN', 'NOT IN', '=', '!=']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IdFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(
+            [
+                'IN',
+                'NOT IN',
+                '=',
+                '!=',
+            ]
+        );
+        $this->supportsOperator('IN')->shouldReturn(true);
+        $this->supportsOperator('DOES NOT CONTAIN')->shouldReturn(false);
+    }
+
+    function it_supports_family_field()
+    {
+        $this->supportsField('id')->shouldReturn(true);
+        $this->supportsField('a_not_supported_field')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_in_list(SearchQueryBuilder $sqb)
+    {
+        $sqb->addFilter(
+            [
+                'terms' => [
+                    'id' => ['4F3FCFEC-2448-11E7-93AE-92361F002671', '5F61FD3C-2448-11E7-93AE-92361F002671'],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'id',
+            Operators::IN_LIST,
+            ['4F3FCFEC-2448-11E7-93AE-92361F002671', '5F61FD3C-2448-11E7-93AE-92361F002671'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_not_in_list(SearchQueryBuilder $sqb)
+    {
+        $sqb->addMustNot(
+            [
+                'terms' => [
+                    'id' => ['4F3FCFEC-2448-11E7-93AE-92361F002671', '5F61FD3C-2448-11E7-93AE-92361F002671'],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'id',
+            Operators::NOT_IN_LIST,
+            ['4F3FCFEC-2448-11E7-93AE-92361F002671', '5F61FD3C-2448-11E7-93AE-92361F002671'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_equal(SearchQueryBuilder $sqb)
+    {
+        $sqb->addFilter(
+            [
+                'term' => [
+                    'id' => '4F3FCFEC-2448-11E7-93AE-92361F002671',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('id', Operators::EQUALS, '4F3FCFEC-2448-11E7-93AE-92361F002671', null, null, []);
+    }
+
+    function it_adds_a_filter_with_operator_not_equal(SearchQueryBuilder $sqb)
+    {
+        $sqb->addMustNot(
+            [
+                'term' => [
+                    'id' => '4F3FCFEC-2448-11E7-93AE-92361F002671',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addFilter(
+            [
+                'exists' => [
+                    'field' => 'id',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('id', Operators::NOT_EQUAL, '4F3FCFEC-2448-11E7-93AE-92361F002671', null, null, []);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during(
+            'addFieldFilter',
+            [
+                'id',
+                Operators::IN_LIST,
+                ['4F3FCFEC-2448-11E7-93AE-92361F002671', '5F61FD3C-2448-11E7-93AE-92361F002671'],
+                null,
+                null,
+                []
+            ]
+        );
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_an_array_with_in_list(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                'id',
+                IdFilter::class,
+                'NOT_AN_ARRAY'
+            )
+        )->during('addFieldFilter', ['id', Operators::IN_LIST, 'NOT_AN_ARRAY', null, null, []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_an_array_with_not_in_list(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                'id',
+                IdFilter::class,
+                'NOT_AN_ARRAY'
+            )
+        )->during('addFieldFilter', ['id', Operators::NOT_IN_LIST, 'NOT_AN_ARRAY', null, null, []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_a_string_with_equals(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'id',
+                IdFilter::class,
+                [false]
+            )
+        )->during('addFieldFilter', ['id', Operators::EQUALS, [false], null, null, []]);
+    }
+
+    function it_throws_an_exception_when_the_given_value_is_not_a_string_with_not_equals(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'id',
+                IdFilter::class,
+                [false]
+            )
+        )->during('addFieldFilter', ['id', Operators::NOT_EQUAL, [false], null, null, []]);
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                IdFilter::class
+            )
+        )->during('addFieldFilter', ['id', Operators::IN_CHILDREN_LIST, ['5f61fd3c-2448-11e7-93ae-92361f002671'], null, null, []]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogFamilyIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\ElasticSearch\IndexConfiguration;
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
 /**
  * @author    Samir Boulil <samir.boulil@gmail.com>

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/IdFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/IdFilterIntegration.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * @author    Jullien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IdFilterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    private static $ids = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
+            $foo = $this->createProduct('foo', []);
+            $bar = $this->createProduct('bar', []);
+            $baz = $this->createProduct('baz', []);
+            $barista = $this->createProduct('BARISTA', []);
+            $bazar = $this->createProduct('BAZAR', []);
+
+            self::$ids['foo'] = (string) $foo->getId();
+            self::$ids['bar'] = (string) $bar->getId();
+            self::$ids['baz'] = (string) $baz->getId();
+            self::$ids['barista'] = (string) $barista->getId();
+            self::$ids['bazar'] = (string) $bazar->getId();
+        }
+    }
+
+    public function testOperatorEquals()
+    {
+        $result = $this->executeFilter([['id', Operators::EQUALS, self::$ids['baz']]]);
+        $this->assert($result, ['baz']);
+
+        $result = $this->executeFilter([['id', Operators::EQUALS, $this->getUnknowRandomId()]]);
+        $this->assert($result, []);
+    }
+
+    public function testOperatorNotEquals()
+    {
+        $result = $this->executeFilter([['id', Operators::NOT_EQUAL, $this->getUnknowRandomId()]]);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+
+        $result = $this->executeFilter([['id', Operators::NOT_EQUAL, self::$ids['baz']]]);
+        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR']);
+    }
+
+    public function testOperatorInList()
+    {
+        $result = $this->executeFilter([['id', Operators::IN_LIST, [self::$ids['baz'], self::$ids['foo']]]]);
+        $this->assert($result, ['foo', 'baz']);
+
+        $result = $this->executeFilter([['id', Operators::IN_LIST, [self::$ids['baz'], $this->getUnknowRandomId()]]]);
+        $this->assert($result, ['baz']);
+
+        $result = $this->executeFilter([['id', Operators::IN_LIST, [$this->getUnknowRandomId(), $this->getUnknowRandomId()]]]);
+        $this->assert($result, []);
+    }
+
+    public function testOperatorNotInList()
+    {
+        $result = $this->executeFilter([['id', Operators::NOT_IN_LIST, [self::$ids['baz'], self::$ids['foo']]]]);
+        $this->assert($result, ['bar', 'BARISTA', 'BAZAR']);
+
+        $result = $this->executeFilter([['id', Operators::NOT_IN_LIST, [self::$ids['baz'], $this->getUnknowRandomId()]]]);
+        $this->assert($result, ['bar', 'BARISTA', 'BAZAR', 'foo']);
+
+        $result = $this->executeFilter([['id', Operators::NOT_IN_LIST, [$this->getUnknowRandomId(), $this->getUnknowRandomId()]]]);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "id" expects a string as data, "array" given.
+     */
+    public function testErrorDataIsMalformed()
+    {
+        $this->executeFilter([['id', Operators::EQUALS, ['string']]]);
+    }
+
+    /**
+     * @expectedException \Pim\Component\Catalog\Exception\UnsupportedFilterException
+     * @expectedExceptionMessage Filter on property "id" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->executeFilter([['id', Operators::BETWEEN, 'foo']]);
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "id" expects an array as data, "string" given.
+     */
+    public function testDataIsMalformedForOperatorInList()
+    {
+        $this->executeFilter([['id', Operators::IN_LIST, 'foo']]);
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "id" expects an array with valid data, one of the value is not string.
+     */
+    public function testDataIsNotAListOfStringForOperatorInList()
+    {
+        $this->executeFilter([['id', Operators::IN_LIST, [12, 'foo']]]);
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "id" expects an array as data, "string" given.
+     */
+    public function testDataIsMalformedForOperatorNotInList()
+    {
+        $this->executeFilter([['id', Operators::NOT_IN_LIST, 'foo']]);
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "id" expects an array with valid data, one of the value is not string.
+     */
+    public function testDataIsNotAListOfStringForOperatorNotInList()
+    {
+        $this->executeFilter([['id', Operators::NOT_IN_LIST, [12, 'foo']]]);
+    }
+
+    /**
+     * @return int
+     */
+    private function getUnknowRandomId()
+    {
+        do {
+            $id = rand();
+        } while (in_array($id, self::$ids));
+
+        return (string) $id;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
@@ -47,13 +47,13 @@ class BooleanSorterIntegration extends AbstractProductQueryBuilderTestCase
     public function testSorterAscending()
     {
         $result = $this->executeSorter([['a_yes_no', Directions::ASCENDING]]);
-        $this->assertOrder($result, ['no', 'yes', 'empty_product', 'null_product']);
+        $this->assertOrder($result, ['no', 'yes', 'null_product', 'empty_product']);
     }
 
     public function testSorterDescending()
     {
         $result = $this->executeSorter([['a_yes_no', Directions::DESCENDING]]);
-        $this->assertOrder($result, ['yes', 'no', 'empty_product', 'null_product']);
+        $this->assertOrder($result, ['yes', 'no', 'null_product', 'empty_product']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
@@ -22,7 +22,7 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             Directions::ASCENDING,
             ['locale' => 'fr_FR', 'scope' => 'tablet'],
         ]]);
-        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'empty_product', 'product_four']);
+        $this->assertOrder($result, ['product_three', 'product_two', 'product_one', 'product_four', 'empty_product']);
     }
 
     public function testSorterDescending()
@@ -32,7 +32,7 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             Directions::DESCENDING,
             ['locale' => 'fr_FR', 'scope' => 'tablet']
         ]]);
-        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product', 'product_four']);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four', 'empty_product']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/IsAssociatedSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/IsAssociatedSorterIntegration.php
@@ -17,14 +17,14 @@ class IsAssociatedSorterIntegration extends AbstractProductQueryBuilderTestCase
         $result = $this->executeSorter([['is_associated', Directions::DESCENDING]]);
         $this->assertOrder($result, [
             'foo_bar',
-            'foo_bar_baz',
             'foo_baz',
+            'foo_bar_baz',
             'foo_group_A',
             'foo_group_B',
             'foo_groups_AB',
+            'foo',
             'bar',
             'baz',
-            'foo',
         ]);
     }
 
@@ -32,12 +32,12 @@ class IsAssociatedSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $result = $this->executeSorter([['is_associated', Directions::ASCENDING]]);
         $this->assertOrder($result, [
+            'foo',
             'bar',
             'baz',
-            'foo',
             'foo_bar',
-            'foo_bar_baz',
             'foo_baz',
+            'foo_bar_baz',
             'foo_group_A',
             'foo_group_B',
             'foo_groups_AB',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/StatusSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/StatusSorterIntegration.php
@@ -31,13 +31,13 @@ class StatusSorterIntegration extends AbstractProductQueryBuilderTestCase
     public function testSortDescendant()
     {
         $result = $this->executeSorter([['enabled', Directions::DESCENDING]]);
-        $this->assertOrder($result, ['bar', 'foobar', 'foobaz', 'baz', 'foo']);
+        $this->assertOrder($result, ['bar', 'foobar', 'foobaz', 'foo', 'baz']);
     }
 
     public function testSortAscendant()
     {
         $result = $this->executeSorter([['enabled', Directions::ASCENDING]]);
-        $this->assertOrder($result, ['baz', 'foo', 'bar', 'foobar', 'foobaz']);
+        $this->assertOrder($result, ['foo', 'baz', 'bar', 'foobar', 'foobaz']);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
@@ -15,13 +15,13 @@ class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
     public function testSortDescendant()
     {
         $result = $this->executeSorter([['in_group_4', Directions::DESCENDING]]);
-        $this->assertOrder($result, ['bar', 'foo', 'baz', 'empty']);
+        $this->assertOrder($result, ['foo', 'bar', 'baz', 'empty']);
     }
 
     public function testSortAscendant()
     {
         $result = $this->executeSorter([['in_group_4', Directions::ASCENDING]]);
-        $this->assertOrder($result, ['bar', 'foo', 'baz', 'empty']);
+        $this->assertOrder($result, ['foo', 'bar', 'baz', 'empty']);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -20,6 +20,7 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
     const FIELD_COMPLETENESS = 'completeness';
     const FIELD_IS_ASSOCIATED = 'is_associated';
     const FIELD_IN_GROUP = 'in_group';
+    const FIELD_ID = 'id';
 
     /**
      * {@inheritdoc}
@@ -32,6 +33,7 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
 
         $data = [];
 
+        $data[self::FIELD_ID] = (string) $product->getId();
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $product->getIdentifier();
         $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
             $product->getCreated(),

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -40,6 +40,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         Collection $completenesses,
         Collection $associations
     ) {
+        $product->getId()->willReturn(67);
         $family = null;
         $product->getFamily()->willReturn($family);
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
@@ -72,6 +73,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
+                'id'            => '67',
                 'identifier'    => 'sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
@@ -94,6 +96,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         Collection $completenesses,
         Collection $associations
     ) {
+        $product->getId()->willReturn(67);
         $family = null;
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -132,6 +135,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
+                'id'            => '67',
                 'identifier'    => 'sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
@@ -158,6 +162,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
+        $product->getId()->willReturn(67);
         $product->getIdentifier()->willReturn('sku-001');
 
         $product->getCreated()->willReturn($now);
@@ -227,6 +232,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, 'indexing')->shouldReturn(
             [
+                'id'            => '67',
                 'identifier'    => 'sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -31,6 +31,7 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
+            'id'            => '47',
             'identifier'    => 'bar',
             'created'       => $date->format('c'),
             'updated'       => $date->format('c'),
@@ -56,6 +57,7 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
+            'id'            => '48',
             'identifier'    => 'baz',
             'created'       => $date->format('c'),
             'updated'       => $date->format('c'),
@@ -81,6 +83,7 @@ class ProductIndexingIntegration extends TestCase
         );
 
         $expected = [
+            'id'            => '49',
             'identifier'    => 'foo',
             'created'       => $date->format('c'),
             'updated'       => $date->format('c'),


### PR DESCRIPTION
Last filter of the PQB \o/
We need it for the mass edit mostly, as grid only returns the ID of the products (and obviously, we don't want to rewrite the grid in our topic :p).

## Indexing the product by ID instead of identifier
In this PR, I also changed the Elasticsearch __id_ of the product documents, to use the _id_ instead of the _identifier_. As the _identifier_ is mutable, it's not a good candidate for the ES __id_. It would force us to remove documents in some places and could lead to inconsistent data results if we forgot this operation.

With the agreement of Benoit, we decided to use a technical ID for the __id_. Currently, it's the MySQL autoincrement ID, but soon, in another PR, it will be a real UUID generated by application.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | 
| Added integration tests           | Y
| Changelog updated                 | 
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -