### PR TITLE
TIP-698: unique data

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -14,6 +14,7 @@
 
 ### Constructors
 
+- Extract and rename method `valueExists` of `Pim\Component\Catalog\Repository\ProductRepositoryInterface` into `Pim\Component\Catalog\Repository\ProductUniqueDataRepositoryInterface`::`uniqueDataExistsInAnotherProduct`.
 - Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Pim\Component\Api\Pagination\PaginatorInterface`
 - Change the constructor of `Pim\Component\Catalog\Manager\CompletenessManager` to remove the completeness class.
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array

--- a/features/import/product/import_products_with_media.feature
+++ b/features/import/product/import_products_with_media.feature
@@ -81,8 +81,8 @@ Feature: Import media with products
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 0 products
     And I should see "skipped 2"
-    And I should see "values[frontView].media: The file extension is not allowed (allowed extensions: gif, jpg)"
-    And I should see "values[userManual].media: The file is too large (3.15 MB). Allowed maximum size is 1 MB"
+    And I should see "values[frontView].data: The file extension is not allowed (allowed extensions: gif, jpg)"
+    And I should see "values[userManual].data: The file is too large (3.15 MB). Allowed maximum size is 1 MB"
 
   Scenario: Import several times the same media
     Given the following CSV file to import:

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -9,9 +9,10 @@ Feature: Display the completeness of a product
     And I add the "french" locale to the "tablet" channel
     And I add the "french" locale to the "mobile" channel
     And the following products:
-      | sku      | family   | manufacturer | weather_conditions | color | name-en_US | name-fr_FR  | price          | rating | size | lace_color  |
-      | sneakers | sneakers | Converse     | hot                | blue  | Sneakers   | Espadrilles | 69 EUR, 99 USD | 4      | 43   | laces_white |
-      | sandals  | sandals  |              |                    | white |            | Sandales    |                |        |      |             |
+      | sku              | family   | manufacturer | weather_conditions | color | name-en_US | name-fr_FR  | price          | rating | size | lace_color  |
+      | sneakers         | sneakers | Converse     | hot                | blue  | Sneakers   | Espadrilles | 69 EUR, 99 USD | 4      | 43   | laces_white |
+      | sandals          | sandals  |              |                    | white |            | Sandales    |                |        |      |             |
+      | my_nice_sneakers |          |              |                    |       |            |             |                |        |      |             |
     And the following product values:
       | product  | attribute   | value                 | locale | scope  |
       | sneakers | description | Great sneakers        | en_US  | mobile |
@@ -131,10 +132,7 @@ Feature: Display the completeness of a product
 
   @jira https://akeneo.atlassian.net/browse/PIM-4489
   Scenario: Don't display the completeness if the family is not defined on product creation
-    Given the following products:
-      | sku              |
-      | my_nice_sneakers |
-    And I am on the "my_nice_sneakers" product page
+    Given I am on the "my_nice_sneakers" product page
     When I open the "Completeness" panel
     Then I should see the text "No family defined. Please define a family to calculate the completeness of this product."
     And I change the family of the product to "Sneakers"

--- a/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
+++ b/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
@@ -32,6 +32,7 @@ class ResolveDoctrineTargetModelPass extends AbstractResolveDoctrineTargetModelP
             'Pim\Component\Catalog\Model\CompletenessInterface'              => 'pim_catalog.entity.completeness.class',
             'Pim\Component\Catalog\Model\LocaleInterface'                    => 'pim_catalog.entity.locale.class',
             'Pim\Component\Catalog\Model\ProductInterface'                   => 'pim_catalog.entity.product.class',
+            'Pim\Component\Catalog\Model\ProductUniqueDataInterface'         => 'pim_catalog.entity.product_unique_data.class',
             'Pim\Component\Catalog\Model\CategoryInterface'                  => 'pim_catalog.entity.category.class',
             'Pim\Component\Catalog\Model\CurrencyInterface'                  => 'pim_catalog.entity.currency.class',
             'Pim\Component\Catalog\Model\FamilyInterface'                    => 'pim_catalog.entity.family.class',

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -30,19 +30,25 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
     /** @var EventDispatcherInterface */
     protected $eventDispatcher;
 
+    /** @var ProductUniqueDataSynchronizer */
+    protected $uniqueDataSynchronizer;
+
     /**
-     * @param ObjectManager            $objectManager
-     * @param CompletenessManager      $completenessManager
-     * @param EventDispatcherInterface $eventDispatcher
+     * @param ObjectManager                 $objectManager
+     * @param CompletenessManager           $completenessManager
+     * @param EventDispatcherInterface      $eventDispatcher
+     * @param ProductUniqueDataSynchronizer $uniqueDataSynchronizer
      */
     public function __construct(
         ObjectManager $objectManager,
         CompletenessManager $completenessManager,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        ProductUniqueDataSynchronizer $uniqueDataSynchronizer
     ) {
         $this->objectManager = $objectManager;
         $this->completenessManager = $completenessManager;
         $this->eventDispatcher = $eventDispatcher;
+        $this->uniqueDataSynchronizer = $uniqueDataSynchronizer;
     }
 
     /**
@@ -58,6 +64,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
 
         $this->completenessManager->schedule($product);
         $this->completenessManager->generateMissingForProduct($product);
+        $this->uniqueDataSynchronizer->synchronize($product);
 
         $this->objectManager->persist($product);
         $this->objectManager->flush();
@@ -87,6 +94,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
             $this->completenessManager->schedule($product);
             $this->completenessManager->generateMissingForProduct($product);
+            $this->uniqueDataSynchronizer->synchronize($product);
+
             $this->objectManager->persist($product);
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductUniqueDataSynchronizer.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductUniqueDataSynchronizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
+
+use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Factory\ProductUniqueDataFactory;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductUniqueDataInterface;
+
+/**
+ * Synchronize the $uniqueData persistent collection of the product with the unique values of the product.
+ * Those unique values come from the $values collection
+ * {@see Pim\Component\Catalog\Model\ProductValueCollectionInterface}.
+ *
+ * The only aim of the $uniqueData collection is to be able to save these information in the database via Doctrine.
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductUniqueDataSynchronizer
+{
+    /** @var ProductUniqueDataFactory */
+    protected $factory;
+
+    /**
+     * @param ProductUniqueDataFactory $factory
+     */
+    public function __construct(ProductUniqueDataFactory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * @param ProductInterface $product
+     */
+    public function synchronize(ProductInterface $product)
+    {
+        $uniqueDataCollection = $product->getUniqueData();
+
+        foreach ($product->getValues()->getUniqueValues() as $value) {
+            $attribute = $value->getAttribute();
+
+            $uniqueData = $this->getUniqueDataFromCollection($uniqueDataCollection, $attribute);
+            if (null !== $uniqueData) {
+                $uniqueData->setProductValue($value);
+            } else {
+                $uniqueData = $this->factory->create($product, $value);
+                $product->addUniqueData($uniqueData);
+            }
+        }
+    }
+
+    /**
+     * @param Collection         $uniqueDataCollection
+     * @param AttributeInterface $attribute
+     *
+     * @return ProductUniqueDataInterface|null
+     */
+    protected function getUniqueDataFromCollection(Collection $uniqueDataCollection, AttributeInterface $attribute)
+    {
+        foreach ($uniqueDataCollection as $uniqueData) {
+            if ($attribute === $uniqueData->getAttribute()) {
+                return $uniqueData;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -189,25 +189,6 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
-    public function valueExists(ProductValueInterface $value)
-    {
-        return false;
-
-        $criteria = [
-            'attribute'                              => $value->getAttribute(),
-            $value->getAttribute()->getBackendType() => $value->getData()
-        ];
-        $result = $this->getEntityManager()->getRepository(get_class($value))->findBy($criteria);
-
-        return (
-            (0 !== count($result)) &&
-            !(1 === count($result) && $value === ($result instanceof \Iterator ? $result->current() : current($result)))
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getEligibleProductsForVariantGroup($variantGroupId)
     {
         $variantGroup = $this->groupRepository->find($variantGroupId);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductUniqueDataRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductUniqueDataRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Repository\ProductUniqueDataRepositoryInterface;
+
+/**
+ * Product unique data repository. Please see {@see Pim\Component\Catalog\Model\ProductUniqueDataInterface}
+ * for more information.
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductUniqueDataRepository extends EntityRepository implements ProductUniqueDataRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function uniqueDataExistsInAnotherProduct(ProductValueInterface $value, ProductInterface $product)
+    {
+        $queryBuilder = $this->createQueryBuilder('ud')
+            ->select('COUNT(ud)')
+            ->where('ud.attribute = :attribute')
+            ->andWhere('ud.rawData = :data')
+        ;
+
+        $parameters = [
+            'attribute' => $value->getAttribute(),
+            'data' => $value->__toString(),
+        ];
+
+        if (null !== $product->getId()) {
+            $queryBuilder->andWhere('ud.product != :product');
+            $parameters['product'] = $product;
+        }
+
+        $queryBuilder->setParameters($parameters);
+
+        $count = (int) $queryBuilder->getQuery()->getSingleScalarResult();
+
+        return 0 !== $count;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/entities.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/entities.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_catalog.entity.product.class:                      Pim\Component\Catalog\Model\Product
+    pim_catalog.entity.product_unique_data.class:          Pim\Component\Catalog\Model\ProductUniqueData
     pim_catalog.entity.association.class:                  Pim\Component\Catalog\Model\Association
     pim_catalog.entity.completeness.class:                 Pim\Component\Catalog\Model\Completeness
     pim_catalog.entity.association_type.class:             Pim\Bundle\CatalogBundle\Entity\AssociationType

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -8,6 +8,7 @@ parameters:
     pim_catalog.factory.group_type.class:            Pim\Component\Catalog\Factory\GroupTypeFactory
     pim_catalog.factory.currency.class:              Pim\Component\Catalog\Factory\CurrencyFactory
     pim_catalog.factory.product_template.class:      Pim\Component\Catalog\Factory\ProductTemplateFactory
+    pim_catalog.factory.product_unique_data.class:   Pim\Component\Catalog\Factory\ProductUniqueDataFactory
 
     pim_catalog.factory.product_value_collection.class:       Pim\Component\Catalog\Factory\ProductValueCollectionFactory
     pim_catalog.factory.product_value.class:                  Pim\Component\Catalog\Factory\ProductValueFactory
@@ -109,6 +110,11 @@ services:
         class: '%pim_catalog.factory.product_template.class%'
         arguments:
             - '%pim_catalog.entity.product_template.class%'
+
+    pim_catalog.factory.product_unique_data:
+        class: '%pim_catalog.factory.product_unique_data.class%'
+        arguments:
+            - '%pim_catalog.entity.product_unique_data.class%'
 
     pim_catalog.factory.product_value_collection:
         class: '%pim_catalog.factory.product_value_collection.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
@@ -72,3 +72,11 @@ Pim\Component\Catalog\Model\Product:
                 - persist
                 - refresh
                 - detach
+        uniqueData:
+            targetEntity: Pim\Component\Catalog\Model\ProductUniqueDataInterface
+            mappedBy: product
+            cascade:
+                - remove
+                - persist
+                - refresh
+                - detach

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductUniqueData.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductUniqueData.orm.yml
@@ -1,0 +1,33 @@
+Pim\Component\Catalog\Model\ProductUniqueData:
+    type: entity
+    table: pim_catalog_product_unique_data
+    changeTrackingPolicy: DEFERRED_EXPLICIT
+    fields:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+        rawData:
+            type: string
+            column: raw_data
+    uniqueConstraints:
+        unique_value_idx:
+            columns:
+                - attribute_id
+                - raw_data
+    manyToOne:
+        product:
+            targetEntity: Pim\Component\Catalog\Model\ProductInterface
+            joinColumns:
+                product_id:
+                    referencedColumnName: id
+                    onDelete: CASCADE
+                    nullable: false
+        attribute:
+            targetEntity: Pim\Component\Catalog\Model\AttributeInterface
+            joinColumns:
+                attribute_id:
+                    referencedColumnName: id
+                    onDelete: CASCADE
+                    nullable: false

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -12,6 +12,7 @@ parameters:
     pim_catalog.repository.group_type.class:            Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\GroupTypeRepository
     pim_catalog.repository.locale.class:                Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\LocaleRepository
     pim_catalog.repository.product_template.class:      Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductTemplateRepository
+    pim_catalog.repository.product_unique_data.class:   Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductUniqueDataRepository
 
 services:
     # Base repositories
@@ -116,6 +117,13 @@ services:
         factory_service: doctrine.orm.entity_manager
         factory_method: getRepository
         arguments: ['%pim_catalog.entity.product_template.class%']
+        tags:
+            - { name: 'pim_repository' }
+
+    pim_catalog.repository.product_unique_data:
+        class: '%pim_catalog.repository.product_unique_data.class%'
+        factory: ['@doctrine.orm.entity_manager', getRepository]
+        arguments: ['%pim_catalog.entity.product_unique_data.class%']
         tags:
             - { name: 'pim_repository' }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
@@ -5,6 +5,7 @@ parameters:
     pim_catalog.saver.group.class:                         Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\GroupSaver
     pim_catalog.saver.family.class:                        Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\FamilySaver
     pim_catalog.saver.attribute.class:                     Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\AttributeSaver
+    pim_catalog.synchronizer.product_unique_data.class:    Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductUniqueDataSynchronizer
 
 services:
     pim_catalog.saver.group_type:
@@ -20,6 +21,12 @@ services:
             - '@doctrine.orm.entity_manager'
             - '@pim_catalog.manager.completeness'
             - '@event_dispatcher'
+            - '@pim_catalog.synchronizer.product_unique_data'
+
+    pim_catalog.synchronizer.product_unique_data:
+        class: '%pim_catalog.synchronizer.product_unique_data.class%'
+        arguments:
+            - '@pim_catalog.factory.product_unique_data'
 
     pim_catalog.saver.group:
         class: '%pim_catalog.saver.group.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -95,7 +95,7 @@ services:
     pim_catalog.validator.constraint.unique_value:
         class: '%pim_catalog.validator.constraint.unique_value.class%'
         arguments:
-            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_unique_data'
             - '@pim_catalog.validator.unique_value_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_value_validator }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductUniqueDataSynchronizerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductUniqueDataSynchronizerSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Saver\Common;
+
+use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Factory\ProductUniqueDataFactory;
+use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductUniqueDataSynchronizer;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductUniqueDataInterface;
+use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+use Prophecy\Argument;
+
+class ProductUniqueDataSynchronizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductUniqueDataSynchronizer::class);
+    }
+
+    function let(ProductUniqueDataFactory $factory)
+    {
+        $this->beConstructedWith($factory);
+    }
+
+    function it_synchronizes_new_unique_values(
+        $factory,
+        ProductInterface $product,
+        Collection $uniqueDataCollection,
+        ProductValueCollectionInterface $values,
+        ProductValueInterface $skuValue,
+        AttributeInterface $sku,
+        \ArrayIterator $uniqueDataCollectionIterator,
+        ProductUniqueDataInterface $uniqueData
+    ) {
+        $product->getUniqueData()->willReturn($uniqueDataCollection);
+        $product->getValues()->willReturn($values);
+        $values->getUniqueValues()->willReturn([$skuValue]);
+
+        $skuValue->getAttribute()->willReturn($sku);
+
+        $uniqueDataCollection->getIterator()->willReturn($uniqueDataCollectionIterator);
+        $uniqueDataCollectionIterator->rewind()->shouldBeCalled();
+        $uniqueDataCollectionIterator->valid()->willReturn(false);
+
+        $factory->create($product, $skuValue)->willReturn($uniqueData);
+        $product->addUniqueData($uniqueData)->shouldBeCalled();
+
+        $this->synchronize($product);
+    }
+
+    function it_synchronizes_existing_unique_values(
+        $factory,
+        ProductInterface $product,
+        Collection $uniqueDataCollection,
+        ProductValueCollectionInterface $values,
+        ProductValueInterface $skuValue,
+        AttributeInterface $sku,
+        \ArrayIterator $uniqueDataCollectionIterator,
+        ProductUniqueDataInterface $uniqueData
+    ) {
+        $product->getUniqueData()->willReturn($uniqueDataCollection);
+        $product->getValues()->willReturn($values);
+        $values->getUniqueValues()->willReturn([$skuValue]);
+
+        $skuValue->getAttribute()->willReturn($sku);
+
+        $uniqueDataCollection->getIterator()->willReturn($uniqueDataCollectionIterator);
+        $uniqueDataCollectionIterator->rewind()->shouldBeCalled();
+        $uniqueDataCollectionIterator->valid()->willReturn(true, false);
+        $uniqueDataCollectionIterator->current()->willReturn($uniqueData);
+
+        $uniqueData->getAttribute()->willReturn($sku);
+
+        $factory->create(Argument::cetera())->shouldNotBeCalled($uniqueData);
+        $product->addUniqueData($uniqueData)->shouldNotBeCalled();
+        $uniqueData->setProductValue($skuValue)->shouldBeCalled();
+
+        $this->synchronize($product);
+    }
+}

--- a/src/Pim/Component/Catalog/Factory/ProductUniqueDataFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductUniqueDataFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Component\Catalog\Factory;
+
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductUniqueDataInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+
+/**
+ * Creates and configures a product unique data.
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductUniqueDataFactory
+{
+    /** @var string */
+    protected $productUniqueDataClass;
+
+    /**
+     * @param string $productUniqueDataClass
+     */
+    public function __construct($productUniqueDataClass)
+    {
+        $this->productUniqueDataClass = $productUniqueDataClass;
+    }
+
+    /**
+     * @param ProductInterface      $product
+     * @param ProductValueInterface $value
+     *
+     * @return ProductUniqueDataInterface
+     */
+    public function create(ProductInterface $product, ProductValueInterface $value)
+    {
+        return new $this->productUniqueDataClass($product, $value);
+    }
+}

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -79,6 +79,9 @@ abstract class AbstractProduct implements ProductInterface
     /** @var string */
     protected $identifier;
 
+    /** @var ArrayCollection */
+    protected $uniqueData;
+
     /**
      * Constructor
      */
@@ -89,6 +92,7 @@ abstract class AbstractProduct implements ProductInterface
         $this->completenesses = new ArrayCollection();
         $this->groups = new ArrayCollection();
         $this->associations = new ArrayCollection();
+        $this->uniqueData = new ArrayCollection();
     }
 
     /**
@@ -666,5 +670,25 @@ abstract class AbstractProduct implements ProductInterface
     public function getReference()
     {
         return $this->getIdentifier();
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getUniqueData()
+    {
+        return $this->uniqueData;
+    }
+
+    /**
+     * @param ProductUniqueDataInterface $uniqueData
+     *
+     * @return ProductInterface
+     */
+    public function addUniqueData(ProductUniqueDataInterface $uniqueData)
+    {
+        $this->uniqueData->add($uniqueData);
+
+        return $this;
     }
 }

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Catalog\Model;
 use Akeneo\Component\Classification\CategoryAwareInterface;
 use Akeneo\Component\Localization\Model\LocalizableInterface;
 use Akeneo\Component\Versioning\Model\VersionableInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Pim\Bundle\CommentBundle\Model\CommentSubjectInterface;
 
@@ -339,4 +340,16 @@ interface ProductInterface extends
      * @return ProductInterface
      */
     public function setFamilyId($familyId);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getUniqueData();
+
+    /**
+     * @param ProductUniqueDataInterface $uniqueData
+     *
+     * @return ProductInterface
+     */
+    public function addUniqueData(ProductUniqueDataInterface $uniqueData);
 }

--- a/src/Pim/Component/Catalog/Model/ProductUniqueData.php
+++ b/src/Pim/Component/Catalog/Model/ProductUniqueData.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Pim\Component\Catalog\Model;
+
+/**
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductUniqueData implements ProductUniqueDataInterface
+{
+    /** @var int */
+    protected $id;
+
+    /** @var ProductInterface */
+    protected $product;
+
+    /** @var ProductValueInterface */
+    protected $value;
+
+    /** @var AttributeInterface */
+    protected $attribute;
+
+    /** @var mixed */
+    protected $rawData;
+
+    /**
+     * @param ProductInterface      $product
+     * @param ProductValueInterface $value
+     */
+    public function __construct(ProductInterface $product, ProductValueInterface $value)
+    {
+        $this->product = $product;
+        $this->setProductValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProduct()
+    {
+        return $this->product;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttribute()
+    {
+        return $this->attribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRawData()
+    {
+        return $this->rawData;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProductValue(ProductValueInterface $value)
+    {
+        $this->value = $value;
+        $this->attribute = $value->getAttribute();
+        $this->rawData = $value->__toString();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEqual(ProductUniqueDataInterface $uniqueValue)
+    {
+        return $this->getAttribute() === $uniqueValue->getAttribute() &&
+            $this->getRawData() === $uniqueValue->getRawData();
+    }
+}

--- a/src/Pim/Component/Catalog/Model/ProductUniqueDataInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductUniqueDataInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pim\Component\Catalog\Model;
+
+/**
+ * Product unique data consists of data that is unique among all the products for a given attribute.
+ * Only pim_catalog_identifier, pim_catalog_number, pim_catalog_text and pim_catalog_date attribute types can be
+ * defined as unique.
+ *
+ * For instance, if the attribute "release date" is defined as unique.
+ * Then, the data "05/24/1980" can be used only once among all the products.
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductUniqueDataInterface
+{
+    /**
+     * @return int
+     */
+    public function getId();
+
+    /**
+     * @param int $id
+     */
+    public function setId($id);
+
+    /**
+     * @return ProductInterface
+     */
+    public function getProduct();
+
+    /**
+     * @return AttributeInterface
+     */
+    public function getAttribute();
+
+    /**
+     * @return string
+     */
+    public function getRawData();
+
+    /**
+     * @param ProductValueInterface $value
+     */
+    public function setProductValue(ProductValueInterface $value);
+
+    /**
+     * @param ProductUniqueDataInterface $uniqueValue
+     *
+     * @return bool
+     */
+    public function isEqual(ProductUniqueDataInterface $uniqueValue);
+}

--- a/src/Pim/Component/Catalog/Model/ProductUniqueValueCollectionInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductUniqueValueCollectionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pim\Component\Catalog\Model;
+
+/**
+ * Business collection interface to handle unique product values.
+ *
+ * Product unique values consists of data that is unique among all the products for a given attribute.
+ * Only pim_catalog_identifier, pim_catalog_number, pim_catalog_text and pim_catalog_date attribute types can be
+ * defined as unique.
+ *
+ * For instance, if the attribute "release date" is defined as unique.
+ * Then, the value with the data "05/24/1980" can be used only once among all the products.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductUniqueValueCollectionInterface
+{
+    /**
+     * Gets all unique values of the collection.
+     *
+     * @return array The unique values in the collection, in the order they
+     *               appear in the collection.
+     */
+    public function getUniqueValues();
+}

--- a/src/Pim/Component/Catalog/Model/ProductValueCollection.php
+++ b/src/Pim/Component/Catalog/Model/ProductValueCollection.php
@@ -13,6 +13,8 @@ namespace Pim\Component\Catalog\Model;
  * This collection also contains the list of attributes used in the collection. The attributes
  * are indexed by attribute codes.
  *
+ * The collection also contains the list of unique values.
+ *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -21,6 +23,9 @@ class ProductValueCollection implements ProductValueCollectionInterface
 {
     /** @var ProductValueInterface[] */
     private $values;
+
+    /** @var ProductValueInterface[] */
+    private $uniqueValues;
 
     /** @var AttributeInterface[] */
     private $attributes;
@@ -31,6 +36,7 @@ class ProductValueCollection implements ProductValueCollectionInterface
     public function __construct(array $values = [])
     {
         $this->values = [];
+        $this->uniqueValues = [];
         $this->attributes = [];
 
         foreach ($values as $value) {
@@ -97,6 +103,7 @@ class ProductValueCollection implements ProductValueCollectionInterface
 
         $removed = $this->values[$key];
         unset($this->values[$key]);
+        unset($this->uniqueValues[$key]);
 
         $this->reIndexAllAttributes();
 
@@ -115,6 +122,7 @@ class ProductValueCollection implements ProductValueCollectionInterface
         }
 
         unset($this->values[$key]);
+        unset($this->uniqueValues[$key]);
 
         $this->reIndexAllAttributes();
 
@@ -213,6 +221,10 @@ class ProductValueCollection implements ProductValueCollectionInterface
 
         $this->values[$key] = $value;
 
+        if ($attribute->isUnique() && null !== $value->getData()) {
+            $this->uniqueValues[$key] = $value;
+        }
+
         $this->indexAttribute($attribute);
 
         return true;
@@ -240,6 +252,7 @@ class ProductValueCollection implements ProductValueCollectionInterface
     public function clear()
     {
         $this->values = [];
+        $this->uniqueValues = [];
         $this->attributes = [];
     }
 
@@ -257,6 +270,14 @@ class ProductValueCollection implements ProductValueCollectionInterface
     public function getAttributes()
     {
         return array_values($this->attributes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUniqueValues()
+    {
+        return $this->uniqueValues;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/ProductValueCollectionInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductValueCollectionInterface.php
@@ -13,7 +13,7 @@ namespace Pim\Component\Catalog\Model;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface ProductValueCollectionInterface extends \Countable, \IteratorAggregate
+interface ProductValueCollectionInterface extends ProductUniqueValueCollectionInterface, \Countable, \IteratorAggregate
 {
     /**
      * Adds a value at the end of the collection.

--- a/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
@@ -39,16 +39,6 @@ interface ProductRepositoryInterface extends ObjectRepository
     public function findAllForVariantGroup(GroupInterface $variantGroup, array $criteria = []);
 
     /**
-     * Returns true if a ProductValue with the provided value alread exists,
-     * false otherwise.
-     *
-     * @param ProductValueInterface $value
-     *
-     * @return bool
-     */
-    public function valueExists(ProductValueInterface $value);
-
-    /**
      * @param ProductQueryBuilderFactoryInterface $factory
      *
      * @return ProductRepositoryInterface

--- a/src/Pim/Component/Catalog/Repository/ProductUniqueDataRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductUniqueDataRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Pim\Component\Catalog\Repository;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+
+/**
+ * Product unique data repository. Please see {@see Pim\Component\Catalog\Model\ProductUniqueDataInterface}
+ * for more information.
+ *
+ * @author    Julien Janvier <julien.janvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductUniqueDataRepositoryInterface extends ObjectRepository
+{
+    /**
+     * Returns true if a unique ProductValue with the provided data already exists in another product,
+     * false otherwise.
+     *
+     * @param ProductValueInterface $value
+     * @param ProductInterface      $product
+     *
+     * @return bool
+     */
+    public function uniqueDataExistsInAnotherProduct(ProductValueInterface $value, ProductInterface $product);
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
@@ -4,9 +4,8 @@ namespace Pim\Component\Catalog\Validator\Constraints;
 
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
-use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductUniqueDataRepositoryInterface;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -19,17 +18,17 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class UniqueValueValidator extends ConstraintValidator
 {
-    /** @var ProductRepositoryInterface */
+    /** @var ProductUniqueDataRepositoryInterface */
     protected $repository;
 
     /** @var UniqueValuesSet */
     protected $uniqueValuesSet;
 
     /**
-     * @param ProductRepositoryInterface $repository
-     * @param UniqueValuesSet            $uniqueValueSet
+     * @param ProductUniqueDataRepositoryInterface $repository
+     * @param UniqueValuesSet                      $uniqueValueSet
      */
-    public function __construct(ProductRepositoryInterface $repository, UniqueValuesSet $uniqueValueSet)
+    public function __construct(ProductUniqueDataRepositoryInterface $repository, UniqueValuesSet $uniqueValueSet)
     {
         $this->repository = $repository;
         $this->uniqueValuesSet = $uniqueValueSet;
@@ -42,38 +41,28 @@ class UniqueValueValidator extends ConstraintValidator
      * It means that we make this validator stateful which is a bad news, the good one is we ensure this validation
      * for any processes (other option was to mess the import as we did with previous implementation)
      *
-     * Due to constraint guesser, the constraint is applied on :
-     * - ProductValueInterface data when applied through form
-     * - ProductValueInterface when applied directly through validator
+     * Due to constraint guesser, the constraint is applied on ProductValueInterface when applied
+     * directly through validator.
      *
      * The constraint guesser should be re-worked in a future version to avoid such behavior
      *
-     * @param ProductValueInterface|mixed $data
-     * @param Constraint                  $constraint
+     * @param ProductValueInterface $productValue
+     * @param Constraint            $constraint
      *
      * @see Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UniqueValueGuesser
      */
-    public function validate($data, Constraint $constraint)
+    public function validate($productValue, Constraint $constraint)
     {
-        // TODO: This validator will be completely reworked in TIP-698
-        return;
-
-        if (empty($data)) {
+        if (empty($productValue)) {
             return;
         }
 
-        if (is_object($data) && $data instanceof ProductValueInterface) {
-            $productValue = $data;
-        } else {
-            $productValue = $this->getProductValueFromForm();
-        }
-
         if ($productValue instanceof ProductValueInterface && $productValue->getAttribute()->isUnique()) {
-            $valueAlreadyExists = $this->alreadyExists($productValue);
+            $valueAlreadyExists = $this->alreadyExists($productValue, $this->context->getRoot());
             $valueAlreadyProcessed = $this->hasAlreadyValidatedTheSameValue($productValue);
 
             if ($valueAlreadyExists || $valueAlreadyProcessed) {
-                $valueData = $this->formatData($productValue->getData());
+                $valueData = $productValue->__toString();
                 $attributeCode = $productValue->getAttribute()->getCode();
                 if (null !== $valueData && '' !== $valueData) {
                     $this->context->buildViolation(
@@ -87,18 +76,17 @@ class UniqueValueValidator extends ConstraintValidator
 
     /**
      * @param ProductValueInterface $productValue
+     * @param ProductInterface      $product
      *
      * @return bool
      */
-    protected function alreadyExists(ProductValueInterface $productValue)
+    protected function alreadyExists(ProductValueInterface $productValue, ProductInterface $product)
     {
-        return $this->repository->valueExists($productValue);
+        return $this->repository->uniqueDataExistsInAnotherProduct($productValue, $product);
     }
 
     /**
      * Checks if the same exact value has already been processed on a different product instance
-     *
-     * When validates values for a VariantGroup there is not product related to the value
      *
      * @param ProductValueInterface $productValue
      *
@@ -106,55 +94,6 @@ class UniqueValueValidator extends ConstraintValidator
      */
     protected function hasAlreadyValidatedTheSameValue(ProductValueInterface $productValue)
     {
-        if (null !== $productValue->getProduct()) {
-            return false === $this->uniqueValuesSet->addValue($productValue);
-        }
-
-        return false;
-    }
-
-    /**
-     * @param $mixed $data
-     *
-     * @return string
-     */
-    protected function formatData($data)
-    {
-        return ($data instanceof \DateTime) ? $data->format('Y-m-d') : (string) $data;
-    }
-
-    /**
-     * Get product value from form
-     *
-     * @return ProductValueInterface|null
-     */
-    protected function getProductValueFromForm()
-    {
-        $root = $this->context->getRoot();
-        if (!$root instanceof Form) {
-            return;
-        }
-
-        preg_match(
-            '/children\[values\].children\[(\w+)\].children\[\w+\].data/',
-            $this->context->getPropertyPath(),
-            $matches
-        );
-        if (!isset($matches[1])) {
-            return;
-        }
-
-        $product = $this->context->getRoot()->getData();
-        if (!$product instanceof ProductInterface) {
-            return;
-        }
-
-        $value = $product->getValue($matches[1]);
-
-        if (false === $value) {
-            return;
-        }
-
-        return $value;
+        return false === $this->uniqueValuesSet->addValue($productValue);
     }
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
@@ -58,7 +58,13 @@ class UniqueValueValidator extends ConstraintValidator
         }
 
         if ($productValue instanceof ProductValueInterface && $productValue->getAttribute()->isUnique()) {
-            $valueAlreadyExists = $this->alreadyExists($productValue, $this->context->getRoot());
+            $root = $this->context->getRoot();
+            // during the validation of variant groups, $root is not a product but a product value
+            // we don't have to check if the value already exists in this case
+            $valueAlreadyExists = $root instanceof ProductInterface ? $this->alreadyExists(
+                $productValue,
+                $root
+            ) : false;
             $valueAlreadyProcessed = $this->hasAlreadyValidatedTheSameValue($productValue);
 
             if ($valueAlreadyExists || $valueAlreadyProcessed) {

--- a/src/Pim/Component/Catalog/Validator/UniqueValuesSet.php
+++ b/src/Pim/Component/Catalog/Validator/UniqueValuesSet.php
@@ -43,27 +43,23 @@ class UniqueValuesSet
      */
     public function addValue(ProductValueInterface $productValue)
     {
-        // TODO: To be reworked in TIP-698
-        return true;
+        $identifier = spl_object_hash($productValue);
+        $data = $productValue->__toString();
+        $attributeCode = $productValue->getAttribute()->getCode();
 
-        $product = $productValue->getProduct();
-        $productIdentifier = $this->getProductIdentifier($product);
-        $productValueData = $this->getValueData($productValue);
-        $uniqueValueCode = $this->getUniqueValueCode($productValue);
-
-        if (isset($this->uniqueValues[$uniqueValueCode][$productValueData])) {
-            $storedIdentifier = $this->uniqueValues[$uniqueValueCode][$productValueData];
-            if ($storedIdentifier !== $productIdentifier) {
+        if (isset($this->uniqueValues[$attributeCode][$data])) {
+            $storedIdentifier = $this->uniqueValues[$attributeCode][$data];
+            if ($storedIdentifier !== $identifier) {
                 return false;
             }
         }
 
-        if (!isset($this->uniqueValues[$uniqueValueCode])) {
-            $this->uniqueValues[$uniqueValueCode] = [];
+        if (!isset($this->uniqueValues[$attributeCode])) {
+            $this->uniqueValues[$attributeCode] = [];
         }
 
-        if (!isset($this->uniqueValues[$uniqueValueCode][$productValueData])) {
-            $this->uniqueValues[$uniqueValueCode][$productValueData] = $productIdentifier;
+        if (!isset($this->uniqueValues[$attributeCode][$data])) {
+            $this->uniqueValues[$attributeCode][$data] = $identifier;
         }
 
         return true;
@@ -75,46 +71,5 @@ class UniqueValuesSet
     public function getUniqueValues()
     {
         return $this->uniqueValues;
-    }
-
-    /**
-     * spl_object_hash for new product and id when product exists
-     *
-     * @param ProductInterface $product
-     *
-     * @return string
-     */
-    protected function getProductIdentifier(ProductInterface $product)
-    {
-        $identifier = $product->getId() ? $product->getId() : spl_object_hash($product);
-
-        return $identifier;
-    }
-
-    /**
-     * @param ProductValueInterface $productValue
-     *
-     * @return string
-     */
-    protected function getUniqueValueCode(ProductValueInterface $productValue)
-    {
-        $attributeCode = $productValue->getAttribute()->getCode();
-        $uniqueValueCode = $attributeCode;
-        $uniqueValueCode .= (null !== $productValue->getLocale()) ? $productValue->getLocale() : '';
-        $uniqueValueCode .= (null !== $productValue->getScope()) ? $productValue->getScope() : '';
-
-        return $uniqueValueCode;
-    }
-
-    /**
-     * @param ProductValueInterface $productValue
-     *
-     * @return string
-     */
-    protected function getValueData(ProductValueInterface $productValue)
-    {
-        $data = $productValue->getData();
-
-        return ($data instanceof \DateTime) ? $data->format('Y-m-d') : (string) $data;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -77,6 +77,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $tshirtFamily->getId()->shouldBeCalled();
         $tshirtFamily->getAttributes()->willReturn([]);
 
+        $identifierAttribute->isUnique()->willReturn(false);
         $attributeRepository->getIdentifier()->willReturn($identifierAttribute);
         $identifierAttribute->getCode()->willReturn('sku');
         $identifierAttribute->getType()->willReturn(AttributeTypes::IDENTIFIER);

--- a/src/Pim/Component/Catalog/spec/Completeness/CompletenessCalculatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Completeness/CompletenessCalculatorSpec.php
@@ -73,6 +73,7 @@ class CompletenessCalculatorSpec extends ObjectBehavior
         ProductValueCollectionInterface $actualProductValues,
         ProductValueInterface $requiredProductValue
     ) {
+        $attribute->isUnique()->willReturn(false);
         $channel->getCode()->willReturn('channel_code');
         $locale->getCode()->willReturn('locale_code');
 
@@ -133,6 +134,7 @@ class CompletenessCalculatorSpec extends ObjectBehavior
         ProductValueInterface $requiredProductValue,
         ProductValueInterface $actualProductValue
     ) {
+        $attribute->isUnique()->willReturn(false);
         $channel->getCode()->willReturn('channel_code');
         $locale->getCode()->willReturn('locale_code');
 
@@ -195,6 +197,7 @@ class CompletenessCalculatorSpec extends ObjectBehavior
         ProductValueInterface $requiredProductValue,
         ProductValueInterface $actualProductValue
     ) {
+        $attribute->isUnique()->willReturn(false);
         $channel->getCode()->willReturn('channel_code');
         $locale->getCode()->willReturn('locale_code');
 
@@ -281,12 +284,14 @@ class CompletenessCalculatorSpec extends ObjectBehavior
         $localesIterator->current()->willReturn($locale);
         $localesIterator->next()->shouldBeCalled();
 
+        $attribute1->isUnique()->willReturn(false);
         $attribute1->isLocaleSpecific()->willReturn(false);
         $attribute1->hasLocaleSpecific($locale)->shouldNotBeCalled();
         $attribute1->isScopable()->willReturn(false);
         $attribute1->isLocalizable()->willReturn(false);
         $attribute1->getCode()->willReturn('attribute_code_1');
 
+        $attribute2->isUnique()->willReturn(false);
         $attribute2->isLocaleSpecific()->willReturn(false);
         $attribute2->hasLocaleSpecific($locale)->shouldNotBeCalled();
         $attribute2->isScopable()->willReturn(false);

--- a/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValuesDenormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValuesDenormalizerSpec.php
@@ -54,12 +54,14 @@ class ProductValuesDenormalizerSpec extends ObjectBehavior
 
         $attributeRepository->findOneByIdentifier('name')->willReturn($name);
         $name->getCode()->willReturn('name');
+        $name->isUnique()->willReturn(false);
         $nameValue->getAttribute()->willReturn($name);
         $nameValue->getScope()->willReturn(null);
         $nameValue->getLocale()->willReturn(null);
 
         $attributeRepository->findOneByIdentifier('color')->willReturn($color);
         $color->getCode()->willReturn('color');
+        $color->isUnique()->willReturn(false);
         $colorValue->getAttribute()->willReturn($color);
         $colorValue->getScope()->willReturn('ecommerce');
         $colorValue->getLocale()->willReturn('en_US');

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
@@ -33,7 +33,9 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
         ProductValueInterface $value4
     ) {
         $sku->getCode()->wilLReturn('sku');
+        $sku->isUnique()->wilLReturn(false);
         $description->getCode()->wilLReturn('description');
+        $description->isUnique()->wilLReturn(false);
 
         $value1->getLocale()->willReturn(null);
         $value1->getScope()->willReturn(null);

--- a/src/Pim/Component/Catalog/spec/Model/ProductValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductValueCollectionSpec.php
@@ -15,6 +15,7 @@ class ProductValueCollectionSpec extends ObjectBehavior
         AttributeInterface $length,
         AttributeInterface $price,
         AttributeInterface $description,
+        AttributeInterface $releaseDate,
         ChannelInterface $ecommerce,
         ChannelInterface $print,
         LocaleInterface $en_US,
@@ -23,12 +24,19 @@ class ProductValueCollectionSpec extends ObjectBehavior
         ProductValueInterface $value2,
         ProductValueInterface $value3,
         ProductValueInterface $value4,
-        ProductValueInterface $value5
+        ProductValueInterface $value5,
+        ProductValueInterface $value6
     ) {
+        $length->isUnique()->willReturn(false);
+        $price->isUnique()->willReturn(false);
+        $description->isUnique()->willReturn(false);
+        $releaseDate->isUnique()->willReturn(true);
+
         $length->getCode()->willReturn('length');
         $price->getCode()->willReturn('price');
         $description->getCode()->willReturn('description');
         $ecommerce->getCode()->willReturn('ecommerce');
+        $releaseDate->getCode()->willReturn('release_date');
         $print->getCode()->willReturn('print');
         $en_US->getCode()->willReturn('en_US');
         $fr_FR->getCode()->willReturn('fr_FR');
@@ -38,20 +46,25 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $value3->getAttribute()->willReturn($description);
         $value4->getAttribute()->willReturn($description);
         $value5->getAttribute()->willReturn($description);
+        $value6->getAttribute()->willReturn($releaseDate);
 
         $value1->getScope()->willReturn(null);
         $value2->getScope()->willReturn(null);
         $value3->getScope()->willReturn('ecommerce');
         $value4->getScope()->willReturn('ecommerce');
         $value5->getScope()->willReturn('print');
+        $value6->getScope()->willReturn(null);
 
         $value1->getLocale()->willReturn(null);
         $value2->getLocale()->willReturn(null);
         $value3->getLocale()->willReturn('en_US');
         $value4->getLocale()->willReturn('fr_FR');
         $value5->getLocale()->willReturn('en_US');
+        $value6->getLocale()->willReturn(null);
 
-        $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5]);
+        $value6->getData()->willReturn('2016-09-12');
+
+        $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5, $value6]);
     }
 
     function it_is_initializable()
@@ -59,14 +72,15 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $this->shouldHaveType(ProductValueCollection::class);
     }
 
-    function it_convert_the_collection_to_an_array($value1, $value2, $value3, $value4, $value5)
+    function it_convert_the_collection_to_an_array($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->toArray()->shouldReturn([
             'length-<all_channels>-<all_locales>' => $value1,
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
     }
 
@@ -75,9 +89,9 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $this->first()->shouldReturn($value1);
     }
 
-    function it_returns_the_last_value($value5)
+    function it_returns_the_last_value($value6)
     {
-        $this->last()->shouldReturn($value5);
+        $this->last()->shouldReturn($value6);
     }
 
     function it_returns_the_key_of_the_current_value()
@@ -95,7 +109,7 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $this->current()->shouldReturn($value1);
     }
 
-    function it_removes_a_value_by_a_key_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5)
+    function it_removes_a_value_by_a_key_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->removeKey('length-<all_channels>-<all_locales>')->shouldReturn($value1);
 
@@ -103,13 +117,31 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['price', 'description', 'release_date']);
+        $this->getUniqueValues()->shouldReturn(['release_date-<all_channels>-<all_locales>' => $value6]);
     }
 
-    function it_removes_a_value_by_a_key_and_keeps_indexed_attribute($value1, $value2, $value3, $value4, $value5)
+    function it_removes_a_unique_value_by_a_key_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
+    {
+        $this->removeKey('release_date-<all_channels>-<all_locales>')->shouldReturn($value6);
+
+        $this->toArray()->shouldReturn([
+            'length-<all_channels>-<all_locales>' => $value1,
+            'price-<all_channels>-<all_locales>' => $value2,
+            'description-ecommerce-en_US' => $value3,
+            'description-ecommerce-fr_FR' => $value4,
+            'description-print-en_US' => $value5,
+        ]);
+
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getUniqueValues()->shouldReturn([]);
+    }
+
+    function it_removes_a_value_by_a_key_and_keeps_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->removeKey('description-ecommerce-en_US')->shouldReturn($value3);
 
@@ -117,13 +149,30 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'length-<all_channels>-<all_locales>' => $value1,
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
+        ]);
+
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
+    }
+
+    function it_removes_a_unique_value_by_a_key_and_keeps_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
+    {
+        $this->removeKey('release_date-<all_channels>-<all_locales>')->shouldReturn($value6);
+
+        $this->toArray()->shouldReturn([
+            'length-<all_channels>-<all_locales>' => $value1,
+            'price-<all_channels>-<all_locales>' => $value2,
+            'description-ecommerce-en_US' => $value3,
+            'description-ecommerce-fr_FR' => $value4,
+            'description-print-en_US' => $value5,
         ]);
 
         $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getUniqueValues()->shouldReturn([]);
     }
 
-    function it_does_not_removes_a_non_existing_key($value1, $value2, $value3, $value4, $value5)
+    function it_does_not_removes_a_non_existing_key($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->removeKey('foo')->shouldReturn(null);
 
@@ -132,13 +181,14 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
-    function it_removes_a_value_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5)
+    function it_removes_a_value_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->remove($value1)->shouldReturn(true);
 
@@ -146,13 +196,30 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['price', 'description', 'release_date']);
     }
 
-    function it_removes_a_value_and_keeps_indexed_attribute($value1, $value2, $value3, $value4, $value5)
+    function it_removes_a_unique_value_and_deletes_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
+    {
+        $this->remove($value6)->shouldReturn(true);
+
+        $this->toArray()->shouldReturn([
+            'length-<all_channels>-<all_locales>' => $value1,
+            'price-<all_channels>-<all_locales>' => $value2,
+            'description-ecommerce-en_US' => $value3,
+            'description-ecommerce-fr_FR' => $value4,
+            'description-print-en_US' => $value5,
+        ]);
+
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getUniqueValues()->shouldReturn([]);
+    }
+
+    function it_removes_a_value_and_keeps_indexed_attribute($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->remove($value3)->shouldReturn(true);
 
@@ -160,13 +227,14 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'length-<all_channels>-<all_locales>' => $value1,
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
-    function it_does_not_removes_a_non_existing_value($value1, $value2, $value3, $value4, $value5, ProductValueInterface $anotherValue)
+    function it_does_not_removes_a_non_existing_value($value1, $value2, $value3, $value4, $value5, $value6, ProductValueInterface $anotherValue)
     {
         $this->remove($anotherValue)->shouldReturn(false);
 
@@ -175,10 +243,11 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
     function it_removes_a_value_by_attribute_and_deletes_indexed_attribute(
@@ -186,6 +255,7 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $value3,
         $value4,
         $value5,
+        $value6,
         $length
     ) {
         $this->removeByAttribute($length)->shouldReturn(true);
@@ -194,10 +264,11 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['price', 'description', 'release_date']);
     }
 
     function it_does_not_removes_values_for_non_present_attribute(
@@ -206,6 +277,7 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $value3,
         $value4,
         $value5,
+        $value6,
         AttributeInterface $anotherAttribute
     ) {
         $this->removeByAttribute($anotherAttribute)->shouldReturn(false);
@@ -215,10 +287,11 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
     function it_contains_a_key()
@@ -255,18 +328,19 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>',
             'description-ecommerce-en_US',
             'description-ecommerce-fr_FR',
-            'description-print-en_US'
+            'description-print-en_US',
+            'release_date-<all_channels>-<all_locales>',
         ]);
     }
 
-    function it_get_values($value1, $value2, $value3, $value4, $value5)
+    function it_get_values($value1, $value2, $value3, $value4, $value5, $value6)
     {
-        $this->getValues()->shouldReturn([$value1, $value2, $value3, $value4, $value5]);
+        $this->getValues()->shouldReturn([$value1, $value2, $value3, $value4, $value5, $value6]);
     }
 
     function it_count_values()
     {
-        $this->count()->shouldReturn(5);
+        $this->count()->shouldReturn(6);
     }
 
     function it_adds_new_value(
@@ -275,9 +349,12 @@ class ProductValueCollectionSpec extends ObjectBehavior
         $value3,
         $value4,
         $value5,
+        $value6,
         ProductValueInterface $newValue,
         AttributeInterface $attribute
     ) {
+        $attribute->isUnique()->willReturn(false);
+
         $newValue->getAttribute()->willReturn($attribute);
         $newValue->getLocale()->willReturn('en_US');
         $newValue->getScope()->willReturn(null);
@@ -291,13 +368,89 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
             'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
             'weight-<all_channels>-en_US' => $newValue
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'weight']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date', 'weight']);
+
+        $this->getUniqueValues()->shouldReturn(['release_date-<all_channels>-<all_locales>' => $value6]);
     }
 
-    function it_adds_only_new_value($value1, $value2, $value3, $value4, $value5)
+    function it_adds_new_unique_value(
+        $value1,
+        $value2,
+        $value3,
+        $value4,
+        $value5,
+        $value6,
+        ProductValueInterface $newValue,
+        AttributeInterface $attribute
+    ) {
+        $attribute->isUnique()->willReturn(true);
+
+        $newValue->getAttribute()->willReturn($attribute);
+        $newValue->getLocale()->willReturn('en_US');
+        $newValue->getScope()->willReturn(null);
+        $newValue->getData()->willReturn('56 KG');
+        $attribute->getCode()->willReturn('weight');
+
+        $this->add($newValue)->shouldReturn(true);
+
+        $this->toArray()->shouldReturn([
+            'length-<all_channels>-<all_locales>' => $value1,
+            'price-<all_channels>-<all_locales>' => $value2,
+            'description-ecommerce-en_US' => $value3,
+            'description-ecommerce-fr_FR' => $value4,
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
+            'weight-<all_channels>-en_US' => $newValue
+        ]);
+
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date', 'weight']);
+
+        $this->getUniqueValues()->shouldReturn([
+            'release_date-<all_channels>-<all_locales>' => $value6,
+            'weight-<all_channels>-en_US' => $newValue,
+        ]);
+    }
+
+    function it_does_not_add_an_empty_value_to_unique_values(
+        $value1,
+        $value2,
+        $value3,
+        $value4,
+        $value5,
+        $value6,
+        ProductValueInterface $newValue,
+        AttributeInterface $attribute
+    ) {
+        $attribute->isUnique()->willReturn(true);
+
+        $newValue->getAttribute()->willReturn($attribute);
+        $newValue->getLocale()->willReturn('en_US');
+        $newValue->getScope()->willReturn(null);
+        $newValue->getData()->willReturn(null);
+        $attribute->getCode()->willReturn('weight');
+
+        $this->add($newValue)->shouldReturn(true);
+
+        $this->toArray()->shouldReturn([
+            'length-<all_channels>-<all_locales>' => $value1,
+            'price-<all_channels>-<all_locales>' => $value2,
+            'description-ecommerce-en_US' => $value3,
+            'description-ecommerce-fr_FR' => $value4,
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
+            'weight-<all_channels>-en_US' => $newValue
+        ]);
+
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date', 'weight']);
+
+        $this->getUniqueValues()->shouldReturn(['release_date-<all_channels>-<all_locales>' => $value6]);
+    }
+
+    function it_adds_only_new_value($value1, $value2, $value3, $value4, $value5, $value6)
     {
         $this->add($value3)->shouldReturn(false);
 
@@ -306,10 +459,11 @@ class ProductValueCollectionSpec extends ObjectBehavior
             'price-<all_channels>-<all_locales>' => $value2,
             'description-ecommerce-en_US' => $value3,
             'description-ecommerce-fr_FR' => $value4,
-            'description-print-en_US' => $value5
+            'description-print-en_US' => $value5,
+            'release_date-<all_channels>-<all_locales>' => $value6,
         ]);
 
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
     function it_checks_if_empty()
@@ -334,11 +488,11 @@ class ProductValueCollectionSpec extends ObjectBehavior
 
     function it_gets_attribute_keys()
     {
-        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description']);
+        $this->getAttributesKeys()->shouldReturn(['length', 'price', 'description', 'release_date']);
     }
 
-    function it_gets_attributes($length, $price, $description)
+    function it_gets_attributes($length, $price, $description, $releaseDate)
     {
-        $this->getAttributes()->shouldReturn([$length, $price, $description]);
+        $this->getAttributes()->shouldReturn([$length, $price, $description, $releaseDate]);
     }
 }


### PR DESCRIPTION
## Current behavior

Currently in the PIM, when you create an attribute, you can define it with the flag `unique value`. For instance, if this flag is set to true on the attribute `release_date`, and we affect the value `2017-09-07` on this attribute for the product `sku-001`, that means no other product will be able to have the value `2017-09-07` on this attribute. 

The  behavior only applies to the following attribute types: dates, identifiers, numbers and text.
When this behavior is enabled, the attribute is forced to be non localisable and non scopable.

## Current implementation

To ensure this behavior, the current implementation is really simple with the EAV model. During the product's validation (in `UniqueValueValidator`) we just have to check in the repository (table `pim_catalog_product_value`) if this value already exists. 

This is not possible anymore as the values as directly stored in the product. And we can't query directly the values.

## What's in this PR?

* unique value = product value (attribute + locale + channel + data) that is linked to an attribute with the flag `unique value` set to true
* unique data = data of a unique value on a given attribute and product

I decided to keep (in memory) the unique values directly in the `ProductValueCollection`. They are accessible via the `getUniqueValues` method. Everytime a value is added to the collection, if it's unique, then we add it to a `$uniqueValues` array. This is simple and allows to always know what are currently the unique values of the product.
The other option was to not modify the value collection, and to iterate a posteriori all the values to check if they are unique or not. It seemed a little bit weird to me.

### How to store in DB this information?

![uniquedata](https://cloud.githubusercontent.com/assets/3691804/25736025/b0cf25da-316f-11e7-93fa-9af6b615e9d9.png)

As you can see, the information to store is quite simple. The real question is, why is the table called `unique_data`?
Simply because we don't store values here. There is no notion of channel or locale. We just store the real data, formatted as a string, for an attribute and a product.

`$uniqueData` is a regular one to many relationship with the product.
During the save of the product, a `ProductUniqueDataSynchronizer` is here to synchronize the unique values of the `$values` collection to the `$uniqueData` Doctrine collection.

## Why not have used ElasticSearch for that?

Elasticsearch can not be used to check the integrity of data or during a write operation. **Never**. Consider it as a read only tool. Our reference source of data **do is** MySQL. Elasticsearch is just a convenient and very efficient way to find and read data.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Fixed 
| Added integration tests           | -
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
