### PR TITLE
TIP-713: Fix completeness filter

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -131,6 +131,7 @@ class SearchQueryBuilder
 
         if (!empty($this->shouldClauses)) {
             $searchQuery['query']['bool']['should'] = $this->shouldClauses;
+            $searchQuery['query']['bool']['minimum_should_match'] = 1;
         }
 
         if (!empty($this->sortClauses)) {

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/SearchQueryBuilderSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/SearchQueryBuilderSpec.php
@@ -135,6 +135,7 @@ class SearchQueryBuilderSpec extends ObjectBehavior
                         'should' => [
                             ['term' => ['family' => 'camcorders']],
                         ],
+                        'minimum_should_match' => 1,
                     ],
                 ],
             ]
@@ -168,6 +169,7 @@ class SearchQueryBuilderSpec extends ObjectBehavior
 
                             ],
                         ],
+                        'minimum_should_match' => 1,
                     ],
                 ],
             ]
@@ -256,7 +258,8 @@ class SearchQueryBuilderSpec extends ObjectBehavior
                                     ]
                                 ]
                             ]
-                        ]
+                        ],
+                        'minimum_should_match' => 1,
                     ],
                 ],
             ]

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -50,6 +50,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
             $this->createProduct('product_one', [
                 'family' => 'familyB',
+                'categories' => ['categoryA1'],
                 'values' => [
                     'a_metric' => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
                 ]
@@ -57,6 +58,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
             $this->createProduct('product_two', [
                 'family' => 'familyB',
+                'categories' => ['categoryA2'],
                 'values' => [
                     'a_metric'                           => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]],
                     'a_localized_and_scopable_text_area' => [['data' => 'text', 'locale' => 'en_US', 'scope' => 'tablet']],
@@ -73,6 +75,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
             $this->createProduct('empty_product', [
                 'family' => 'familyB',
+                'categories' => ['categoryA2']
             ]);
 
             $this->createProduct('no_family', [
@@ -387,6 +390,15 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $result = $this->executeFilter([['completeness', 'ALL', 0]]);
         $this->assert($result, ['product_one', 'product_two', 'empty_product', 'no_family']);
+    }
+
+    public function testOperatorEqualsWithAnotherFilter()
+    {
+        $result = $this->executeFilter([
+            ['completeness', '=', 100, ['scope' => 'tablet', 'locale' => 'en_US']],
+            ['categories', 'IN', ['categoryA2']]
+        ]);
+        $this->assert($result, ['product_two']);
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes: `features/mass-action/mass_actions_on_all_entities.feature:35`

Whenever we want to filter some products based on their completenesses we might use a ES "should" operator that would work like a logical "OR".

However in our previous version when we wanted to filter on the completeness and the category for instance, the request would logically becomes something like this:

`categories IN [categoryA] || completeness.mobile.en_US = 100`

When what we wanted was in fact:

`categories IN [categoryA] && completeness.mobile.en_US = 100`

**Why not use only filter instead of should ?**

Because the Completeness filter supports things like:

`completeness.mobile.fr_FR = 100 || Completeness.fr_FR.en_US = 100` (give me the products complete on any locale)

Given the following conditions and their filter context:
```
filter => X
should => [ Y, Z ]
```
To transform the should X OR Y OR Z to a logical `X AND ( Y OR Z )` we need to use the property: "minimum_should_match" and set it to 1.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
