### PR TITLE
TIP-713: Fix identifier length validation

### DIFF
--- a/features/reference-data/mass-action/edit_common_attributes.feature
+++ b/features/reference-data/mass-action/edit_common_attributes.feature
@@ -43,6 +43,6 @@ Feature: Mass edit common attributes for reference data
     And I move on to the next step
     And I wait for the "edit-common-attributes" mass-edit job to finish
     Then the product "heels" should have the following values:
-      | sole_fabric | Wool, Kevlar, Jute |
+      | sole_fabric | Jute, Kevlar, Wool|
     Then the product "platform_shoes" should have the following values:
-      | sole_fabric | Wool, Kevlar, Jute |
+      | sole_fabric | Jute, Kevlar, Wool|

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
@@ -17,12 +17,11 @@ Pim\Component\Catalog\Model\Product:
                 - pim_catalog_variant_group
     properties:
         identifier:
-            - NotBlank: ~
+            # TODO: TIP-722 - Add not Blank and Length validation here once the product value
+            # identifier is removed.
             - Regex:
                 pattern: '/^[^,;]+$/'
                 message: 'regex.comma_or_semicolon.message'
-            - Length:
-                max: 255
     getters:
         values:
             - Symfony\Component\Validator\Constraints\Valid:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
@@ -52,6 +52,25 @@ class ProductIdentifierValidationIntegration extends TestCase
         );
     }
 
+    public function testMaxCharactersValidation()
+    {
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByCode('sku');
+        $attribute->setMaxCharacters(4);
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        $correctProduct = $this->createProduct('1234');
+        $violations = $this->validateProduct($correctProduct);
+        $this->assertCount(0, $violations);
+
+        $wrongProduct = $this->createProduct('12345');
+        $violations = $this->validateProduct($wrongProduct);
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            $violations->get(0)->getMessage(),
+            'This value is too long. It should have 4 characters or less.'
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
@@ -91,6 +91,21 @@ class ProductIdentifierValidationIntegration extends TestCase
         );
     }
 
+    public function testNotBlankValidation()
+    {
+        $correctProduct = $this->createProduct('sku-001');
+        $violations = $this->validateProduct($correctProduct);
+        $this->assertCount(0, $violations);
+
+        $wrongProduct = $this->createProduct('');
+        $violations = $this->validateProduct($wrongProduct);
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            $violations->get(0)->getMessage(),
+            'This value should not be blank.'
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
@@ -71,6 +71,26 @@ class ProductIdentifierValidationIntegration extends TestCase
         );
     }
 
