### PR TITLE
TIP-713: Fix behat context

### DIFF
--- a/features/Context/CommandContext.php
+++ b/features/Context/CommandContext.php
@@ -25,8 +25,6 @@ class CommandContext extends PimContext
      */
     public function iLaunchedTheCompletenessCalculator()
     {
-        $this->getMainContext()->getSubcontext('hook')->clearUOW();
-
         $commandLauncher = $this->getService('pim_catalog.command_launcher');
         $commandLauncher->executeForeground('pim:completeness:calculate');
     }

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1162,7 +1162,10 @@ class FixturesContext extends BaseFixturesContext
                     if ('**empty**' === $value) {
                         assertEmpty((string) $productValue);
                     } else {
-                        assertTrue(false !== strpos($productValue->getData()->getOriginalFilename(), $value));
+                        assertTrue(
+                            null !== $productValue->getData() &&
+                            false !== strpos($productValue->getData()->getOriginalFilename(), $value)
+                        );
                     }
                 } elseif ('prices' === $attribute->getBackendType() && null !== $priceCurrency) {
                     // $priceCurrency can be null if we want to test all the currencies at the same time


### PR DESCRIPTION
## Description

This PR fixes two methods in behat contexts:
- We cleared the UOW before launching completeness calculation. This is not needed anymore with our new SS completeness.
- A media product value can contain `null` as data (as all product values). We need to ensure it is not before getting the media.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
