### PR TITLE
TIP-613: When there is no image, detect the undefined thumbnail

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -288,7 +288,10 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
         $node = $this->datagrid->getColumnNode($column, $row);
 
         if ('**empty**' === $titleExpectation) {
-            if (null !== $node->find('css', 'img')) {
+            $thumbnailPath = '/media/show/undefined/thumbnail_small';
+            $undefinedThumbnail = $node->find('css', 'img');
+
+            if (null === $undefinedThumbnail || $thumbnailPath !== $undefinedThumbnail->getAttribute('src')) {
                 throw $this->createExpectationException(
                     sprintf('Expecting column "%s" to be empty, but one image found.', $column)
                 );


### PR DESCRIPTION
To fix `features/product/display_attributes_in_the_grid.feature:36`