### PR TITLE
TIP-684: handle deleted options and invalid attributes

### DIFF
--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -17,12 +17,14 @@ monolog:
     handlers:
         main:
             type:         fingers_crossed
-            action_level: error
+            action_level: warning
             handler:      nested
         nested:
-            type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
-            level: debug
+            type: stream
+            path: %kernel.logs_dir%/%kernel.environment%.log
+            level: info
+        console:
+            type:  console
 
 swiftmailer:
     disable_delivery: true

--- a/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
@@ -49,7 +49,7 @@ class ImmutablePropertyException extends PropertyException
      */
     public static function immutableProperty($propertyName, $propertyValue, $className)
     {
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -39,7 +39,7 @@ class InvalidObjectException extends \LogicException
      */
     public static function objectExpected($objectClassName, $expectedClassName)
     {
-        return new self(
+        return new static(
             $objectClassName,
             $expectedClassName,
             sprintf(

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -63,7 +63,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" does not expect an empty value.';
 
-        return new self(
+        return new static(
             $propertyName,
             null,
             $className,
@@ -87,7 +87,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects a valid %s. %s, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -110,7 +110,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects a string with the format "%s" as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -133,7 +133,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects a valid group type. %s, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -156,7 +156,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects a valid group. %s, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -178,7 +178,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects %s.';
 
-        return new self(
+        return new static(
             $propertyName,
             null,
             $className,
@@ -200,7 +200,7 @@ class InvalidPropertyException extends PropertyException
     {
         $message = 'Property "%s" expects a valid pathname as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -220,7 +220,7 @@ class InvalidPropertyException extends PropertyException
      */
     public static function expectedFromPreviousException($propertyName, $className, \Exception $exception)
     {
-        return new self(
+        return new static(
             $propertyName,
             null,
             $className,

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -67,7 +67,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects a scalar as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -89,7 +89,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects a boolean as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -111,7 +111,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects a float as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -133,7 +133,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects an integer as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -155,7 +155,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects a numeric as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -177,7 +177,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects a string as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -199,7 +199,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects an array as data, "%s" given.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -223,7 +223,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects an array with valid data, %s.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -245,7 +245,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects an array of arrays as data.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,
@@ -268,7 +268,7 @@ class InvalidPropertyTypeException extends PropertyException
     {
         $message = 'Property "%s" expects an array with the key "%s" as data.';
 
-        return new self(
+        return new static(
             $propertyName,
             $propertyValue,
             $className,

--- a/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
@@ -31,7 +31,7 @@ class UnknownPropertyException extends PropertyException
      */
     public static function unknownProperty($propertyName, \Exception $previous = null)
     {
-        return new self(
+        return new static(
             $propertyName,
             sprintf(
                 'Property "%s" does not exist.',

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -121,6 +121,7 @@ services:
         arguments:
             - '@pim_catalog.factory.product_value'
             - '@pim_catalog.repository.cached_attribute'
+            - '@logger'
 
     pim_catalog.factory.product_value:
         class: '%pim_catalog.factory.product_value.class%'

--- a/src/Pim/Component/Catalog/Exception/InvalidAttributeException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidAttributeException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pim\Component\Catalog\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+
+/**
+ * Exception thrown when performing an action on a property with invalid attribute.
+ *
+ * @author    Julien Janvier <julien.jjanvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidAttributeException extends InvalidPropertyException
+{
+}

--- a/src/Pim/Component/Catalog/Exception/InvalidOptionException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidOptionException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pim\Component\Catalog\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+
+/**
+ * Exception thrown when performing an action on a property with invalid option.
+ *
+ * @author    Julien Janvier <julien.jjanvier@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidOptionException extends InvalidPropertyException
+{
+}

--- a/src/Pim/Component/Catalog/Factory/ProductValue/OptionProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValue/OptionProductValueFactory.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Catalog\Factory\ProductValue;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
@@ -96,7 +97,7 @@ class OptionProductValueFactory implements ProductValueFactoryInterface
      * @param AttributeInterface $attribute
      * @param string|null        $optionCode
      *
-     * @throws InvalidPropertyException
+     * @throws InvalidOptionException
      * @return AttributeOptionInterface|null
      */
     protected function getOption(AttributeInterface $attribute, $optionCode)
@@ -109,7 +110,7 @@ class OptionProductValueFactory implements ProductValueFactoryInterface
         $option = $this->attrOptionRepository->findOneByIdentifier($identifier);
 
         if (null === $option) {
-            throw InvalidPropertyException::validEntityCodeExpected(
+            throw InvalidOptionException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'code',
                 'The option does not exist',

--- a/src/Pim/Component/Catalog/Factory/ProductValue/OptionsProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValue/OptionsProductValueFactory.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Factory\ProductValue;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
@@ -133,7 +133,7 @@ class OptionsProductValueFactory implements ProductValueFactoryInterface
      * @param AttributeInterface $attribute
      * @param string             $optionCode
      *
-     * @throws InvalidPropertyException
+     * @throws InvalidOptionException
      * @return AttributeOptionInterface|null
      */
     protected function getOption(AttributeInterface $attribute, $optionCode)
@@ -142,7 +142,7 @@ class OptionsProductValueFactory implements ProductValueFactoryInterface
         $option = $this->attrOptionRepository->findOneByIdentifier($identifier);
 
         if (null === $option) {
-            throw InvalidPropertyException::validEntityCodeExpected(
+            throw InvalidOptionException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'code',
                 'The option does not exist',

--- a/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
+use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
@@ -77,6 +78,14 @@ class ProductValueCollectionFactory
                                 sprintf(
                                     'Tried to load a product value with the option "%s" that does not exist.',
                                     $e->getPropertyValue()
+                                )
+                            );
+                        } catch (InvalidAttributeException $e) {
+                            $this->logger->warning(
+                                sprintf(
+                                    'Tried to load a product value with an invalid attribute "%s". %s',
+                                    $attributeCode,
+                                    $e->getMessage()
                                 )
                             );
                         }

--- a/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
@@ -3,8 +3,10 @@
 namespace Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Create a product value collection.
@@ -21,14 +23,22 @@ class ProductValueCollectionFactory
     /** @var CachedObjectRepositoryInterface */
     private $attributeRepository;
 
+    /** @var LoggerInterface */
+    private $logger;
+
     /**
      * @param ProductValueFactory             $valueFactory
      * @param CachedObjectRepositoryInterface $attributeRepository
+     * @param LoggerInterface                 $logger
      */
-    public function __construct(ProductValueFactory $valueFactory, CachedObjectRepositoryInterface $attributeRepository)
-    {
+    public function __construct(
+        ProductValueFactory $valueFactory,
+        CachedObjectRepositoryInterface $attributeRepository,
+        LoggerInterface $logger
+    ) {
         $this->valueFactory = $valueFactory;
         $this->attributeRepository = $attributeRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -60,9 +70,25 @@ class ProductValueCollectionFactory
                             $localeCode = null;
                         }
 
-                        $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data);
+                        try {
+                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data);
+                        } catch (InvalidOptionException $e) {
+                            $this->logger->warning(
+                                sprintf(
+                                    'Tried to load a product value with the option "%s" that does not exist.',
+                                    $e->getPropertyValue()
+                                )
+                            );
+                        }
                     }
                 }
+            } else {
+                $this->logger->warning(
+                    sprintf(
+                        'Tried to load a product value with the attribute "%s" that does not exist.',
+                        $attributeCode
+                    )
+                );
             }
         }
 

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Factory;
 
+use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Factory\ProductValue\ProductValueFactoryInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
@@ -52,8 +53,12 @@ class ProductValueFactory
      */
     public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
     {
-        $this->attributeValidatorHelper->validateScope($attribute, $channelCode);
-        $this->attributeValidatorHelper->validateLocale($attribute, $localeCode);
+        try {
+            $this->attributeValidatorHelper->validateScope($attribute, $channelCode);
+            $this->attributeValidatorHelper->validateLocale($attribute, $localeCode);
+        } catch (\LogicException $e) {
+            throw InvalidAttributeException::expectedFromPreviousException('attribute', self::class, $e);
+        }
 
         $factory = $this->getFactory($attribute->getType());
         $value = $factory->create($attribute, $channelCode, $localeCode, $data);

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Factory\ProductValueCollectionFactory;
 use Pim\Component\Catalog\Factory\ProductValueFactory;
@@ -141,6 +142,35 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
         );
         
         $logger->warning('Tried to load a product value with the option "color.red" that does not exist.');
+
+        $actualValues = $this->createFromStorageFormat([
+            'color' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'red'
+                ],
+            ],
+        ]);
+
+        $actualValues->shouldReturnAnInstanceOf(ProductValueCollection::class);
+        $actualValues->shouldHaveCount(0);
+    }
+
+    function it_skips_invalid_attributes_when_creating_a_values_collection_from_the_storage_format(
+        $valueFactory,
+        $attributeRepository,
+        $logger,
+        AttributeInterface $color
+    ) {
+        $color->getCode()->willReturn('color');
+        $color->isUnique()->willReturn(false);
+        $color->isLocalizable()->willReturn(true);
+
+        $attributeRepository->findOneByIdentifier('color')->willReturn($color);
+        $valueFactory->create($color, null, null, 'red')->willThrow(
+            new InvalidAttributeException('attribute', 'color', static::class)
+        );
+
+        $logger->warning(Argument::containingString('Tried to load a product value with an invalid attribute "color".'));
 
         $actualValues = $this->createFromStorageFormat([
             'color' => [

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValueCollectionFactorySpec.php
@@ -4,17 +4,23 @@ namespace spec\Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Factory\ProductValueCollectionFactory;
 use Pim\Component\Catalog\Factory\ProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Model\ProductValueInterface;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 class ProductValueCollectionFactorySpec extends ObjectBehavior
 {
-    function let(ProductValueFactory $valueFactory, CachedObjectRepositoryInterface $attributeRepository)
-    {
-        $this->beConstructedWith($valueFactory, $attributeRepository);
+    function let(
+        ProductValueFactory $valueFactory,
+        CachedObjectRepositoryInterface $attributeRepository,
+        LoggerInterface $logger
+    ) {
+        $this->beConstructedWith($valueFactory, $attributeRepository, $logger);
     }
 
     function it_is_initializable()
@@ -32,10 +38,10 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
         ProductValueInterface $value3,
         ProductValueInterface $value4
     ) {
-        $sku->getCode()->wilLReturn('sku');
-        $sku->isUnique()->wilLReturn(false);
-        $description->getCode()->wilLReturn('description');
-        $description->isUnique()->wilLReturn(false);
+        $sku->getCode()->willReturn('sku');
+        $sku->isUnique()->willReturn(false);
+        $description->getCode()->willReturn('description');
+        $description->isUnique()->willReturn(false);
 
         $value1->getLocale()->willReturn(null);
         $value1->getScope()->willReturn(null);
@@ -52,7 +58,6 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
 
         $attributeRepository->findOneByIdentifier('sku')->willReturn($sku);
         $attributeRepository->findOneByIdentifier('description')->willReturn($description);
-        $attributeRepository->findOneByIdentifier('attribute_that_does_not_exists')->willReturn(null);
 
         $valueFactory->create($sku, null, null, 'foo')->willReturn($value1);
         $valueFactory
@@ -81,11 +86,6 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
 
                 ],
             ],
-            'attribute_that_does_not_exists' => [
-                '<all_channels>' => [
-                    '<all_locales>' => 'bar'
-                ],
-            ],
         ]);
 
         $actualValues->shouldReturnAnInstanceOf(ProductValueCollection::class);
@@ -96,5 +96,61 @@ class ProductValueCollectionFactorySpec extends ObjectBehavior
         $actualIterator->shouldHaveKeyWithValue('description-ecommerce-en_US', $value2);
         $actualIterator->shouldHaveKeyWithValue('description-tablet-en_US', $value3);
         $actualIterator->shouldHaveKeyWithValue('description-tablet-fr_FR', $value4);
+    }
+
+    function it_skips_unknown_attributes_when_creating_a_values_collection_from_the_storage_format(
+        $valueFactory,
+        $attributeRepository,
+        $logger
+    ) {
+        $attributeRepository->findOneByIdentifier('attribute_that_does_not_exists')->willReturn(null);
+
+        $valueFactory->create(Argument::cetera())->shouldNotBeCalled();
+        $logger->warning('Tried to load a product value with the attribute "attribute_that_does_not_exists" that does not exist.');
+
+        $actualValues = $this->createFromStorageFormat([
+            'attribute_that_does_not_exists' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'bar'
+                ]
+            ]
+        ]);
+
+        $actualValues->shouldReturnAnInstanceOf(ProductValueCollection::class);
+        $actualValues->shouldHaveCount(0);
+    }
+
+    function it_skips_unknown_options_when_creating_a_values_collection_from_the_storage_format(
+        $valueFactory,
+        $attributeRepository,
+        $logger,
+        AttributeInterface $color
+    ) {
+        $color->getCode()->willReturn('color');
+        $color->isUnique()->willReturn(false);
+
+        $attributeRepository->findOneByIdentifier('color')->willReturn($color);
+        $valueFactory->create($color, null, null, 'red')->willThrow(
+            InvalidOptionException::validEntityCodeExpected(
+                'color',
+                'code',
+                'The option does not exist',
+                static::class,
+                'red'
+            )
+        );
+        
+        $logger->warning('Tried to load a product value with the option "color.red" that does not exist.');
+
+        $actualValues = $this->createFromStorageFormat([
+            'color' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'red'
+                ],
+            ],
+        ]);
+
+        $actualValues->shouldReturnAnInstanceOf(ProductValueCollection::class);
+        $actualValues->shouldHaveCount(0);
     }
 }


### PR DESCRIPTION
## Current behavior

In EAV, when an option (or an attribute) is deleted, a cascade delete constraint removes automatically all linked values. 

In Mongo, this behavior is ensured by the `Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM\ProductRelatedEntityRemovalSubscriber` class. 

These processes are synchronous, and we know for sure that [a lot of use cases](https://akeneo.atlassian.net/wiki/display/AKN/Manage+the+whole+lifecycle+of+a+product+catalog) are not handled by the PIM. Which could lead to an inconsistent database.

## Ideally

We agreed with Benoit that:
* ideally, we should not have to update all the products after a structure change. Such a behavior is not scalable. And each time we add a new feature, we'd be impacted.
* if we need to do such changes, (ie: update all the products), it should be done asynchronously via a job

We agreed with Delphine: 
* we need to take into account those structure changes and define the ideal behavior we want from a functional point of view (for instance, is it really useful to be able to delete an attribute?)

## This PR

As you may imagine, it's not with a "+210 lines" that we'll come the ideal situation. This PR is just about making the PIM a little bit more resilient.

In the TIP-613-unified branch, when an option (or an attribute) is deleted, we don't change the products. With this PR, when we load the product, if the value is related a non existing attribute or option, it is simply not loaded.

We should also re-index all related products, but this is not part of this PR. There is a dedicated card for that (TIP-684). We first need to talk about the "ideal behavior" with Benoit and Delphine. Here we just want to fix the Behats.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | 4 fixed
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

