### PR TITLE
TIP-701: fix API pagination

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -705,7 +705,11 @@ class ProductController
         $pqb->addSorter('id', $direction);
 
         $productCursor = $pqb->execute();
-        $products = iterator_to_array($productCursor);
+        $products = [];
+        foreach ($productCursor as $product) {
+            $products[] = $product;
+        }
+
         if (isset($queryParameters['search_before'])) {
             $products = array_reverse($products);
         }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\MediaSanitizer;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -27,6 +28,8 @@ abstract class AbstractProductTestCase extends ApiTestCase
     /**
      * @param string $identifier
      * @param array  $data
+     *
+     * @return ProductInterface
      */
     protected function createProduct($identifier, array $data = [])
     {
@@ -35,6 +38,8 @@ abstract class AbstractProductTestCase extends ApiTestCase
         $this->get('pim_catalog.saver.product')->save($product);
 
         $this->get('akeneo_elasticsearch.client')->refreshIndex();
+
+        return $product;
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * We want to test the API is capable of returning an ordered list of 100 items.
+ * ie, twice the size of a cursor page
+ */
+class SuccessLargeAndOrderedListProductIntegration extends AbstractProductTestCase
+{
+    /** @var Collection */
+    private $products;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $identifiers = [];
+        for ($i = 0; $i < $this->getListSize(); $i++) {
+            $identifiers[] = 'sku-' . str_pad($i, 4, '0', STR_PAD_LEFT);
+        }
+
+        foreach ($identifiers as $identifier) {
+            $product = $this->createProduct($identifier, []);
+            $this->products[$product->getId()] = $product;
+        }
+        // the API will return products sorted alphabetical by MySQL ID, and that's what we expect
+        // for instance, if we have 100 products
+        // 1, 10, 100, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21...
+        ksort($this->products, SORT_STRING);
+    }
+
+    public function testPaginationAllProducts()
+    {
+        $standardizedProducts = [];
+        foreach ($this->products as $product) {
+            $standardizedProducts[] = $this->getStandardizedProduct($product->getIdentifier());
+        }
+        $standardizedProducts = implode(',', $standardizedProducts);
+        $lastEncryptedId = urlencode($this->getEncryptedId(end($this->products)));
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products?limit=100');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=100"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?limit=100"},
+        "next" : {"href": "http://localhost/api/rest/v1/products?limit=100&search_after={$lastEncryptedId}"}
+    },
+    "current_page" : null,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts}
+		]
+    }
+}
+JSON;
+
+        $this->assertResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return string
+     */
+    private function getStandardizedProduct($identifier)
+    {
+        $standardized = <<<JSON
+
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/{$identifier}"
+        }
+    },    
+    "identifier": "{$identifier}",
+    "family": null,
+    "groups": [],
+    "variant_group": null,
+    "categories": [],
+    "enabled": true,
+    "values": {},
+    "created": "2017-05-12T16:46:14+02:00",
+    "updated": "2017-05-12T16:46:14+02:00",
+    "associations": {}
+}
+JSON;
+
+        return $standardized;
+    }
+
+    /**
+     * @param Response $response
+     * @param array    $expected
+     */
+    private function assertResponse(Response $response, $expected)
+    {
+        $result = json_decode($response->getContent(), true);
+        $expected = json_decode($expected, true);
+
+        foreach ($result['_embedded']['items'] as $index => $product) {
+            $product = $this->sanitizeMediaAttributeData($product);
+            NormalizedProductCleaner::clean($product);
+            $result['_embedded']['items'][$index] = $product;
+
+            if (isset($expected['_embedded']['items'][$index])) {
+                $expectedProduct = $expected['_embedded']['items'][$index];
+                $expectedProduct = $this->sanitizeMediaAttributeData($expectedProduct);
+                NormalizedProductCleaner::clean($expectedProduct);
+                $expected['_embedded']['items'][$index] = $expectedProduct;
+            }
+        }
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @param ProductInterface $product
+     *
+     * @return string
+     */
+    private function getEncryptedId(ProductInterface $product)
+    {
+        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
+
+        return $encrypter->encrypt($product->getId());
+    }
+
+    /**
+     * We want to test the API is capable of returning a list of 100 items.
+     * (Twice the page of the cursor).
+     *
+     * @return int
+     */
+    private function getListSize()
+    {
+        $cursorPageSize = (int)$this->getParameter('pim_catalog.factory.product_cursor.page_size');
+
+        return $cursorPageSize * 2;
+    }
+}


### PR DESCRIPTION
Currently, `iterator_to_array($productCursor)` returns only the last internal page of the cursor.
It seems to be related to a bug of `iterator_to_array`.

In our cursor, we don't keep the whole set of products. We keep only the last page to free memory.
Even if there is no counter-argument about this practice in the \Iterator documentation, `iterator_to_array` does not handle properly this case.

To fix this behavior, we iterate normally over the cursor. An integration test has been added.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
