### PR TITLE
TIP-713: Fix datagrid sorters

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -46,6 +46,7 @@
 - Change the constructor of `Pim\Component\Catalog\Updater\VariantGroupUpdater` to replace `Pim\Component\Catalog\BuilderProductBuilderInterface` and `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
     by `Pim\Component\Catalog\Factory\ProductValueFactory`, `Akeneo\Component\FileStorage\Repository\FileInfoRepositoryInterface` and `Akeneo\Component\FileStorage\File\FileStorerInterface`
 - Change the constructor of `Pim\Component\Connector\Processor\Normalization\VariantGroupProcessor` to remove `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
+- Change the constructor of `Pim\Bundle\DataGridBundle\Extension\Sorter\Product\ValueSorter` to add `Pim\Component\Catalog\Repository\AttributeRepositoryInterface`
 
 ### Others
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -565,11 +565,15 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
         foreach ($columns as $column) {
             $steps[] = new Step\Then(sprintf('I sort by "%s" value ascending', $column));
             $steps[] = new Step\Then(sprintf(
-                'the rows should be%s sorted ascending by %s', $naturally ? ' naturally' : '', $column
+                'the rows should be%s sorted ascending by %s',
+                $naturally ? ' naturally' : '',
+                $column
             ));
             $steps[] = new Step\Then(sprintf('I sort by "%s" value descending', $column));
             $steps[] = new Step\Then(sprintf(
-                'the rows should be%s sorted descending by %s', $naturally ? ' naturally' : '', $column
+                'the rows should be%s sorted descending by %s',
+                $naturally ? ' naturally' : '',
+                $column
             ));
         }
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -438,7 +438,8 @@ class Grid extends Index
         foreach ($rows as $row) {
             $cell = $this->getRowCell($row, $position);
             if ($span = $cell->find('css', 'span')) {
-                $values[] = (string) (strpos($span->getAttribute('class'), 'success') !== false);
+                $value = strpos($span->getAttribute('class'), 'success') !== false;
+                $values[] = true === $value ? '1' : '0';
             } else {
                 $values[] = $cell->getText();
             }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/sorters.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/sorters.yml
@@ -20,6 +20,8 @@ services:
 
     pim_datagrid.extension.sorter.product.value_sorter:
         class: '%pim_datagrid.extension.sorter.product.value_sorter.class%'
+        arguments:
+            - '@pim_catalog.repository.attribute'
         tags:
             - { name: pim_datagrid.extension.sorter, type: product_value }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/Sorter/Product/ValueSorterSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/Sorter/Product/ValueSorterSpec.php
@@ -3,22 +3,35 @@
 namespace spec\Pim\Bundle\DataGridBundle\Extension\Sorter\Product;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 class ValueSorterSpec extends ObjectBehavior
 {
+    function let(AttributeRepositoryInterface $attributeRepository)
+    {
+        $this->beConstructedWith($attributeRepository);
+    }
+
     function it_is_a_sorter()
     {
         $this->shouldImplement('Pim\Bundle\DataGridBundle\Extension\Sorter\SorterInterface');
     }
 
     function it_applies_a_sort_on_product_sku(
+        $attributeRepository,
         ProductDatasource $datasource,
-        ProductQueryBuilderInterface $pqb
+        ProductQueryBuilderInterface $pqb,
+        AttributeInterface $attribute
     ) {
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($attribute);
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+
         $datasource->getProductQueryBuilder()->willReturn($pqb);
-        $pqb->addSorter('sku', 'ASC')->shouldBeCalled();
+        $pqb->addSorter('sku', 'ASC', ['scope' => null, 'locale' => null])->shouldBeCalled();
 
         $this->apply($datasource, 'sku', 'ASC');
     }


### PR DESCRIPTION
## What does this PR fix?

### The datagrid value sorter

We recently made the PQB stronger, which is a good thing, by harmonizing its behavior between every filters and sorters. For instance, we now always check that scope and channel are valid for the provided attribute: https://github.com/jjanvier/pim-community-dev/blob/TIP-613-unified/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attribute/AbstractAttributeSorter.php#L52, which is a very good thing.

Problem is, until now, the datagrid did not pass any context (locale and scop) to the PQB, resulting in an error when sorting on attribute non scopable and/or non localizable.

This is fixed by adding this context if needed: scope and/or locale are set to `null` if attribute is non scopable and/or non localizable, respectively.

### Behat DatagridContext

Tests failed when sorting boolean values in the datagrid, as in the behat method, values were converted to strings: `true` became `"1"`, and `false` bacame `""`, which didn't work. Now, `false` is converted to `"0"`, and behats work.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
