### PR TITLE
TIP-706: Fix sequential edit

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -298,6 +298,7 @@ class WebUser extends RawMinkContext
     public function iSwitchTheLocaleTo($locale)
     {
         $this->getCurrentPage()->getElement('Main context selector')->switchLocale($locale);
+        $this->wait();
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
@@ -125,9 +125,9 @@ class ProductController
      * @AclAncestor("pim_enrich_product_index")
      * @Template
      *
-     * @return Response
+     * @return array
      */
-    public function indexAction(Request $request)
+    public function indexAction()
     {
         $this->seqEditManager->removeByUser($this->tokenStorage->getToken()->getUser());
 
@@ -153,14 +153,13 @@ class ProductController
     /**
      * Toggle product status (enabled/disabled)
      *
-     * @param Request $request
-     * @param int     $id
+     * @param int $id
      *
      * @return Response
      *
      * @AclAncestor("pim_enrich_product_edit_attributes")
      */
-    public function toggleStatusAction(Request $request, $id)
+    public function toggleStatusAction($id)
     {
         $product = $this->findProductOr404($id);
 

--- a/src/Pim/Bundle/EnrichBundle/Factory/SequentialEditFactory.php
+++ b/src/Pim/Bundle/EnrichBundle/Factory/SequentialEditFactory.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Factory;
 
+use Pim\Bundle\EnrichBundle\Entity\SequentialEdit;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
@@ -4,7 +4,7 @@ pim_enrich_product_index:
 
 pim_enrich_product_edit:
     path: /{id}
-    defaults: { _controller: pim_enrich.controller.rest.product:editAction }
+    defaults: { _controller: pim_enrich.controller.product:editAction }
     requirements:
         id: '[0-9a-f]+'
     methods: [GET, POST]


### PR DESCRIPTION
## Description

Sequential edit were absolutely not working anymore.

### Why?

The `SequentialEditController calls a manager that calls the `SequentialEditHandler`. This handler is responsible to get the results from the datasource: the IDs of the products that were selected in the datagrid, so they can be edited one after another.

Problem is: we change the behavior of this datasource, the `ProductDatasource`, to normalize products as the datagrid expect them. Reason for that change is that with ES, we now need to use directly the PQB, and not the Doctrine QB as the ORO datasource used to.

In the process, we removed from the `ProductDatasource` all use of the ORO hydrators (a sort of datagrid normalizer).

### The result

The `SequentialEditHandler` is quite simple: it replaces the hydrator of the `ProductDatasource` by a simpler one that only returns product IDs, as sequential edit expects.

But as we removed all calls to the hydrator, this does not work anymore.

### The fix

The fix is simple, just getting the datasource results, and extract from it only what we want: the product IDs.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
