### PR TITLE
TIP-713: Various groups and variant groups fixes

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -45,6 +45,7 @@
 - Change the constructor of `Pim\Component\Connector\Writer\File\ProductColumnSorter` to replace `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` by `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepositoryInterface`
 - Change the constructor of `Pim\Component\Catalog\Updater\VariantGroupUpdater` to replace `Pim\Component\Catalog\BuilderProductBuilderInterface` and `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
     by `Pim\Component\Catalog\Factory\ProductValueFactory`, `Akeneo\Component\FileStorage\Repository\FileInfoRepositoryInterface` and `Akeneo\Component\FileStorage\File\FileStorerInterface`
+- Change the constructor of `Pim\Component\Connector\Processor\Normalization\VariantGroupProcessor` to remove `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
 
 ### Others
 
@@ -106,3 +107,4 @@
 - Add method `findCodesByIdentifiers` in `Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface`
 - Add method `findCodesByIdentifiers` in `Pim\Component\ReferenceData\Repository\ReferenceDataRepositoryInterface`
 - Remove class `Pim\Bundle\DataGridBundle\EventListener\AddParametersToVariantProductGridListener`
+- Remove methods `createVariantGroupDatagridQueryBuilder` and `createGroupDatagridQueryBuilder` from `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductRepository`

--- a/features/enrich/variant-group/add_products/add_products_history_updated_without_context.feature
+++ b/features/enrich/variant-group/add_products/add_products_history_updated_without_context.feature
@@ -43,7 +43,8 @@ Feature: Add products to a variant group
     And I open the history
     And I should see history in panel:
       | version | author                                                            | property | value           |