+    public function testRegexValidation()
+    {
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByCode('sku');
+        $attribute->setValidationRule('regexp');
+        $attribute->setValidationRegexp('/^sku-\d*$/');
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        $correctProduct = $this->createProduct('sku-001');
+        $violations = $this->validateProduct($correctProduct);
+        $this->assertCount(0, $violations);
+
+        $wrongProduct = $this->createProduct('001');
+        $violations = $this->validateProduct($wrongProduct);
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            $violations->get(0)->getMessage(),
+            'This value is not valid.'
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -83,7 +83,6 @@ class ViolationNormalizerSpec extends ObjectBehavior
     function it_normalizes_an_exception_with_error_on_product_identifier_when_too_long(
         ViolationHttpException $exception,
         ConstraintViolationList $constraintViolations,
-        ConstraintViolation $violationIdentifier,
         ConstraintViolation $violationProductValue,
         ProductInterface $product,
         \ArrayIterator $iterator,
@@ -102,12 +101,6 @@ class ViolationNormalizerSpec extends ObjectBehavior
         $product->getValues()->willReturn($productValues);
         $productValues->getByKey('sku')->willReturn($sku);
 
-        $violationIdentifier->getRoot()->willReturn($product);
-        $violationIdentifier->getMessage()->willReturn('Field identifier is too long (255)');
-        $violationIdentifier->getPropertyPath()->willReturn('identifier');
-        $violationIdentifier->getConstraint()->willReturn($lengthConstraint);
-        $violationIdentifier->getMessageTemplate()->willReturn('This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.');
-
         $violationProductValue->getRoot()->willReturn($product);
         $violationProductValue->getMessage()->willReturn('Product value sku is too long (10)');
         $violationProductValue->getPropertyPath()->willReturn('values[sku].varchar');
@@ -115,20 +108,20 @@ class ViolationNormalizerSpec extends ObjectBehavior
         $violationProductValue->getMessageTemplate()->willReturn('This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.');
 
         $constraintViolations->getIterator()->willReturn($iterator);
-        $iterator->rewind()->willReturn($violationIdentifier);
-        $valueCount = 2;
+        $iterator->rewind()->willReturn($violationProductValue);
+        $valueCount = 1;
         $iterator->valid()->will(
             function () use (&$valueCount) {
                 return $valueCount-- > 0;
             }
         );
-        $iterator->current()->willReturn($violationIdentifier, $violationProductValue);
+        $iterator->current()->willReturn($violationProductValue);
         $iterator->next()->shouldBeCalled();
 
         $exception->getViolations()->willReturn($constraintViolations);
         $exception->getStatusCode()->willReturn(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $violationIdentifier->getConstraint()->willReturn($lengthConstraint);
+        $violationProductValue->getConstraint()->willReturn($lengthConstraint);
 
         $this->normalize($exception)->shouldReturn([
             'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
@@ -31,7 +31,8 @@ class LengthGuesser implements ConstraintGuesserInterface
             $attribute->getType(),
             [
                 AttributeTypes::TEXT,
-                AttributeTypes::TEXTAREA
+                AttributeTypes::TEXTAREA,
+                AttributeTypes::IDENTIFIER
             ]
         );
     }

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/LengthGuesser.php
@@ -17,10 +17,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class LengthGuesser implements ConstraintGuesserInterface
 {
     /** @staticvar int */
-    const TEXT_FIELD_LEMGTH = 255;
+    const TEXT_FIELD_LENGTH = 255;
 
     /** @staticvar int */
-    const TEXTAREA_FIELD_LEMGTH = 65535;
+    const TEXTAREA_FIELD_LENGTH = 65535;
 
     /**
      * {@inheritdoc}
@@ -45,8 +45,8 @@ class LengthGuesser implements ConstraintGuesserInterface
         $constraints = [];
 
         $characterLimit = AttributeTypes::TEXTAREA === $attribute->getType() ?
-            static::TEXTAREA_FIELD_LEMGTH :
-            static::TEXT_FIELD_LEMGTH;
+            static::TEXTAREA_FIELD_LENGTH :
+            static::TEXT_FIELD_LENGTH;
 
         if ($maxCharacters = $attribute->getMaxCharacters()) {
             $characterLimit = min($maxCharacters, $characterLimit);

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/NotBlankGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/NotBlankGuesser.php
@@ -21,12 +21,7 @@ class NotBlankGuesser implements ConstraintGuesserInterface
      */
     public function supportAttribute(AttributeInterface $attribute)
     {
-        return !in_array(
-            $attribute->getType(),
-            [
-                AttributeTypes::IDENTIFIER
-            ]
-        );
+        return true;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RegexGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RegexGuesser.php
@@ -25,6 +25,7 @@ class RegexGuesser implements ConstraintGuesserInterface
             $attribute->getType(),
             [
                 AttributeTypes::TEXT,
+                AttributeTypes::IDENTIFIER,
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/LengthGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/LengthGuesserSpec.php
@@ -29,7 +29,7 @@ class LengthGuesserSpec extends ObjectBehavior
         $image->getType()->willReturn('pim_catalog_image');
 
         $this->supportAttribute($text)->shouldReturn(true);
-        $this->supportAttribute($identifier)->shouldReturn(false);
+        $this->supportAttribute($identifier)->shouldReturn(true);
         $this->supportAttribute($textarea)->shouldReturn(true);
 
         $this->supportAttribute($image)->shouldReturn(false);

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RegexGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RegexGuesserSpec.php
@@ -22,7 +22,7 @@ class RegexGuesserSpec extends ObjectBehavior
         $attribute->getType()
             ->willReturn('pim_catalog_identifier');
         $this->supportAttribute($attribute)
-            ->shouldReturn(false);
+            ->shouldReturn(true);
 
         $attribute->getType()
             ->willReturn('foo');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Drops the Length/NotBlank validation on the Identifier column as they are already ensured by the Identifier attribute.
- Adds back a length/regexp constraint on the identifier product value types.
- Fixes the Api ViolationNormalizer to remove potentially duplicated constraints on the "identifier" (sql column) and "identifier" product value which have different instances of the same constraints.
- Adds Specs on the ViolationNormalizer specs
- Adds Integration tests to ensure those  constraints are enforced.

Solves:
- `features/product/validation/validate_identifier_attribute.feature:23`
- `features/product/validation/validate_identifier_attribute.feature:33`
- `features/reference-data/mass-action/edit_common_attributes.feature:37`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
