### PR TITLE
TIP-713: don't use orm pager extension for products group grid

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Extension/Pager/PagerExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Pager/PagerExtension.php
@@ -55,7 +55,7 @@ class PagerExtension extends AbstractExtension
     {
         return !in_array(
             $config->offsetGetByPath('name'),
-            ['product-grid', 'association-product-grid', 'product-variant-group-grid']
+            ['product-grid', 'association-product-grid', 'product-variant-group-grid', 'product-group-grid']
         );
     }
 


### PR DESCRIPTION
This does not fix behat, but now it fails for a common reason of other behat about the grid.