### PR TITLE
TIP-713: Allow sorting on SKU in product grids

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/SortersConfigurator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/SortersConfigurator.php
@@ -7,6 +7,7 @@ use Oro\Bundle\DataGridBundle\Extension\Formatter\Configuration as FormatterConf
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Property\PropertyInterface;
 use Oro\Bundle\DataGridBundle\Extension\Sorter\Configuration as OrmSorterConfiguration;
 use Pim\Bundle\DataGridBundle\Datagrid\Configuration\ConfiguratorInterface;
+use Pim\Component\Catalog\AttributeTypes;
 
 /**
  * Sorters configurator for product grid
@@ -53,6 +54,10 @@ class SortersConfigurator implements ConfiguratorInterface
             sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY)
         );
         foreach ($attributes as $attributeCode => $attribute) {
+            if (AttributeTypes::IDENTIFIER === $attribute['type']) {
+                $attributeCode = 'identifier';
+            }
+
             $attributeType = $attribute['type'];
             $attributeTypeConf = $this->registry->getConfiguration($attributeType);
             $columnExists = isset($columns[$attributeCode]);

--- a/src/Pim/Bundle/DataGridBundle/spec/Datagrid/Configuration/Product/SortersConfiguratorSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datagrid/Configuration/Product/SortersConfiguratorSpec.php
@@ -31,7 +31,7 @@ class SortersConfiguratorSpec extends ObjectBehavior
 
         $configuration
             ->offsetGetByPath(sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY))
-            ->willReturn(['family' => ['family_config'], 'sku' => [], 'name' => []]);
+            ->willReturn(['family' => ['family_config'], 'identifier' => [], 'name' => []]);
 
         $registry
             ->getConfiguration('pim_catalog_identifier')
@@ -51,7 +51,7 @@ class SortersConfiguratorSpec extends ObjectBehavior
             ->getConfiguration('pim_catalog_text')
             ->willReturn(['column' => ['text_config'], 'sorter' => 'flexible_field']);
 
-        $columnConfPath = sprintf('%s[%s]', OrmSorterConfiguration::COLUMNS_PATH, 'sku');
+        $columnConfPath = sprintf('%s[%s]', OrmSorterConfiguration::COLUMNS_PATH, 'identifier');
         $configuration->offsetSetByPath($columnConfPath, Argument::any())->shouldBeCalled();
 
         $columnConfPath = sprintf('%s[%s]', OrmSorterConfiguration::COLUMNS_PATH, 'name');
@@ -67,7 +67,7 @@ class SortersConfiguratorSpec extends ObjectBehavior
     {
         $registry->getConfiguration('pim_catalog_text')->willReturn([]);
 
-        $columnConfPath = sprintf('%s[%s]', OrmSorterConfiguration::COLUMNS_PATH, 'sku');
+        $columnConfPath = sprintf('%s[%s]', OrmSorterConfiguration::COLUMNS_PATH, 'identifier');
         $configuration->offsetSetByPath($columnConfPath, Argument::any())->shouldBeCalled();
 
         $this->shouldThrow('\LogicException')->duringConfigure($configuration);


### PR DESCRIPTION
## Description

Datagrid column for SKU uses the field "identifier" of the product, when the datagrid sorter configuration tried to use the identifier attribute. This PR replace fixes the SorterConfigurator, making it use the product identifier.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
