### PR TITLE
TIP-713: Fix product builder "addBooleanToProduct"

### DIFF
--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -296,7 +296,7 @@ class ProductBuilder implements ProductBuilderInterface
                 $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
 
                 foreach ($requiredValues as $value) {
-                    $this->addOrReplaceProductValue($product, $attribute, $value['scope'], $value['locale'], false);
+                    $this->addOrReplaceProductValue($product, $attribute, $value['locale'], $value['scope'], false);
                 }
             }
         }


### PR DESCRIPTION
## Description

An issue with boolean in 1.7 (PIM-6056)  forced us to set boolean product values to false when empty.

This is done in the product builder, but when merging 1.7 in our branch, a terrible mistake occurs: scope and locale were switched! This PR bring back order.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
