### PR TITLE
TIP-692: give more flexibility to the completeness services 

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -12,8 +12,8 @@
 
 ### Constructors
 
-- Extract methods `schedule*` of `Pim\Component\Catalog\Completeness\CompletenessGeneratorInterface` into a `Pim\Component\Catalog\Completeness\CompletenessRemoverInterface`. Methods `schedule`, `scheduleForFamily` and `scheduleForChannelAndLocale` have been renamed respectively `removeForProduct`, `removeForFamily` and `removeForChannelAndLocale`.
-- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array 
+- Change the constructor of `Pim\Component\Catalog\Manager\CompletenessManager` to remove the completeness class.
+- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `kernel.logs_dir`
@@ -45,6 +45,7 @@
 
 ### Others
 
+- Extract methods `schedule*` of `Pim\Component\Catalog\Completeness\CompletenessGeneratorInterface` into a `Pim\Component\Catalog\Completeness\CompletenessRemoverInterface`. Methods `schedule`, `scheduleForFamily` and `scheduleForChannelAndLocale` have been renamed respectively `removeForProduct`, `removeForFamily` and `removeForChannelAndLocale`.
 - Remove method `findOneById` of `Pim\Component\Catalog\Repository\ProductRepositoryInterface`.
 - Move class `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\DummyFilter` to `Pim\Bundle\EnrichBundle\ProductQueryBuilder\Filter\DummyFilter` as this filter is just for UI concerns
 - Rename class `Pim\Component\Catalog\Completeness\Checker\ChainedProductValueCompleteChecker`  to `Pim\Component\Catalog\Completeness\Checker\ProductValueCompleteChecker`

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/completeness.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/completeness.yml
@@ -10,6 +10,7 @@ services:
             - '@pim_catalog.repository.cached_channel'
             - '@pim_catalog.repository.cached_locale'
             - '@pim_catalog.completeness.checker'
+            - '%pim_catalog.entity.completeness.class%'
 
     pim_catalog.completeness.generator:
         class: '%pim_catalog.completeness.generator.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/managers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/managers.yml
@@ -30,7 +30,6 @@ services:
             - '@pim_catalog.completeness.generator'
             - '@pim_catalog.remover.completeness'
             - '@pim_catalog.completeness.checker'
-            - '%pim_catalog.entity.completeness.class%'
 
     pim_catalog.manager.product_template_media:
         class: '%pim_catalog.manager.product_template_media.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
@@ -83,6 +83,7 @@ services:
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.elasticsearch.product_indexer'
+            - 'pim_catalog_completeness'
 
     pim_catalog.remover.base_options_resolver:
         class: '%pim_catalog.remover.base_options_resolver.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
@@ -28,7 +28,7 @@ class CompletenessRemoverSpec extends ObjectBehavior
         ProductIndexer $indexer,
         Connection $connection
     ) {
-        $this->beConstructedWith($pqbFactory, $entityManager, $indexer);
+        $this->beConstructedWith($pqbFactory, $entityManager, $indexer, 'pim_catalog_completeness');
 
         $entityManager->getConnection()->willReturn($connection);
     }

--- a/src/Pim/Component/Catalog/Completeness/CompletenessCalculator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessCalculator.php
@@ -4,11 +4,14 @@ namespace Pim\Component\Catalog\Completeness;
 
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Pim\Component\Catalog\Completeness\Checker\ProductValueCompleteCheckerInterface;
 use Pim\Component\Catalog\Factory\ProductValueFactory;
+use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\Completeness;
 use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
@@ -40,22 +43,28 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
     /** @var ProductValueCompleteCheckerInterface */
     protected $productValueCompleteChecker;
 
