### PR TITLE
 TIP-713: Fix product selection in group product grid

### DIFF
--- a/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
@@ -40,7 +40,7 @@ Feature: Add attributes to a variant group
       | sku  | groups            | name-en_US | color | size |
       | boot | caterpillar_boots | foo        | black | 39   |
     And I am on the "caterpillar_boots" variant group page
-    Then the english Name of "boot" should be "foo"
+    Then the english localizable value Name of "boot" should be "foo"
     When I visit the "Attributes" tab
     And I add available attribute Name
     When I save the variant group

--- a/features/enrich/variant-group/edit_variant_group.feature
+++ b/features/enrich/variant-group/edit_variant_group.feature
@@ -44,7 +44,7 @@ Feature: Edit a variant group
     When I add available attributes Description
     And I visit the "Products" tab
     And I save the variant group
-    And I should see the text "89%"
+    And I should see the text "88%"
     And I check the row "sneakers"
     And I save the variant group
-    Then I should see the text "78%"
+    Then I should see the text "77%"

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/GroupProductNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/GroupProductNormalizer.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\DataGridBundle\Normalizer;
 
+use Pim\Component\Catalog\Model\GroupInterface;
+
 /**
  * Normalize Products for variant group grid
  *
@@ -9,7 +11,7 @@ namespace Pim\Bundle\DataGridBundle\Normalizer;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class VariantGroupProductNormalizer extends ProductNormalizer
+class GroupProductNormalizer extends ProductNormalizer
 {
     /**
      * {@inheritdoc}
@@ -18,8 +20,12 @@ class VariantGroupProductNormalizer extends ProductNormalizer
     {
         $data = parent::normalize($product, $format, $context);
 
-        $data['in_group'] = null !== $product->getVariantGroup();
-        $data['is_checked'] = null !== $product->getVariantGroup();
+        $groupIds = array_map(function (GroupInterface $group) {
+            return $group->getId();
+        }, $product->getGroups()->toArray());
+
+        $data['in_group'] = in_array($context['current_group_id'], $groupIds);
+        $data['is_checked'] = in_array($context['current_group_id'], $groupIds);
 
         return $data;
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -140,7 +140,7 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_datagrid.datasource.result_record.hydrator.associated_product'
             - '@pim_catalog.query.product_query_builder_bounded_factory'
-            - '@pim_datagrid.normalizer.variant_group_product'
+            - '@pim_datagrid.normalizer.group_product'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_variant_group_product }
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
@@ -7,7 +7,7 @@ parameters:
     pim_datagrid.normalizer.product.options.class: Pim\Bundle\DataGridBundle\Normalizer\Product\OptionsNormalizer
     pim_datagrid.normalizer.product.file.class: Pim\Bundle\DataGridBundle\Normalizer\Product\FileNormalizer
     pim_datagrid.normalizer.datetime.class: Pim\Bundle\DataGridBundle\Normalizer\DateTimeNormalizer
-    pim_datagrid.normalizer.variant_group_product.class: Pim\Bundle\DataGridBundle\Normalizer\VariantGroupProductNormalizer
+    pim_datagrid.normalizer.group_product.class: Pim\Bundle\DataGridBundle\Normalizer\GroupProductNormalizer
 
 services:
     pim_datagrid.normalizer.product:
@@ -61,8 +61,8 @@ services:
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
-    pim_datagrid.normalizer.variant_group_product:
-        class: '%pim_datagrid.normalizer.variant_group_product.class%'
+    pim_datagrid.normalizer.group_product:
+        class: '%pim_datagrid.normalizer.group_product.class%'
         arguments:
             - '@pim_catalog.filter.chained'
         tags:

--- a/src/Pim/Bundle/EnrichBundle/Controller/VariantGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/VariantGroupController.php
@@ -72,7 +72,7 @@ class VariantGroupController
      * @Template
      * @AclAncestor("pim_enrich_variant_group_index")
      *
-     * @return Response
+     * @return array
      */
     public function indexAction()
     {

--- a/src/Pim/Component/Catalog/Query/ProductQueryBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Query/ProductQueryBuilderInterface.php
@@ -20,7 +20,7 @@ interface ProductQueryBuilderInterface
      *
      * @param string $field    the field
      * @param string $operator the used operator
-     * @param string $value    the value to filter
+     * @param mixed  $value    the value to filter
      * @param array  $context  the filter context, used for locale and scope
      *
      * @throws \LogicException


### PR DESCRIPTION
## Description

This PR fixes the selection of products when editing a variant group. This should also affect regular groups.

Problem was identified in `features/enrich/variant-group/remove_products.feature:20`, but should solve other scenarios too.

It also fixes wrong completeness values in ` features/enrich/variant-group/edit_variant_group.feature:32`.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
