### PR TITLE
TIP-713: Fix remaining completeness behat failures

### DIFF
--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -31,9 +31,9 @@ Feature: Display the completeness of a product
     And I should see the completeness:
       | channel | locale | state   | missing_values         | ratio |
       | mobile  | en_US  | success |                        | 100%  |
-      | tablet  | en_US  | warning | Side view              | 89%   |
+      | tablet  | en_US  | warning | Side view              | 88%   |
       | mobile  | fr_FR  | success |                        | 100%  |
-      | tablet  | fr_FR  | warning | Description, Side view | 78%   |
+      | tablet  | fr_FR  | warning | Description, Side view | 77%   |
     When I am on the products page
     Then I am on the "sandals" product page
     And the Name field should be highlighted
@@ -117,7 +117,7 @@ Feature: Display the completeness of a product
     When I filter by "scope" with operator "equals" and value "Tablet"
     Then the row "sneakers" should contain:
      | column   | value |
-     | complete | 89%   |
+     | complete | 88%   |
 
   Scenario: Don't display the completeness if the family is not defined
     Given I am on the "sneakers" product page

--- a/features/product/completeness/remove_completeness.feature
+++ b/features/product/completeness/remove_completeness.feature
@@ -71,7 +71,7 @@ Feature: Display the completeness of a product
       | channel | locale | state   | missing_values         | ratio |
       | mobile  | en_US  | success |                        | 100%  |
       | mobile  | fr_FR  | success |                        | 100%  |
-      | tablet  | fr_FR  | warning | Description, Side view | 78%   |
+      | tablet  | fr_FR  | warning | Description, Side view | 77%   |
     When I am on the "sandals" product page
     And I open the "Completeness" panel
     Then I should see the completeness:
@@ -112,7 +112,7 @@ Feature: Display the completeness of a product
     When I filter by "scope" with operator "equals" and value "Tablet"
     Then the row "sneakers" should contain:
      | column   | value |
-     | complete | 78%   |
+     | complete | 77%   |
     And the row "sandals" should contain:
      | column   | value |
      | complete | 50%   |

--- a/features/product/completeness/update_completeness.feature
+++ b/features/product/completeness/update_completeness.feature
@@ -28,9 +28,9 @@ Feature: Display the completeness of a product
     Then I should see the completeness:
       | channel | locale | state   | missing_values         | ratio |
       | mobile  | en_US  | success |                        | 100%  |
-      | tablet  | en_US  | warning | Side view              | 89%   |
+      | tablet  | en_US  | warning | Side view              | 88%   |
       | mobile  | fr_FR  | success |                        | 100%  |
-      | tablet  | fr_FR  | warning | Description, Side view | 78%   |
+      | tablet  | fr_FR  | warning | Description, Side view | 77%   |
     When I visit the "Attributes" tab
     And I visit the "Media" group
     And I attach file "SNKRS-1C-s.png" to "Side view"
@@ -42,4 +42,4 @@ Feature: Display the completeness of a product
       | mobile  | en_US  | success |                | 100%  |
       | tablet  | en_US  | success |                | 100%  |
       | mobile  | fr_FR  | success |                | 100%  |
-      | tablet  | fr_FR  | warning | Description    | 89%   |
+      | tablet  | fr_FR  | warning | Description    | 88%   |


### PR DESCRIPTION
## Description

This PR fixes remaing behat tests on completeness that still fails:
- Some expected completenesses in scenarios were false since we always round values to the lowest
- There was a bug on the CompletenessRemover introduced in a previous PR:
    - we used a Doctrine prepare statement on the bulk remove, and bind the array of product ids to work on. This cannot work https://doctrine-orm.readthedocs.io/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#list-of-parameters-conversion and so the `prepare` has been replaced by an `executeQuery`,
    - when removing a locale from a channel, all completenesses were removed, which is wrong. Now only the ones corresponding to this couple channel/locale are, both from database and products (as products are immediately reindexed).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
