### PR TITLE
Tip 713 fix groups filter

### DIFF
--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -43,7 +43,6 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
             $product->getUpdated(),
             $format
         );
-
         $data[StandardPropertiesNormalizer::FIELD_FAMILY] = $this->serializer->normalize(
             $product->getFamily(),
             $format
@@ -52,14 +51,14 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data[StandardPropertiesNormalizer::FIELD_ENABLED] = (bool) $product->isEnabled();
         $data[StandardPropertiesNormalizer::FIELD_CATEGORIES] = $product->getCategoryCodes();
 
-        $groups = array_diff(
-            $product->getGroupCodes(),
-            null !== $product->getVariantGroup() ? [$product->getVariantGroup()->getCode()] : []
-        );
-
-        $data[StandardPropertiesNormalizer::FIELD_GROUPS] = $groups;
-        $data[StandardPropertiesNormalizer::FIELD_VARIANT_GROUP] = null !== $product->getVariantGroup()
-            ? $product->getVariantGroup()->getCode() : null;
+        $groups = $product->getGroupCodes();
+        $variantGroupCode = null;
+        if (null !== $product->getVariantGroup()) {
+            $variantGroupCode = $product->getVariantGroup()->getCode();
+            $groups[] = $variantGroupCode;
+        }
+        $data[StandardPropertiesNormalizer::FIELD_GROUPS] = array_unique($groups);
+        $data[StandardPropertiesNormalizer::FIELD_VARIANT_GROUP] = $variantGroupCode;
 
         foreach ($product->getGroupCodes() as $groupCode) {
             $data[self::FIELD_IN_GROUP][$groupCode] = true;

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -51,14 +51,9 @@ class PropertiesNormalizer extends SerializerAwareNormalizer implements Normaliz
         $data[StandardPropertiesNormalizer::FIELD_ENABLED] = (bool) $product->isEnabled();
         $data[StandardPropertiesNormalizer::FIELD_CATEGORIES] = $product->getCategoryCodes();
 
-        $groups = $product->getGroupCodes();
-        $variantGroupCode = null;
-        if (null !== $product->getVariantGroup()) {
-            $variantGroupCode = $product->getVariantGroup()->getCode();
-            $groups[] = $variantGroupCode;
-        }
-        $data[StandardPropertiesNormalizer::FIELD_GROUPS] = array_unique($groups);
-        $data[StandardPropertiesNormalizer::FIELD_VARIANT_GROUP] = $variantGroupCode;
+        $data[StandardPropertiesNormalizer::FIELD_GROUPS] = $product->getGroupCodes();
+        $data[StandardPropertiesNormalizer::FIELD_VARIANT_GROUP] = null !== $product->getVariantGroup()
+            ? $product->getVariantGroup()->getCode() : null;
 
         foreach ($product->getGroupCodes() as $groupCode) {
             $data[self::FIELD_IN_GROUP][$groupCode] = true;

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -245,7 +245,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 ],
                 'enabled'       => true,
                 'categories'    => ['first_category', 'second_category'],
-                'groups'        => ['first_group', 'second_group'],
+                'groups'        => ['first_group', 'second_group', 'a_variant_group'],
                 'variant_group' => 'a_variant_group',
                 'in_group' => [
                     'first_group'     => true,

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -96,7 +96,7 @@ class ProductIndexingIntegration extends TestCase
             ],
             'enabled'       => true,
             'categories'    => ['categoryA1', 'categoryB'],
-            'groups'        => ['groupA', 'groupB'],
+            'groups'        => ['groupA', 'groupB', 'variantA'],
             'variant_group' => 'variantA',
             'in_group'      => [
                 'groupA'   => true,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
- Now variant group code is indexed in "groups" along with all other group codes (the variant_group property still exists)

This PR fixes the following scenarios:
- `features/product/filtering/filter_products_per_group.feature:38`
- `features/product/filtering/filter_products_per_group.feature:51` 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