+    /** @var string */
+    protected $completenessClass;
+
     /**
      * @param ProductValueFactory                  $productValueFactory
      * @param CachedObjectRepositoryInterface      $channelRepository
      * @param CachedObjectRepositoryInterface      $localeRepository
      * @param ProductValueCompleteCheckerInterface $productValueCompleteChecker
+     * @param string                               $completenessClass
      */
     public function __construct(
         ProductValueFactory $productValueFactory,
         CachedObjectRepositoryInterface $channelRepository,
         CachedObjectRepositoryInterface $localeRepository,
-        ProductValueCompleteCheckerInterface $productValueCompleteChecker
+        ProductValueCompleteCheckerInterface $productValueCompleteChecker,
+        $completenessClass
     ) {
         $this->productValueFactory = $productValueFactory;
         $this->channelRepository = $channelRepository;
         $this->localeRepository = $localeRepository;
         $this->productValueCompleteChecker = $productValueCompleteChecker;
+        $this->completenessClass = $completenessClass;
     }
 
     /**
@@ -218,7 +227,7 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
             $requiredCount++;
         }
 
-        $completeness = new Completeness(
+        $completeness = $this->createCompleteness(
             $product,
             $channel,
             $locale,
@@ -228,5 +237,33 @@ class CompletenessCalculator implements CompletenessCalculatorInterface
         );
 
         return $completeness;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param ChannelInterface $channel
+     * @param LocaleInterface  $locale
+     * @param Collection       $missingAttributes
+     * @param int              $missingCount
+     * @param int              $requiredCount
+     *
+     * @return CompletenessInterface
+     */
+    private function createCompleteness(
+        ProductInterface $product,
+        ChannelInterface $channel,
+        LocaleInterface $locale,
+        Collection $missingAttributes,
+        $missingCount,
+        $requiredCount
+    ) {
+        return new $this->completenessClass(
+            $product,
+            $channel,
+            $locale,
+            $missingAttributes,
+            $missingCount,
+            $requiredCount
+        );
     }
 }

--- a/src/Pim/Component/Catalog/Manager/CompletenessManager.php
+++ b/src/Pim/Component/Catalog/Manager/CompletenessManager.php
@@ -44,9 +44,6 @@ class CompletenessManager
     /** @var ProductValueCompleteCheckerInterface */
     protected $valueCompleteChecker;
 
-    /** @var string */
-    protected $class;
-
     /**
      * @param FamilyRepositoryInterface            $familyRepository
      * @param ChannelRepositoryInterface           $channelRepository
@@ -54,7 +51,6 @@ class CompletenessManager
      * @param CompletenessGeneratorInterface       $generator
      * @param CompletenessRemoverInterface         $remover
      * @param ProductValueCompleteCheckerInterface $valueCompleteChecker
-     * @param string                               $class
      */
     public function __construct(
         FamilyRepositoryInterface $familyRepository,
@@ -62,8 +58,7 @@ class CompletenessManager
         LocaleRepositoryInterface $localeRepository,
         CompletenessGeneratorInterface $generator,
         CompletenessRemoverInterface $remover,
-        ProductValueCompleteCheckerInterface $valueCompleteChecker,
-        $class
+        ProductValueCompleteCheckerInterface $valueCompleteChecker
     ) {
         $this->familyRepository = $familyRepository;
         $this->channelRepository = $channelRepository;
@@ -71,7 +66,6 @@ class CompletenessManager
         $this->generator = $generator;
         $this->remover = $remover;
         $this->valueCompleteChecker = $valueCompleteChecker;
-        $this->class = $class;
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Completeness/CompletenessCalculatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Completeness/CompletenessCalculatorSpec.php
@@ -12,6 +12,7 @@ use Pim\Component\Catalog\Factory\ProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\Completeness;
 use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
@@ -32,7 +33,8 @@ class CompletenessCalculatorSpec extends ObjectBehavior
             $productValueFactory,
             $channelRepository,
             $localeRepository,
-            $productValueCompleteChecker
+            $productValueCompleteChecker,
+            Completeness::class
         );
     }
 


### PR DESCRIPTION
2 things here:
- this PR allows the CompletenessRemover to be used by published products (in EE, the completeness table is different)
- this PR allows the CompletenessCalculator to be used by published products (in EE, the completeness class is different)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
