### PR TITLE
TIP-613: Fix mass edit

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -971,11 +971,12 @@ class FixturesContext extends BaseFixturesContext
         $this->getMainContext()->getSubcontext('hook')->clearUOW();
         foreach ($this->listToArray($products) as $identifier) {
             $productValue = $this->getProductValue($identifier, strtolower($attribute));
-            $options      = $productValue->getOptions();
-            $optionCodes  = $options->map(
-                function ($option) {
+            $options      = $productValue->getData();
+            $optionCodes  = array_map(
+                function($option) {
                     return $option->getCode();
-                }
+                },
+                $options
             );
 
             $values = array_map(
@@ -986,12 +987,12 @@ class FixturesContext extends BaseFixturesContext
             );
             $values = array_filter($values);
 
-            assertEquals(count($values), $options->count());
+            assertEquals(count($values), count($options));
             foreach ($values as $value) {
                 assertContains(
                     $value,
                     $optionCodes,
-                    sprintf('"%s" does not contain "%s"', implode(', ', $optionCodes->toArray()), $value)
+                    sprintf('"%s" does not contain "%s"', implode(', ', $optionCodes), $value)
                 );
             }
         }
@@ -1009,7 +1010,7 @@ class FixturesContext extends BaseFixturesContext
         $this->getMainContext()->getSubcontext('hook')->clearUOW();
         foreach ($this->listToArray($products) as $identifier) {
             $productValue = $this->getProductValue($identifier, strtolower($attribute));
-            $media        = $productValue->getMedia();
+            $media        = $productValue->getData();
             if ('' === trim($filename)) {
                 if ($media) {
                     assertNull($media->getOriginalFilename());
@@ -1032,7 +1033,7 @@ class FixturesContext extends BaseFixturesContext
         $this->getMainContext()->getSubcontext('hook')->clearUOW();
         foreach ($this->listToArray($products) as $identifier) {
             $productValue = $this->getProductValue($identifier, strtolower($attribute));
-            assertEquals($data, $productValue->getMetric()->getData());
+            assertEquals($data, $productValue->getData()->getData());
         }
     }
 

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -39,22 +39,28 @@ class MassActionDispatcher
     /** @var MassActionParametersParser */
     protected $parametersParser;
 
+    /** @var array */
+    protected $gridsWithoutMassActionRepository;
+
     /**
      * @param MassActionHandlerRegistry  $handlerRegistry
      * @param ManagerInterface           $manager
      * @param RequestParameters          $requestParams
      * @param MassActionParametersParser $parametersParser
+     * @param array                      $gridsWithoutMassActionRepository
      */
     public function __construct(
         MassActionHandlerRegistry $handlerRegistry,
         ManagerInterface $manager,
         RequestParameters $requestParams,
-        MassActionParametersParser $parametersParser
+        MassActionParametersParser $parametersParser,
+        array $gridsWithoutMassActionRepository
     ) {
         $this->handlerRegistry = $handlerRegistry;
         $this->manager = $manager;
         $this->requestParams = $requestParams;
         $this->parametersParser = $parametersParser;
+        $this->gridsWithoutMassActionRepository = $gridsWithoutMassActionRepository;
     }
 
     /**
@@ -165,8 +171,10 @@ class MassActionDispatcher
             }
         }
 
-        $repository = $datagrid->getDatasource()->getMassActionRepository();
-        $repository->applyMassActionParameters($qb, $inset, $values);
+        if (!in_array($datagridName, $this->gridsWithoutMassActionRepository)) {
+            $repository = $datagrid->getDatasource()->getMassActionRepository();
+            $repository->applyMassActionParameters($qb, $inset, $values);
+        }
 
         return [
             'datagrid'   => $datagrid,

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
@@ -19,6 +19,7 @@ services:
             - '@oro_datagrid.datagrid.manager'
             - '@oro_datagrid.datagrid.request_params'
             - '@oro_datagrid.mass_action.parameters_parser'
+            - ['product-grid']
 
     # Handlers
     pim_datagrid.extension.mass_action.handler.export:


### PR DESCRIPTION
## First commit: do not use mass action repo in the product grids

Currently, the mass edit uses a [design flaw](https://github.com/jjanvier/pim-community-dev/blob/TIP-613-unified/src/Pim/Bundle/DataGridBundle/Datasource/DatasourceInterface.php#L18-L27) of the datagrid. We retrieve the query builder of the datasource, to modify it in the [MassActionRepositoryInterface](https://github.com/jjanvier/pim-community-dev/blob/TIP-613-unified/src/Pim/Bundle/DataGridBundle/Doctrine/ORM/Repository/MassActionRepositoryInterface.php). This is done for really weird and unclear reasons that I don't understand completely, but it seems we remove some parts of the query builder that were added by the grid pager.

For the product grids (products + published in EE), we don't need that anymore as we retrieve the products from ElasticSearch. But we still need it for the other grids.

I'm really conscious this is quite a dirty fix. but hey that's the datagrid + the mass edit  ¯\\_(ツ)_/¯ :man_shrugging: :woman_shrugging: 

## Second commit
All the product values now have their own dedicated class, which means we know if it's a metric, a price or a collection of options. So we kept only the method `getData` and deleted things like `getMetric`, `getOptions` etc. This commit simply fixes that in the Behat contexts. We have already fixed it previously in all the application.



| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added Behats                      | 
| Added integration tests           | 
| Changelog updated                 | 
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
