### PR TITLE
TIP-713: Fix wrong method renaming

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -18,7 +18,6 @@ use League\Flysystem\MountManager;
 use Oro\Bundle\UserBundle\Entity\Role;
 use Pim\Behat\Context\FixturesContext as BaseFixturesContext;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver;
-use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
 use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
 use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
 use Pim\Bundle\CatalogBundle\Entity\Channel;
@@ -383,7 +382,7 @@ class FixturesContext extends BaseFixturesContext
         $optionLabelPattern = 'Option %d for attribute %d';
 
         $attributeConfig = [
-            'type'                   => $this->getType($type . 'select'),
+            'type'                   => $this->getAttributeType($type . 'select'),
             'group'                  => 'other',
             'useable_as_grid_filter' => (bool) $filterable
         ];

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Behat\Context;
 
-use Behat\Behat\Console\Processor\ProcessorInterface;
-use Behat\Behat\Context\Step;
 use Context\Spin\SpinCapableTrait;
 use Context\Spin\TimeoutException;
 use Doctrine\Common\Util\ClassUtils;


### PR DESCRIPTION
## Description

On master, the deprecated method `AttributeInterface::getAttributeType()` has been removed and replaced everywhere by `AttributeInterface::getType()`.

During the corresponding merge of master in our branch, `FixtureContext::getAttributeType` has been renamed by mistake. This PR fixes this error.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
