### PR TITLE
TIP-713: fix option value rendered as strings

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
@@ -224,8 +224,11 @@ class AttributeOption implements AttributeOptionInterface
                 }
             }
         );
-        $value = $values->first();
 
-        return $value;
+        if ($values->isEmpty()) {
+            return null;
+        }
+
+        return $values->first();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Entity;
+
+use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
+use Prophecy\Argument;
+
+class AttributeOptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AttributeOption::class);
+    }
+
+    function it_returns_null_when_there_is_no_translation()
+    {
+        $this->getOptionValue()->shouldReturn(null);
+    }
+
+    function it_returns_the_expected_translation(AttributeOptionValueInterface $en, AttributeOptionValueInterface $fr)
+    {
+        $en->getLocale()->willReturn('en');
+        $fr->getLocale()->willReturn('fr');
+
+        $en->setOption(Argument::any())->shouldBeCalled();
+        $fr->setOption(Argument::any())->shouldBeCalled();
+
+        $this->addOptionValue($en);
+        $this->addOptionValue($fr);
+        $this->setLocale('fr');
+
+        $this->getOptionValue()->shouldReturn($fr);
+    }
+}

--- a/src/Pim/Component/Catalog/ProductValue/OptionProductValue.php
+++ b/src/Pim/Component/Catalog/ProductValue/OptionProductValue.php
@@ -50,6 +50,9 @@ class OptionProductValue extends AbstractProductValue implements OptionProductVa
      */
     public function __toString()
     {
-        return null !== $this->data ? $this->data->getCode() : '';
+        $option = $this->getData();
+        $optionValue = $option->getOptionValue();
+
+        return (null !== $option && null !== $optionValue) ? $optionValue->getValue() : '['.$option->getCode().']';
     }
 }

--- a/src/Pim/Component/Catalog/spec/ProductValue/OptionProductValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductValue/OptionProductValueSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\ProductValue;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 
 class OptionProductValueSpec extends ObjectBehavior
 {
@@ -19,5 +20,25 @@ class OptionProductValueSpec extends ObjectBehavior
     {
         $this->getData()->shouldBeAnInstanceOf(AttributeOptionInterface::class);
         $this->getData()->shouldReturn($option);
+    }
+
+    function it_can_be_formatted_as_string_when_there_is_no_translation($option)
+    {
+        $option->getOptionValue()->willReturn(null);
+        $option->getCode()->willReturn('red');
+
+        $this->__toString()->shouldReturn('[red]');
+    }
+
+    function it_can_be_formatted_as_string_when_there_is_a_translation(
+        $option,
+        AttributeOptionValueInterface $translation
+    ) {
+        $translation->getValue()->willReturn('Blue');
+
+        $option->getOptionValue()->willReturn($translation);
+        $option->getCode()->shouldNotBeCalled();
+
+        $this->__toString()->shouldReturn('Blue');
     }
 }


### PR DESCRIPTION
This will fix all the Behat where we search options without translation, like `[5]`, `[red]` os `[s]`.

69 failed remaining

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | 
| Added integration tests           | 
| Changelog updated                 | 
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