-      | 4       | Julia Stark - Julia@example.com                                   | groups   |                 |
+      | 5       | Julia Stark - Julia@example.com                                   | groups   |                 |
+      | 4       | Julia Stark - Julia@example.com (Comes from variant group SANDAL) | Comment  | New comment     |
       | 3       | Julia Stark - Julia@example.com (Comes from variant group SANDAL) | groups   | SANDAL          |
       | 2       | John Doe - admin@example.com                                      | Color    | white           |
       | 1       | John Doe - admin@example.com                                      | SKU      | sandal-white-37 |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -187,60 +187,6 @@ class ProductRepository extends EntityRepository implements
     }
 
     /**
-     * Returns the ProductValue class
-     *
-     * @return string
-     */
-    protected function getValuesClass()
-    {
-        return $this->getClassMetadata()
-            ->getAssociationTargetClass('values');
-    }
-
-    /**
-     * Returns the Attribute class
-     *
-     * @return string
-     */
-    protected function getAttributeClass()
-    {
-        return $this->getEntityManager()
-            ->getClassMetadata($this->getValuesClass())
-            ->getAssociationTargetClass('attribute');
-    }
-
-    /**
-     * @return QueryBuilder
-     */
-    public function createGroupDatagridQueryBuilder()
-    {
-        $qb = $this->getEntityManager()->createQueryBuilder()
-            ->select('p')
-            ->from($this->_entityName, 'p', 'p.id');
-
-        $isCheckedExpr =
-            'CASE WHEN ' .
-            '(:currentGroup MEMBER OF p.groups '.
-            'OR p.id IN (:data_in)) AND p.id NOT IN (:data_not_in) '.
-            'THEN true ELSE false END';
-        $qb
-            ->addSelect($isCheckedExpr.' AS is_checked');
-
-        return $qb;
-    }
-
-    /**
-     * @return QueryBuilder
-     */
-    public function createVariantGroupDatagridQueryBuilder()
-    {
-        $qb = $this->createGroupDatagridQueryBuilder();
-        $qb->andWhere($qb->expr()->in('p.id', ':productIds'));
-
-        return $qb;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function valueExists(ProductValueInterface $value)
@@ -283,19 +229,6 @@ class ProductRepository extends EntityRepository implements
     public function findOneByIdentifier($identifier)
     {
         return $this->findOneBy(['identifier' => $identifier]);
-    }
-
-    /**
-     * Add join to values tables
-     *
-     * @param QueryBuilder $qb
-     */
-    protected function addJoinToValueTables(QueryBuilder $qb)
-    {
-        $qb->leftJoin(current($qb->getRootAliases()).'.values', 'Value')
-            ->leftJoin('Value.attribute', 'Attribute')
-            ->leftJoin('Value.options', 'ValueOption')
-            ->leftJoin('ValueOption.optionValues', 'AttributeOptionValue');
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -207,7 +207,6 @@ services:
             - '@pim_catalog.normalizer.standard.variant_group'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.bulk_media_fetcher'
-            - '@pim_catalog.updater.variant_group'
 
     pim_connector.processor.normalization.family:
         class: '%pim_connector.processor.normalization.class%'

--- a/src/Pim/Bundle/DataGridBundle/Datasource/VariantGroupProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/VariantGroupProductDatasource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Bundle\DataGridBundle\Datasource;
+
+use Pim\Bundle\DataGridBundle\Datagrid\Configuration\Product\ContextConfigurator;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class VariantGroupProductDatasource extends ProductDatasource
+{
+    /**
+     * @param string $method the query builder creation method
+     * @param array  $config the query builder creation config
+     *
+     * @return Datasource
+     */
+    protected function initializeQueryBuilder($method, array $config = [])
+    {
+        $factoryConfig['repository_parameters'] = $config;
+        $factoryConfig['repository_method'] = $method;
+        $factoryConfig['default_locale'] = $this->getConfiguration('locale_code');
+        $factoryConfig['default_scope'] = $this->getConfiguration('scope_code');
+        $factoryConfig['limit'] = $this->getConfiguration(ContextConfigurator::PRODUCTS_PER_PAGE);
+        $factoryConfig['search_after'] =  $this->getConfiguration('search_after', false);
+
+        $this->pqb = $this->factory->create($factoryConfig);
+        $this->qb = $this->pqb->getQueryBuilder();
+
+        return $this;
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -1,6 +1,7 @@
 parameters:
     pim_datagrid.datasource.default.class: Pim\Bundle\DataGridBundle\Datasource\Datasource
     pim_datagrid.datasource.product.class: Pim\Bundle\DataGridBundle\Datasource\ProductDatasource
+    pim_datagrid.datasource.variant_group_product.class: Pim\Bundle\DataGridBundle\Datasource\VariantGroupProductDatasource
     pim_datagrid.datasource.family.class: Pim\Bundle\DataGridBundle\Datasource\FamilyDatasource
     pim_datagrid.datasource.repository.class: Pim\Bundle\DataGridBundle\Datasource\RepositoryDatasource
     pim_datagrid.datasource.support_resolver.class: Pim\Bundle\DataGridBundle\Datasource\DatasourceSupportResolver
@@ -143,6 +144,16 @@ services:
             - '@pim_datagrid.normalizer.group_product'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_group_product }
+
+    pim_datagrid.datasource.variant_group_product:
+        class: '%pim_datagrid.datasource.variant_group_product.class%'
+        arguments:
+            - '@pim_catalog.object_manager.product'
+            - '@pim_datagrid.datasource.result_record.hydrator.associated_product'
+            - '@pim_catalog.query.product_query_builder_bounded_factory'
+            - '@pim_datagrid.normalizer.group_product'
+        tags:
+            - { name: oro_datagrid.datasource, type: pim_datasource_variant_group_product }
 
     pim_datagrid.datasource.support_resolver:
         class: '%pim_datagrid.datasource.support_resolver.class%'

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -152,6 +152,7 @@ services:
             - '@pim_datagrid.datasource.result_record.hydrator.associated_product'
             - '@pim_catalog.query.product_query_builder_bounded_factory'
             - '@pim_datagrid.normalizer.group_product'
+            - '@pim_catalog.repository.group'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_variant_group_product }
 
@@ -173,3 +174,5 @@ services:
         calls:
             - [addProductDatasource, ['pim_datasource_product']]
             - [addProductDatasource, ['pim_datasource_associated_product']]
+            - [addProductDatasource, ['pim_datasource_group_product']]
+            - [addProductDatasource, ['pim_datasource_variant_group_product']]

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -134,7 +134,7 @@ services:
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_associated_product }
 
-    pim_datagrid.datasource.variant_group_product:
+    pim_datagrid.datasource.group_product:
         class: '%pim_datagrid.datasource.product.class%'
         arguments:
             - '@pim_catalog.object_manager.product'
@@ -142,7 +142,7 @@ services:
             - '@pim_catalog.query.product_query_builder_bounded_factory'
             - '@pim_datagrid.normalizer.group_product'
         tags:
-            - { name: oro_datagrid.datasource, type: pim_datasource_variant_group_product }
+            - { name: oro_datagrid.datasource, type: pim_datasource_group_product }
 
     pim_datagrid.datasource.support_resolver:
         class: '%pim_datagrid.datasource.support_resolver.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -8,7 +8,6 @@ datagrid:
             acl_resource:      pim_enrich_product_index
             type:              pim_datasource_product
             entity:            '%pim_catalog.entity.product.class%'
-            repository_method: createDatagridQueryBuilder
         columns:
             label:
                 label:         Label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -14,9 +14,6 @@ datagrid:
             acl_resource:      pim_enrich_product_index
             type:              pim_datasource_group_product
             entity:            '%pim_catalog.entity.product.class%'
-            repository_method: createGroupDatagridQueryBuilder
-            repository_parameters:
-                - currentGroup
         columns:
             is_checked:
                 frontend_type: boolean

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -12,10 +12,11 @@ datagrid:
                     excluded: '#removeProducts'
         source:
             acl_resource:      pim_enrich_product_index
-            type:              pim_datasource_product
+            type:              pim_datasource_group_product
             entity:            '%pim_catalog.entity.product.class%'
             repository_method: createGroupDatagridQueryBuilder
-            user_config_alias: product-grid
+            repository_parameters:
+                - currentGroup
         columns:
             is_checked:
                 frontend_type: boolean
@@ -23,42 +24,30 @@ datagrid:
                 editable:      true
             in_group:
                 label:         In group
-                data_name:     in_group
-                selector:      product_in_group
-                type:          twig
-                primary:       true
-                template:      PimDataGridBundle:Property:boolean.html.twig
-                frontend_type: html
+                frontend_type: boolean-label
             label:
                 label:         Label
-                data_name:     productLabel
-                selector:      product_label
+                data_name:     label
+                type:          field
             family:
                 label:         Family
-                data_name:     familyLabel
-                selector:      product_family
+                data_name:     family
+                type:          field
             enabled:
                 label:         Status
-                type:          twig
-                template:      PimDataGridBundle:Property:enabled.html.twig
-                frontend_type: html
+                frontend_type: enabled
             completeness:
                 label:         Complete
-                type:          twig
-                data_name:     ratio
-                template:      PimDataGridBundle:Property:completeness.html.twig
-                frontend_type: html
-                selector:      product_completeness
+                frontend_type: completeness
             created:
                 label:         Created At
-                type:          product_value_date
-                frontend_type: date
+                type:          field
             updated:
                 label:         Updated At
-                type:          product_value_date
-                frontend_type: date
+                type:          field
         properties:
             id: ~
+            identifier: ~
         sorters:
             columns:
                 in_group:
@@ -112,10 +101,10 @@ datagrid:
                     label:     Complete
                     data_name: ratio
                 created:
-                    type:       product_date
-                    ftype:      date
-                    data_name:  created
-                    label:      Created At
+                    type:      product_date
+                    ftype:     date
+                    data_name: created
+                    label:     Created At
                 updated:
                     type:      product_date
                     ftype:     date

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -12,7 +12,7 @@ datagrid:
                     excluded: '#removeProducts'
         source:
             acl_resource:      pim_enrich_product_index
-            type:              pim_datasource_variant_group_product
+            type:              pim_datasource_group_product
             entity:            '%pim_catalog.entity.product.class%'
             repository_method: createVariantGroupDatagridQueryBuilder
             repository_parameters:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -12,11 +12,8 @@ datagrid:
                     excluded: '#removeProducts'
         source:
             acl_resource:      pim_enrich_product_index
-            type:              pim_datasource_group_product
+            type:              pim_datasource_variant_group_product
             entity:            '%pim_catalog.entity.product.class%'
-            repository_method: createVariantGroupDatagridQueryBuilder
-            repository_parameters:
-                - currentGroup
         columns:
             is_checked:
                 frontend_type: boolean

--- a/src/Pim/Component/Catalog/Updater/GroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupUpdater.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\GroupInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\GroupTypeRepositoryInterface;
@@ -62,7 +63,7 @@ class GroupUpdater implements ObjectUpdaterInterface
         if (!$group instanceof GroupInterface) {
             throw InvalidObjectException::objectExpected(
                 ClassUtils::getClass($group),
-                'Pim\Component\Catalog\Model\GroupInterface'
+                GroupInterface::class
             );
         }
 
@@ -91,9 +92,6 @@ class GroupUpdater implements ObjectUpdaterInterface
                 break;
             case 'labels':
                 $this->setLabels($group, $data);
-                break;
-            case 'axis':
-                $this->setAxis($group, $data);
                 break;
             case 'products':
                 $this->setProducts($group, $data);
@@ -157,45 +155,20 @@ class GroupUpdater implements ObjectUpdaterInterface
 
     /**
      * @param GroupInterface $group
-     * @param string[]       $attributeCodes
-     *
-     * @throws InvalidPropertyException
+     * @param array          $productIdentifiers
      */
-    protected function setAxis(GroupInterface $group, array $attributeCodes)
-    {
-        $attributes = [];
-        foreach ($attributeCodes as $attributeCode) {
-            $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
-            if (null === $attribute) {
-                throw InvalidPropertyException::validEntityCodeExpected(
-                    'axis',
-                    'attribute code',
-                    'The attribute does not exist',
-                    static::class,
-                    $attributeCode
-                );
-            }
-            $attributes[] = $attribute;
-        }
-        $group->setAxisAttributes($attributes);
-    }
-
-    /**
-     * @param GroupInterface $group
-     * @param array          $productIds
-     */
-    protected function setProducts(GroupInterface $group, array $productIds)
+    protected function setProducts(GroupInterface $group, array $productIdentifiers)
     {
         foreach ($group->getProducts() as $product) {
             $group->removeProduct($product);
         }
 
-        if (empty($productIds)) {
+        if (empty($productIdentifiers)) {
             return;
         }
 
         $pqb = $this->productQueryBuilderFactory->create();
-        $pqb->addFilter('id', 'IN', $productIds);
+        $pqb->addFilter('identifier', Operators::IN_LIST, $productIdentifiers);
 
         $products = $pqb->execute();
 

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -66,7 +66,9 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             foreach ($variantGroup->getAxisAttributes() as $attribute) {
                 $code = $attribute->getCode();
                 $value = $product->getValue($code);
-                $option = $value instanceof OptionProductValueInterface && null !== $value->getData() ? $value->getData()->getCode() : null;
+                $option = $value instanceof OptionProductValueInterface && null !== $value->getData() ?
+                    $value->getData()->getCode() :
+                    null;
 
                 if (null === $option && !$attribute->isBackendTypeReferenceData()) {
                     $this->addEmptyAxisViolation(
@@ -105,7 +107,9 @@ class UniqueVariantAxisValidator extends ConstraintValidator
         if (count($matches) !== 0) {
             $values = [];
             foreach ($criteria as $item) {
-                $data = $item['attribute']->isBackendTypeReferenceData() ? $item['referenceData']['data'] : $item['option'];
+                $data = $item['attribute']->isBackendTypeReferenceData() ?
+                    $item['referenceData']['data'] :
+                    $item['option'];
                 $values[] = sprintf('%s: %s', $item['attribute']->getCode(), (string)$data);
             }
             $this->addExistingCombinationViolation($constraint, $group->getLabel(), implode(', ', $values));
@@ -132,7 +136,9 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             $isOption = $value instanceof OptionProductValueInterface;
 
             // we don't add criteria when option is null, as this check is performed by HasVariantAxesValidator
-            if (null === $value || (null === $value->getData() && $isOption && !$attribute->isBackendTypeReferenceData())) {
+            if (null === $value ||
+                (null === $value->getData() && $isOption && !$attribute->isBackendTypeReferenceData())
+            ) {
                 $this->addEmptyAxisViolation(
                     $constraint,
                     $variantGroup->getLabel(),

--- a/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
@@ -66,7 +66,7 @@ class GroupUpdaterSpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier('size')->willReturn($attributeSize);
 
         $pqbFactory->create()->willReturn($pqb);
-        $pqb->addFilter('id', 'IN', [2])->shouldBeCalled();
+        $pqb->addFilter('identifier', 'IN', ['foo'])->shouldBeCalled();
         $pqb->execute()->willReturn([$addedProduct]);
 
         $group->getTranslation()->willReturn($translatable);
@@ -74,7 +74,6 @@ class GroupUpdaterSpec extends ObjectBehavior
         $group->setCode('mycode')->shouldBeCalled();
         $group->setLocale('fr_FR')->shouldBeCalled();
         $group->setType($type)->shouldBeCalled();
-        $group->setAxisAttributes([$attributeColor, $attributeSize])->shouldBeCalled();
         $group->getId()->willReturn(null);
 
         $group->removeProduct($removedProduct)->shouldBeCalled();
@@ -87,8 +86,7 @@ class GroupUpdaterSpec extends ObjectBehavior
             'labels'   => [
                 'fr_FR' => 'T-shirt super beau',
             ],
-            'axis'     => ['color', 'size'],
-            'products' => [2]
+            'products' => ['foo']
         ];
 
         $this->update($group, $values, []);
@@ -133,28 +131,6 @@ class GroupUpdaterSpec extends ObjectBehavior
                 'Cannot process variant group, only groups are supported',
                 'Pim\Component\Catalog\Updater\GroupUpdater',
                 'mycode'
-            )
-        )->during('update', [$group, $values, []]);
-    }
-
-    function it_throws_an_exception_if_attribute_is_unknown($attributeRepository, GroupInterface $group)
-    {
-        $group->setCode('mycode')->shouldBeCalled();
-        $attributeRepository->findOneByIdentifier('foo')->willReturn(null);
-        $group->getId()->willReturn(null);
-
-        $values = [
-            'code' => 'mycode',
-            'axis' => ['foo']
-        ];
-
-        $this->shouldThrow(
-            InvalidPropertyException::validEntityCodeExpected(
-                'axis',
-                'attribute code',
-                'The attribute does not exist',
-                'Pim\Component\Catalog\Updater\GroupUpdater',
-                'foo'
             )
         )->during('update', [$group, $values, []]);
     }

--- a/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
@@ -36,25 +36,19 @@ class VariantGroupProcessor implements ItemProcessorInterface, StepExecutionAwar
     /** @var BulkMediaFetcher */
     protected $mediaFetcher;
 
-    /** @var ObjectUpdaterInterface */
-    protected $variantGroupUpdater;
-
     /**
      * @param NormalizerInterface     $normalizer
      * @param ObjectDetacherInterface $objectDetacher
      * @param BulkMediaFetcher        $mediaFetcher
-     * @param ObjectUpdaterInterface  $variantGroupUpdater
      */
     public function __construct(
         NormalizerInterface $normalizer,
         ObjectDetacherInterface $objectDetacher,
-        BulkMediaFetcher $mediaFetcher,
-        ObjectUpdaterInterface $variantGroupUpdater
+        BulkMediaFetcher $mediaFetcher
     ) {
         $this->normalizer = $normalizer;
         $this->objectDetacher = $objectDetacher;
         $this->mediaFetcher = $mediaFetcher;
-        $this->variantGroupUpdater = $variantGroupUpdater;
     }
 
     /**
@@ -102,7 +96,6 @@ class VariantGroupProcessor implements ItemProcessorInterface, StepExecutionAwar
         }
 
         $identifier = $variantGroup->getCode();
-        $this->variantGroupUpdater->update($variantGroup, ['values' => $productTemplate->getValuesData()]);
 
         $this->mediaFetcher->fetchAll($productTemplate->getValues(), $directory, $identifier);
 

--- a/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
@@ -8,7 +8,6 @@ use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Connector\Processor\BulkMediaFetcher;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/VariantGroupProcessorSpec.php
@@ -29,10 +29,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         NormalizerInterface $normalizer,
         ObjectDetacherInterface $objectDetacher,
         BulkMediaFetcher $mediaFetcher,
-        ObjectUpdaterInterface $variantGroupUpdater,
         StepExecution $stepExecution
     ) {
-        $this->beConstructedWith($normalizer, $objectDetacher, $mediaFetcher, $variantGroupUpdater);
+        $this->beConstructedWith($normalizer, $objectDetacher, $mediaFetcher);
         $this->setStepExecution($stepExecution);
     }
 
@@ -50,7 +49,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $objectDetacher,
         $normalizer,
         $stepExecution,
-        $variantGroupUpdater,
         $mediaFetcher,
         AttributeInterface $color,
         AttributeInterface $weight,
@@ -86,7 +84,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
             ]
         )->willReturn($variantStandard);
 
-        $variantGroupUpdater->update($variantGroup, Argument::any())->shouldNotBeCalled();
         $mediaFetcher->fetchAll(Argument::any())->shouldNotBeCalled();
 
         $this->process($variantGroup)->shouldReturn($variantStandard);
@@ -97,7 +94,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
     function it_processes_variant_group_without_media(
         $objectDetacher,
         $normalizer,
-        $variantGroupUpdater,
         $stepExecution,
         $mediaFetcher,
         ProductValueCollectionInterface $emptyCollection,
@@ -154,8 +150,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $mediaFetcher->fetchAll($emptyCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn([]);
 
-        $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
-
         $this->process($variantGroup)->shouldReturn($variantStandard);
 
         $objectDetacher->detach($variantGroup)->shouldBeCalled();
@@ -166,7 +160,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $normalizer,
         $mediaFetcher,
         $stepExecution,
-        $variantGroupUpdater,
         ProductValueCollectionInterface $productValueCollection,
         FileInfoInterface $media1,
         FileInfoInterface $media2,
@@ -226,7 +219,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
             ]
         )->willReturn($variantStandard);
 
-        $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
         $productTemplate->getValuesData()->willReturn($variantStandard['values']);
         $productTemplate->getValues()->willReturn($productValueCollection);
         $mediaFetcher->fetchAll($productValueCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();
@@ -242,7 +234,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $normalizer,
         $mediaFetcher,
         $stepExecution,
-        $variantGroupUpdater,
         ProductValueCollectionInterface $productValueCollection,
         FileInfoInterface $media1,
         FileInfoInterface $media2,
@@ -297,7 +288,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
             ]
         )->willReturn($variantStandard);
 
-        $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
         $productTemplate->getValuesData()->willReturn($variantStandard['values']);
         $productTemplate->getValues()->willReturn($productValueCollection);
         $mediaFetcher->fetchAll($productValueCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();


### PR DESCRIPTION
## Description

This PR fixes:
- [x] a wrong history in `features/enrich/variant-group/add_products/add_products_history_updated_without_context.feature:33`
- [x] the group product datagrid: display the grid, add and remove products (affects the variant group product datagrid too!)
- [x] the export of variant groups when containing scopable and/or localizable template values
- [x] clean some useless methods from the ProductRepository
- [x] filter correctly products on variant group product grid.

Regarding this last point, scenarios `features/enrich/variant-group/edit_variant_browse_products.feature:43` and `features/enrich/variant-group/edit_variant_browse_products.feature:52` are still failing because the "in_group" column does not work at the moment (it will be fix in another PR) but they are OK regarding product displayed in the datagrid.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
