### PR TITLE
TIP-713: fixes sort on product families

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -494,17 +494,18 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     /**
      * @param string $order
      * @param string $columnName
+     * @param bool   $naturally If TRUE, empty values are taken in account when sorting
      *
      * @throws ExpectationException
      *
-     * @Then /^the rows should be sorted (ascending|descending) by (.*)$/
+     * @Then /^the rows should be( naturally)? sorted (ascending|descending) by (.*)$/
      */
-    public function theRowsShouldBeSortedBy($order, $columnName)
+    public function theRowsShouldBeSortedBy($naturally, $order, $columnName)
     {
         $columnName = strtoupper($columnName);
 
-        $this->spin(function () use ($columnName, $order) {
-            return $this->datagrid->isSortedAndOrdered($columnName, $order);
+        $this->spin(function () use ($naturally, $columnName, $order) {
+            return $this->datagrid->isSortedAndOrdered($columnName, $order, $naturally);
         }, sprintf('The rows are not sorted %s by column %s', $order, $columnName));
     }
 
@@ -547,13 +548,14 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
+     * @param bool   $naturally If TRUE, empty values are taken in account when sorting
      * @param string $columns
      *
-     * @Then /^I should be able to sort the rows by (.*)$/
+     * @Then /^I should be able to( naturally)? sort the rows by (.*)$/
      *
      * @return Then[]
      */
-    public function iShouldBeAbleToSortTheRowsBy($columns)
+    public function iShouldBeAbleToSortTheRowsBy($naturally, $columns)
     {
         $steps = [
             new Step\Then(sprintf('the rows should be sortable by %s', $columns))
@@ -562,9 +564,13 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
         foreach ($columns as $column) {
             $steps[] = new Step\Then(sprintf('I sort by "%s" value ascending', $column));
-            $steps[] = new Step\Then(sprintf('the rows should be sorted ascending by %s', $column));
+            $steps[] = new Step\Then(sprintf(
+                'the rows should be%s sorted ascending by %s', $naturally ? ' naturally' : '', $column
+            ));
             $steps[] = new Step\Then(sprintf('I sort by "%s" value descending', $column));
-            $steps[] = new Step\Then(sprintf('the rows should be sorted descending by %s', $column));
+            $steps[] = new Step\Then(sprintf(
+                'the rows should be%s sorted descending by %s', $naturally ? ' naturally' : '', $column
+            ));
         }
 
         return $steps;

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -533,6 +533,13 @@ class Grid extends Index
             rsort($sortedValues, SORT_NATURAL | SORT_FLAG_CASE);
         }
 
+        $valuesCount = count($sortedValues);
+        $sortedValues = array_filter($sortedValues, function ($value) {
+            return $value !== '';
+        });
+
+        $sortedValues = array_pad($sortedValues, $valuesCount, '');
+
         return $sortedValues === $values;
     }
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -512,10 +512,11 @@ class Grid extends Index
      *
      * @param string $columnName
      * @param string $order
+     * @param bool   $natural If TRUE, empty values are taken in account when sorting
      *
      * @return bool
      */
-    public function isSortedAndOrdered($columnName, $order)
+    public function isSortedAndOrdered($columnName, $order, $natural)
     {
         $order = strtolower($order);
         if (!$this->getColumnHeader($columnName)->hasClass($order)) {
@@ -533,12 +534,15 @@ class Grid extends Index
             rsort($sortedValues, SORT_NATURAL | SORT_FLAG_CASE);
         }
 
-        $valuesCount = count($sortedValues);
-        $sortedValues = array_filter($sortedValues, function ($value) {
-            return $value !== '';
-        });
+        // If not sorted naturally, always put empty values at the end, whatever the $order
+        if (!$natural) {
+            $valuesCount = count($sortedValues);
+            $sortedValues = array_filter($sortedValues, function ($value) {
+                return $value !== '';
+            });
 
-        $sortedValues = array_pad($sortedValues, $valuesCount, '');
+            $sortedValues = array_pad($sortedValues, $valuesCount, '');
+        }
 
         return $sortedValues === $values;
     }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Field/FamilySorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Field/FamilySorter.php
@@ -53,8 +53,9 @@ class FamilySorter extends BaseFieldSorter
                 if (null !== $familyLabelPath) {
                     $sortFamilyLabelClause = [
                         $familyLabelPath => [
-                            'order'   => 'ASC',
-                            'missing' => '_last',
+                            'order'         => 'ASC',
+                            'unmapped_type' => 'string',
+                            'missing'       => '_last',
                         ],
                     ];
                     $this->searchQueryBuilder->addSort($sortFamilyLabelClause);
@@ -73,8 +74,9 @@ class FamilySorter extends BaseFieldSorter
                 if (null !== $familyLabelPath) {
                     $sortFamilyLabelClause = [
                         $familyLabelPath => [
-                            'order'   => 'DESC',
-                            'missing' => '_last',
+                            'order'         => 'DESC',
+                            'unmapped_type' => 'string',
+                            'missing'       => '_last',
                         ],
                     ];
                     $this->searchQueryBuilder->addSort($sortFamilyLabelClause);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -41,6 +41,7 @@ services:
         class: '%pim_catalog.normalizer.indexing.product.family.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
+            - '@pim_catalog.repository.locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -5,7 +5,7 @@ mappings:
             categories:
                 type: 'keyword'
             family.code:
-                    type: 'keyword'
+                type: 'keyword'
             # family labels are handled by the "family" dynamic template
             id:
                 type: 'keyword'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Field/FamilySorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Field/FamilySorterSpec.php
@@ -55,8 +55,9 @@ class FamilySorterSpec extends ObjectBehavior
         $sqb->addSort(
             [
                 'family.labels.en_US' => [
-                    'order'   => 'ASC',
-                    'missing' => '_last',
+                    'order'         => 'ASC',
+                    'unmapped_type' => 'string',
+                    'missing'       => '_last',
                 ],
             ]
         )->shouldBeCalled();
@@ -96,8 +97,9 @@ class FamilySorterSpec extends ObjectBehavior
         $sqb->addSort(
             [
                 'family.labels.en_US' => [
-                    'order'   => 'DESC',
-                    'missing' => '_last',
+                    'order'         => 'DESC',
+                    'unmapped_type' => 'string',
+                    'missing'       => '_last',
                 ],
             ]
         )->shouldBeCalled();

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/FamilyNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/FamilyNormalizer.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
 
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -17,12 +18,19 @@ class FamilyNormalizer implements NormalizerInterface
     /** @var NormalizerInterface */
     protected $translationNormalizer;
 
+    /** @var LocaleRepositoryInterface */
+    protected $localeRepository;
+
     /**
-     * @param NormalizerInterface $translationNormalizer
+     * @param NormalizerInterface       $translationNormalizer
+     * @param LocaleRepositoryInterface $localeRepository
      */
-    public function __construct(NormalizerInterface $translationNormalizer)
-    {
+    public function __construct(
+        NormalizerInterface $translationNormalizer,
+        LocaleRepositoryInterface $localeRepository
+    ) {
         $this->translationNormalizer = $translationNormalizer;
+        $this->localeRepository = $localeRepository;
     }
 
     /**
@@ -30,6 +38,10 @@ class FamilyNormalizer implements NormalizerInterface
      */
     public function normalize($object, $format = null, array $context = [])
     {
+        $context = array_merge($context, [
+            'locales' => $this->localeRepository->getActivatedLocaleCodes()
+        ]);
+
         return [
             'code'   => $object->getCode(),
             'labels' => $this->translationNormalizer->normalize($object, $format, $context)

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/FamilyNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/FamilyNormalizerSpec.php
@@ -6,13 +6,14 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductPrice;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\FamilyNormalizer;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FamilyNormalizerSpec extends ObjectBehavior
 {
-    function let(NormalizerInterface $translationNormalizer)
+    function let(NormalizerInterface $translationNormalizer, LocaleRepositoryInterface $localeRepository)
     {
-        $this->beConstructedWith($translationNormalizer);
+        $this->beConstructedWith($translationNormalizer, $localeRepository);
     }
 
     function it_is_initializable()
@@ -33,12 +34,14 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($price, 'standard')->shouldReturn(false);
     }
 
-    function it_normalizes_families($translationNormalizer, FamilyInterface $family)
+    function it_normalizes_families($translationNormalizer, $localeRepository, FamilyInterface $family)
     {
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['de_DE']);
         $family->getCode()->willReturn('camcorders');
-        $translationNormalizer->normalize($family, 'indexing', [])->willReturn([
+        $translationNormalizer->normalize($family, 'indexing', ['locales' => ['de_DE']])->willReturn([
             'fr_FR' => 'La famille des caméras',
             'en_US' => 'Camcorders family',
+            'de_DE' => null,
         ]);
 
         $this->normalize($family, 'indexing')->shouldReturn(
@@ -47,6 +50,7 @@ class FamilyNormalizerSpec extends ObjectBehavior
                 'labels' => [
                     'fr_FR' => 'La famille des caméras',
                     'en_US' => 'Camcorders family',
+                    'de_DE' => null,
                 ],
             ]
         );

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -90,8 +90,9 @@ class ProductIndexingIntegration extends TestCase
             'family'        => [
                 'code'   => 'familyA',
                 'labels' => [
-                    'fr_FR' => 'Une famille A',
+                    'de_DE' => null,
                     'en_US' => 'A family A',
+                    'fr_FR' => 'Une famille A',
                 ],
             ],
             'enabled'       => true,


### PR DESCRIPTION
Fixes `features/product/sorting/sort_products_per_family_field.feature:25`.

Problem is on the indexed value for product family. If there is no label translation for the family, then we can't sort on it : 
```
               "family": {
                  "code": "tshirts",
                  "labels": []
               },
```
So now, when indexing product, we fill in the missing translations for family labels:
```
               "family": {
                  "code": "tshirts",
                  "labels": [
                     "fr_FR": null,
                     "en_US": null
                   ]
               },
```

**Note: When activating a new locale, we'd need to re-index products.**