### PR TITLE
TIP-713: Fix validation behat scenarios

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -150,7 +150,11 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iTypeInTheManageFilterInput($text)
     {
-        $this->datagrid->typeInManageFilterInput($text);
+        $this->spin(function () use ($text) {
+            $this->datagrid->typeInManageFilterInput($text);
+
+            return true;
+        }, sprintf('Cannot find the filter "%s" in the filter list', $text));
     }
 
 
@@ -163,7 +167,9 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iCouldSeeInTheManageFiltersList($title)
     {
-        $filterElement = $this->datagrid->getElement('Manage filters')->find('css', sprintf('input[title="%s"]', $title));
+        $filterElement = $this->spin(function () use ($title) {
+            return $this->datagrid->getElement('Manage filters')->find('css', sprintf('input[title="%s"]', $title));
+        }, sprintf('Cannot find the filter "%s" in the filter list', $title));
 
         if ($filterElement == null || !$filterElement->isVisible()) {
             throw $this->createExpectationException(

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2318,11 +2318,17 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $family
+     *
      * @Then /^I change the family of the product to "([^"]*)"$/
      */
     public function iChangeTheFamilyOfTheProductTo($family)
     {
-        $this->getCurrentPage()->changeFamily($family);
+        $this->spin(function () use ($family) {
+            $this->getCurrentPage()->changeFamily($family);
+
+            return true;
+        }, sprintf('Cannot change the product family to %s', $family));
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Normalizer;
 
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\Validator\Constraints\UniqueValue;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
@@ -40,9 +41,17 @@ class ProductViolationNormalizer implements NormalizerInterface
             }
 
             $attribute = explode('-', $matches['attribute']);
+            $attributeCode = $attribute[0];
+
+            // TODO: TIP-722 - to revert once the identifier product value is dropped.
+            if ($attributeCode === $this->attributeRepository->getIdentifierCode() &&
+                $violation->getConstraint() instanceof UniqueValue
+            ) {
+                return [];
+            }
 
             $normalizedViolation = [
-                'attribute' => $attribute[0],
+                'attribute' => $attributeCode,
                 'locale'    => '<all_locales>' === $attribute[2] ? null : $attribute[2],
                 'scope'     => '<all_channels>' === $attribute[1] ? null : $attribute[1],
                 'message'   => $violation->getMessage(),

--- a/src/Pim/Component/Catalog/ProductValue/DateProductValue.php
+++ b/src/Pim/Component/Catalog/ProductValue/DateProductValue.php
@@ -45,6 +45,6 @@ class DateProductValue extends AbstractProductValue implements DateProductValueI
      */
     public function __toString()
     {
-        return null !== $this->data ? $this->data->format(\DateTime::ISO8601) : '';
+        return null !== $this->data ? $this->data->format('Y-m-d') : '';
     }
 }


### PR DESCRIPTION
## Description

This PR fixes:
- `features/product/validation/validate_date_attributes.feature:23`
  DateProductValue::__toString() was wrong, returning a datetime, when we only want a date (there is no datetime attribute type in the PIM)
- `features/product/validation/validate_identifier_attribute.feature:13`
  The fix consists in skipping the normalization of the violation message when it is for the identifier product value, and keep only the one for the identifier field. This fix is commented as to be revert in TIP-722, (dropping the identifier product value).
- `features/datagrid/products_backtothegrid.feature:34` and `features/product/edit_product_family.feature:31`
  Add some spin to fix those "random" scenarios.

Incidentally, the DateProductValue correction also fixes `features/import/product/validate_unicity_when_importing_products.feature:17` and `features/localization/product/validation/validate_date_attributes.feature:24`

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
