### PR TITLE
TIP-613: Sync ES and MySQL

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
@@ -47,34 +47,37 @@ class Client
     }
 
     /**
-     * @param string $indexType
-     * @param string $id
-     * @param array  $body
+     * @param string  $indexType
+     * @param string  $id
+     * @param array   $body
+     * @param Refresh $refresh
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_index_a_document}
      */
-    public function index($indexType, $id, array $body)
+    public function index($indexType, $id, array $body, Refresh $refresh)
     {
         $params = [
             'index' => $this->indexName,
-            'type'  => $indexType,
-            'id'    => $id,
-            'body'  => $body
+            'type' => $indexType,
+            'id' => $id,
+            'body' => $body,
+            'refresh' => $refresh->getType(),
         ];
 
         return $this->client->index($params);
     }
 
     /**
-     * @param string $indexType
-     * @param array  $documents
-     * @param string $keyAsId
+     * @param string  $indexType
+     * @param array   $documents
+     * @param string  $keyAsId
+     * @param Refresh $refresh
      *
      * @throws MissingIdentifierException
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_indexing_documents.html#_bulk_indexing}
      */
-    public function bulkIndexes($indexType, $documents, $keyAsId)
+    public function bulkIndexes($indexType, $documents, $keyAsId, Refresh $refresh)
     {
         $params = [];
 
@@ -86,12 +89,13 @@ class Client
             $params['body'][] = [
                 'index' => [
                     '_index' => $this->indexName,
-                    '_type'  => $indexType,
-                    '_id'    => $document[$keyAsId]
-                ]
+                    '_type' => $indexType,
+                    '_id' => $document[$keyAsId],
+                ],
             ];
 
             $params['body'][] = $document;
+            $params['refresh'] = $refresh->getType();
         }
 
         return $this->client->bulk($params);
@@ -107,8 +111,8 @@ class Client
     {
         $params = [
             'index' => $this->indexName,
-            'type'  => $indexType,
-            'id'    => $id,
+            'type' => $indexType,
+            'id' => $id,
         ];
 
         return $this->client->get($params);
@@ -124,8 +128,8 @@ class Client
     {
         $params = [
             'index' => $this->indexName,
-            'type'  => $indexType,
-            'body'  => $body
+            'type' => $indexType,
+            'body' => $body,
         ];
 
         return $this->client->search($params);
@@ -141,8 +145,8 @@ class Client
     {
         $params = [
             'index' => $this->indexName,
-            'type'  => $indexType,
-            'id'    => $id
+            'type' => $indexType,
+            'id' => $id,
         ];
 
         return $this->client->delete($params);
@@ -162,9 +166,9 @@ class Client
             $params['body'][] = [
                 'delete' => [
                     '_index' => $this->indexName,
-                    '_type'  => $indexType,
-                    '_id'    => $identifier
-                ]
+                    '_type' => $indexType,
+                    '_id' => $identifier,
+                ],
             ];
         }
 
@@ -188,7 +192,7 @@ class Client
     {
         $params = [
             'index' => $this->indexName,
-            'body'  => $body,
+            'body' => $body,
         ];
 
         return $this->client->indices()->create($params);

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Refresh.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Refresh.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Akeneo\Bundle\ElasticsearchBundle;
+
+/**
+ * Object that represents refresh parameter to control when changes made by this request are made visible to search.
+ *
+ * @author    Arnaud Langlade <arnaud.langlade@@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * {@link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html}
+ */
+final class Refresh
+{
+    const ENABLE = true;
+    const DISABLE = false;
+    const WAIT_FOR = 'wait_for';
+
+    /** @var bool|string */
+    private $type;
+
+    /**
+     * @param string $type
+     */
+    private function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return Refresh
+     */
+    public static function enable()
+    {
+        return new self(Refresh::ENABLE);
+    }
+
+    /**
+     * @return Refresh
+     */
+    public static function disabled()
+    {
+        return new self(Refresh::DISABLE);
+    }
+
+    /**
+     * @return Refresh
+     */
+    public static function waitFor()
+    {
+        return new self(Refresh::WAIT_FOR);
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/ClientSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/ClientSpec.php
@@ -4,6 +4,7 @@ namespace spec\Akeneo\Bundle\ElasticsearchBundle;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Bundle\ElasticsearchBundle\Exception\MissingIdentifierException;
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Elasticsearch\Client as NativeClient;
 use Elasticsearch\ClientBuilder;
 use Elasticsearch\Namespaces\IndicesNamespace;
@@ -31,11 +32,12 @@ class ClientSpec extends ObjectBehavior
                 'index' => 'an_index_name',
                 'type'  => 'an_index_type',
                 'id'    => 'identifier',
-                'body'  => ['a key' => 'a value']
+                'body'  => ['a key' => 'a value'],
+                'refresh' => 'wait_for',
             ]
         )->shouldBeCalled();
 
-        $this->index('an_index_type', 'identifier', ['a key' => 'a value']);
+        $this->index('an_index_type', 'identifier', ['a key' => 'a value'], Refresh::waitFor());
     }
 
     public function it_gets_a_document($client)
@@ -157,7 +159,8 @@ class ClientSpec extends ObjectBehavior
                         '_id' => 'bar'
                     ]],
                     ['identifier' => 'bar', 'name' => 'a name']
