### PR TITLE
TIP-713: Fix error normalization for PEF

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
@@ -47,6 +47,21 @@ class ProductViolationNormalizer implements NormalizerInterface
                 'scope'     => '<all_channels>' === $attribute[1] ? null : $attribute[1],
                 'message'   => $violation->getMessage(),
             ];
+        } elseif (0 === strpos($propertyPath, 'values[')) {
+            if (!isset($context['product'])) {
+                throw new \InvalidArgumentException('Expects a product context');
+            }
+
+            $codeStart = strpos($propertyPath, '[') + 1;
+            $codeLength = strpos($propertyPath, ']') - $codeStart;
+            $attribute = json_decode(substr($propertyPath, $codeStart, $codeLength), true);
+
+            $normalizedViolation = [
+                'attribute' => $attribute['code'],
+                'locale'    => $attribute['locale'],
+                'scope'     => $attribute['scope'],
+                'message'   => $violation->getMessage(),
+            ];
         } elseif ('identifier' === $propertyPath) {
             $normalizedViolation = [
                 'attribute' => $this->attributeRepository->getIdentifierCode(),

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
@@ -43,6 +43,30 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_normlizes_localization_constraint_violation_with_scope_and_locale(
+        ConstraintViolationInterface $violation,
+        ProductInterface $product,
+        ProductValueInterface $productValue,
+        AttributeInterface $attribute
+    ) {
+        $productValue->getLocale()->willReturn('en_US');
+        $productValue->getScope()->willReturn('mobile');
+        $productValue->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('description');
+
+        $violation->getPropertyPath()->willReturn(
+            'values[{"code":"description","locale":"en_US","scope":"mobile"}].text'
+        );
+        $violation->getMessage()->willReturn('The text is too long.');
+
+        $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
+            'attribute' => 'description',
+            'locale'    => 'en_US',
+            'scope'     => 'mobile',
+            'message'   => 'The text is too long.'
+        ]);
+    }
+
     function it_normalizes_constraint_violation_with_locale(
         ConstraintViolationInterface $violation,
         ProductInterface $product,
@@ -53,11 +77,32 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         $productValue->getLocale()->willReturn('fr_FR');
         $productValue->getScope()->willReturn(null);
         $productValue->getAttribute()->willReturn($attribute);
-        $attribute->getCode()->willReturn('movie-title');
+        $attribute->getCode()->willReturn('movie_title');
 
-        $violation
-            ->getPropertyPath()
-            ->willReturn('values[movie_title-<all_channels>-fr_FR].text');
+        $violation->getPropertyPath()->willReturn('values[movie_title-<all_channels>-fr_FR].text');
+        $violation->getMessage()->willReturn('This movie title is very bad.');
+
+        $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
+            'attribute' => 'movie_title',
+            'locale'    => 'fr_FR',
+            'scope'     => null,
+            'message'   => 'This movie title is very bad.'
+        ]);
+    }
+
+    function it_normalizes_localization_constraint_violation_with_locale(
+        ConstraintViolationInterface $violation,
+        ProductInterface $product,
+        ProductValueInterface $productValue,
+        AttributeInterface $attribute
+    ) {
+        $violation->getRoot()->willReturn($product);
+        $productValue->getLocale()->willReturn('fr_FR');
+        $productValue->getScope()->willReturn(null);
+        $productValue->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('movie_title');
+
+        $violation->getPropertyPath()->willReturn('values[{"code":"movie_title","locale":"fr_FR","scope":null}].text');
         $violation->getMessage()->willReturn('This movie title is very bad.');
 
         $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
@@ -79,9 +124,29 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         $productValue->getAttribute()->willReturn($attribute);
         $attribute->getCode()->willReturn('name');
 
-        $violation
-            ->getPropertyPath()
-            ->willReturn('values[name-ecommerce-<all_locales>].varchar');
+        $violation->getPropertyPath()->willReturn('values[name-ecommerce-<all_locales>].varchar');
+        $violation->getMessage()->willReturn('The text is too short.');
+
+        $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
+            'attribute' => 'name',
+            'locale'    => null,
+            'scope'     => 'ecommerce',
+            'message'   => 'The text is too short.'
+        ]);
+    }
+
+    function it_normalizes_localization_constraint_violation_with_scope(
+        ConstraintViolationInterface $violation,
+        ProductInterface $product,
+        ProductValueInterface $productValue,
+        AttributeInterface $attribute
+    ) {
+        $productValue->getLocale()->willReturn(null);
+        $productValue->getScope()->willReturn('ecommerce');
+        $productValue->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('name');
+
+        $violation->getPropertyPath()->willReturn('values[{"code":"name","locale":null,"scope":"ecommerce"}].varchar');
         $violation->getMessage()->willReturn('The text is too short.');
 
         $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
@@ -103,9 +168,29 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         $productValue->getAttribute()->willReturn($attribute);
         $attribute->getCode()->willReturn('price');
 
-        $violation
-            ->getPropertyPath()
-            ->willReturn('values[price-<all_channels>-<all_locales>].float');
+        $violation->getPropertyPath()->willReturn('values[price-<all_channels>-<all_locales>].float');
+        $violation->getMessage()->willReturn('The price should be above 10.');
+
+        $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
+            'attribute' => 'price',
+            'locale'    => null,
+            'scope'     => null,
+            'message'   => 'The price should be above 10.'
+        ]);
+    }
+
+    function it_normalizes_localization_constraint_violation(
+        ConstraintViolationInterface $violation,
+        ProductInterface $product,
+        ProductValueInterface $productValue,
+        AttributeInterface $attribute
+    ) {
+        $productValue->getLocale()->willReturn(null);
+        $productValue->getScope()->willReturn(null);
+        $productValue->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('price');
+
+        $violation->getPropertyPath()->willReturn('values[{"code":"price","locale":null,"scope":null}].float');
         $violation->getMessage()->willReturn('The price should be above 10.');
 
         $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([


### PR DESCRIPTION
## Description

Constraint violations messages are normalized for the PEF by the `ProductViolationNormalizer`. This is used to display those normalized messages under the right field on the PEF, so the user know why product saving failed.

![image](https://cloud.githubusercontent.com/assets/5039018/25271368/39b460b4-2684-11e7-93e6-741654e5ce11.png)
We use the constraint violation property path to know which field (attribute code + channel + locale) contains a wrong value.

With the SingleStorage, this property path changed from one based on a JSON string containing standard format, to one based on the new storage keys of the ProductValueCollection:
- before: `values[{"code":"description","locale":"en_US","scope":"mobile"}].text`
- after: `values[description-mobile-en_US].text`

A previous PR addressed this change, but then we realized that the Localization validators use their own logic to set the property path and still use the standard format.

As this custom logic is not easy to set on the other validators, and should not be done in this PR, we just reintroduce the old behavior of the `ProductViolationNormalizer` and keep the new one too, so all cases are handled.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
