### PR TITLE
TIP-713: Fix variant group imports

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1318,7 +1318,7 @@ class FixturesContext extends BaseFixturesContext
      *
      * @throws \InvalidArgumentException
      *
-     * @return \Pim\Component\Catalog\Model\ProductInterface
+     * @return ProductInterface
      */
     public function getProduct($sku)
     {

--- a/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
@@ -51,9 +51,9 @@ Feature: Execute an import with valid data
     And I should see "read lines 1"
     And I should see "Processed 1"
     And I should see "Updated products 6"
-    And the english tablet name of "sandal-white-37" should be "My sandal"
+    And the english localizable value name of "sandal-white-37" should be "My sandal"
     And the english tablet description of "sandal-white-37" should be "My sandal description for locale en_US and channel tablet"
-    And the english tablet name of "sandal-white-38" should be "My sandal"
+    And the english localizable value name of "sandal-white-38" should be "My sandal"
     And the english tablet description of "sandal-white-38" should be "My sandal description for locale en_US and channel tablet"
 
   Scenario: Successfully import a csv file of variant group values with numbers

--- a/src/Pim/Component/Catalog/ProductValue/OptionsProductValue.php
+++ b/src/Pim/Component/Catalog/ProductValue/OptionsProductValue.php
@@ -73,6 +73,12 @@ class OptionsProductValue extends AbstractProductValue implements OptionsProduct
      */
     public function __toString()
     {
-        return implode(', ', $this->getOptionCodes());
+        $optionValues = [];
+        foreach ($this->data as $option) {
+            $optionValue = $option->getOptionValue();
+            $optionValues[] = null !== $optionValue ? $optionValue->getValue() : '['.$option->getCode().']';
+        }
+
+        return implode(', ', $optionValues);
     }
 }

--- a/src/Pim/Component/Catalog/spec/ProductValue/OptionsProductValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductValue/OptionsProductValueSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\ProductValue;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 
 class OptionsProductValueSpec extends ObjectBehavior
 {
@@ -32,5 +33,33 @@ class OptionsProductValueSpec extends ObjectBehavior
         $optionA->getCode()->willReturn('option_a');
         $optionB->getCode()->willReturn('option_b');
         $this->getOptionCodes()->shouldReturn(['option_a', 'option_b']);
+    }
+
+    function it_can_be_formatted_as_string_when_there_is_no_translation($optionA, $optionB)
+    {
+        $optionA->getOptionValue()->willReturn(null);
+        $optionA->getCode()->willReturn('option_a');
+
+        $optionB->getOptionValue()->willReturn(null);
+        $optionB->getCode()->willReturn('option_b');
+
+        $this->__toString()->shouldReturn('[option_a], [option_b]');
+    }
+
+    function it_can_be_formatted_as_string_when_there_is_a_translation(
+        $optionA,
+        $optionB,
+        AttributeOptionValueInterface $translationA,
+        AttributeOptionValueInterface $translationB
+    ) {
+        $optionA->getOptionValue()->willReturn($translationA);
+        $translationA->getValue()->willReturn('Translation A');
+        $optionA->getCode()->shouldNotBeCalled();
+
+        $optionB->getOptionValue()->willReturn($translationB);
+        $translationB->getValue()->willReturn('Translation B');
+        $optionB->getCode()->shouldNotBeCalled();
+
+        $this->__toString()->shouldReturn('Translation A, Translation B');
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantGroupValuesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantGroupValuesValidatorSpec.php
@@ -7,6 +7,7 @@ use Pim\Bundle\CatalogBundle\Entity\GroupType;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
+use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Validator\Constraints\VariantGroupValues;
 use Prophecy\Argument;
@@ -47,13 +48,14 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
     }
 
     function it_does_not_add_violations_if_variant_group_template_does_not_contain_axis_or_unique_attributes(
+        $attributeRepository,
+        $context,
         GroupInterface $variantGroup,
         GroupType $type,
         ProductTemplateInterface $template,
         Constraint $constraint,
-        $attributeRepository,
         AttributeInterface $axisAttribute,
-        $context
+        ProductValueCollectionInterface $productValueCollection
     ) {
         $variantGroup->getType()->willReturn($type);
         $type->isVariant()->willReturn(true);
@@ -62,7 +64,8 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
         $variantGroup->getAxisAttributes()->willReturn([$axisAttribute]);
         $attributeRepository->findUniqueAttributeCodes()->willReturn(['sku', 'barcode']);
 
-        $template->getValuesData()->willReturn([]);
+        $template->getValues()->willReturn($productValueCollection);
+        $productValueCollection->getAttributesKeys()->willReturn([]);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
@@ -70,14 +73,15 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
     }
 
     function it_adds_a_violation_if_variant_group_template_contains_an_axis_attribute(
+        $attributeRepository,
+        $context,
         GroupInterface $variantGroup,
         GroupType $type,
         ProductTemplateInterface $template,
         VariantGroupValues $constraint,
-        $attributeRepository,
         AttributeInterface $axisAttribute,
-        $context,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violation,
+        ProductValueCollectionInterface $productValueCollection
     ) {
         $variantGroup->getType()->willReturn($type);
         $variantGroup->getCode()->willReturn('tshirt');
@@ -88,7 +92,8 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
         $axisAttribute->getCode()->willReturn('size');
         $attributeRepository->findUniqueAttributeCodes()->willReturn(['sku', 'barcode']);
 
-        $template->getValuesData()->willReturn(['size' => 'M']);
+        $template->getValues()->willReturn($productValueCollection);
+        $productValueCollection->getAttributesKeys()->willReturn(['size']);
 
         $violationData = [
             '%group%'      => 'tshirt',
@@ -102,13 +107,14 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
     }
 
     function it_adds_a_violation_if_variant_group_template_contains_a_unique_attribute(
+        $attributeRepository,
+        $context,
         GroupInterface $variantGroup,
         GroupType $type,
         ProductTemplateInterface $template,
         VariantGroupValues $constraint,
-        $attributeRepository,
-        $context,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violation,
+        ProductValueCollectionInterface $productValueCollection
     ) {
         $variantGroup->getType()->willReturn($type);
         $variantGroup->getCode()->willReturn('tshirt');
@@ -118,7 +124,8 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
         $variantGroup->getAxisAttributes()->willReturn([]);
         $attributeRepository->findUniqueAttributeCodes()->willReturn(['sku', 'barcode']);
 
-        $template->getValuesData()->willReturn(['sku' => 'SKU-001']);
+        $template->getValues()->willReturn($productValueCollection);
+        $productValueCollection->getAttributesKeys()->willReturn(['sku']);
 
         $violationData = [
             '%group%'      => 'tshirt',
@@ -130,7 +137,8 @@ class VariantGroupValuesValidatorSpec extends ObjectBehavior
 
         $this->validate($variantGroup, $constraint);
 
-        $template->getValuesData()->willReturn(['sku' => 'SKU-001', 'barcode' => 001122334455]);
+        $template->getValues()->willReturn($productValueCollection);
+        $productValueCollection->getAttributesKeys()->willReturn(['sku', 'barcode']);
 
         $violationData = [
             '%group%'      => 'tshirt',


### PR DESCRIPTION
## Description

This PR fixes all variant group import scenarios remaining by:
- [x] fixing the `VariantGroupValuesValidator`, responsible to prevent the import of axes values,
- [x] fixing the `__toString` method of the OptionsProductValue, so translated values are returned, and `[code]` if no translations (like for the OptionProductValue).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