-                ]
+                ],
+                'refresh' => 'wait_for'
             ]
         )->shouldBeCalled();
 
@@ -166,7 +169,7 @@ class ClientSpec extends ObjectBehavior
             ['identifier' => 'bar', 'name' => 'a name']
         ];
 
-        $this->bulkIndexes('an_index_type', $documents, 'identifier');
+        $this->bulkIndexes('an_index_type', $documents, 'identifier', Refresh::waitFor());
     }
 
     function it_throws_an_exception_if_identifier_key_is_missing($client)
@@ -179,6 +182,6 @@ class ClientSpec extends ObjectBehavior
         ];
 
         $this->shouldThrow(new MissingIdentifierException('Missing "identifier" key in document'))
-            ->during('bulkIndexes', ['an_index_type', $documents, 'identifier']);
+            ->during('bulkIndexes', ['an_index_type', $documents, 'identifier', Refresh::waitFor()]);
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/RefreshSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/RefreshSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Akeneo\Bundle\ElasticsearchBundle;
+
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
+use PhpSpec\ObjectBehavior;
+
+class RefreshSpec extends ObjectBehavior
+{
+    function it_creates_a_enable_refresh_param()
+    {
+        $this->beConstructedThrough('enable');
+        $this->getType()->shouldReturn(Refresh::ENABLE);
+    }
+
+    function it_creates_a_disable_refresh_param()
+    {
+        $this->beConstructedThrough('disabled');
+        $this->getType()->shouldReturn(Refresh::DISABLE);
+    }
+
+    function it_creates_a_wait_for_refresh_param()
+    {
+        $this->beConstructedThrough('waitFor');
+        $this->getType()->shouldReturn(Refresh::WAIT_FOR);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductIndexer.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
@@ -49,7 +50,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
         $this->validateProduct($product);
         $normalizedProduct = $this->normalizer->normalize($product, 'indexing');
         $this->validateProductNormalization($normalizedProduct);
-        $this->indexer->index($this->indexType, $normalizedProduct['id'], $normalizedProduct);
+        $this->indexer->index($this->indexType, $normalizedProduct['id'], $normalizedProduct, Refresh::waitFor());
     }
 
     /**
@@ -65,7 +66,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
             $normalizedProducts[] = $normalizedProduct;
         }
 
-        $this->indexer->bulkIndexes($this->indexType, $normalizedProducts, 'id');
+        $this->indexer->bulkIndexes($this->indexType, $normalizedProducts, 'id', Refresh::waitFor());
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/ProductIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/ProductIndexerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
@@ -88,7 +89,7 @@ class ProductIndexerSpec extends ObjectBehavior
     function it_indexes_a_single_product($normalizer, $indexer, ProductInterface $product)
     {
         $normalizer->normalize($product, 'indexing')->willReturn(['id' => 'foobar', 'a key' => 'a value']);
-        $indexer->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])->shouldBeCalled();
+        $indexer->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'], Refresh::waitFor())->shouldBeCalled();
 
         $this->index($product);
     }
@@ -105,7 +106,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $indexer->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value']
-        ], 'id')->shouldBeCalled();
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2]);
     }


### PR DESCRIPTION
Prevent to get a product before the index refreshing. To fix that we use the refresh option: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html with the value 'wait_for'.