### PR TITLE
TIP-713: Fix "In Group" sorter

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/GroupColumnsConfigurator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/GroupColumnsConfigurator.php
@@ -122,7 +122,13 @@ class GroupColumnsConfigurator extends ColumnsConfigurator
      */
     protected function sortColumns()
     {
-        $this->displayedColumns = $this->editableColumns + $this->primaryColumns + $this->identifierColumn
-            + $this->axisColumns + $this->propertiesColumns;
+        $inGroupColumn = [];
+        if (isset($this->propertiesColumns['in_group'])) {
+            $inGroupColumn['in_group'] = $this->propertiesColumns['in_group'];
+            unset($this->propertiesColumns['in_group']);
+        }
+
+        $this->displayedColumns = $this->editableColumns + $inGroupColumn + $this->primaryColumns
+            + $this->identifierColumn + $this->axisColumns + $this->propertiesColumns;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/Sorter/InGroupSorter.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/Sorter/InGroupSorter.php
@@ -63,7 +63,7 @@ class InGroupSorter extends BaseFieldSorter implements FieldSorterInterface
                 $sortClause = [
                     $field => [
                         'order'   => 'ASC',
-                        'missing' => '_last',
+                        'missing' => '_first',
                         'unmapped_type'=> 'boolean',
                     ],
                 ];

--- a/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/integration/PQB/Sorter/InGroupSorterIntegration.php
@@ -21,7 +21,7 @@ class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
     public function testSortAscendant()
     {
         $result = $this->executeSorter([['in_group_4', Directions::ASCENDING]]);
-        $this->assertOrder($result, ['foo', 'bar', 'baz', 'empty']);
+        $this->assertOrder($result, ['baz', 'empty', 'foo', 'bar']);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/Sorter/InGroupSorterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/Sorter/InGroupSorterSpec.php
@@ -52,7 +52,7 @@ class InGroupSorterSpec extends ObjectBehavior
             [
                 'in_group.group_code' => [
                     'order'   => 'ASC',
-                    'missing' => '_last',
+                    'missing' => '_first',
                     'unmapped_type'=> 'boolean',
                 ],
             ]


### PR DESCRIPTION
## Description

This PR:
- [x] fixes the elasticsearch "In Group" sorter,
- [x] fixes the position of the "In Group" column in the group and variant group product datagrids (should be second, next to the checkboxes).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
