### PR TITLE
TIP-713: CompletenessFilter Add should clause in a filter one

### DIFF
--- a/features/mass-action/mass_actions_on_all_entities.feature
+++ b/features/mass-action/mass_actions_on_all_entities.feature
@@ -42,8 +42,6 @@ Feature: Apply a mass action on all entities
     When I select all entities
     And I press "Change product information" on the "Bulk Actions" dropdown button
     And I choose the "Change the family of products" operation
-    And I press the "Back" button
-    And I choose the "Change the family of products" operation
     And I change the Family to "Sandals"
     And I move on to the next step
     And I wait for the "change-family" mass-edit job to finish

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
@@ -125,6 +125,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
             return $this;
         }
 
+        $shouldClauses = [];
+
         foreach ($localeCodes as $localeCode) {
             $field = sprintf('completeness.%s.%s', $channel, $localeCode);
 
@@ -136,7 +138,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                             $field => $value
                         ]
                     ];
-                    $this->searchQueryBuilder->addShould($clause);
+
+                    $shouldClauses[] = $clause;
                     break;
                 case Operators::LOWER_THAN:
                 case Operators::LOWER_THAN_ON_AT_LEAST_ONE_LOCALE:
@@ -147,7 +150,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                             ]
                         ]
                     ];
-                    $this->searchQueryBuilder->addShould($clause);
+
+                    $shouldClauses[] = $clause;
                     break;
                 case Operators::LOWER_THAN_ON_ALL_LOCALES:
                     $clause = [
@@ -168,7 +172,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                             ]
                         ]
                     ];
-                    $this->searchQueryBuilder->addShould($clause);
+
+                    $shouldClauses[] = $clause;
                     break;
                 case Operators::GREATER_THAN_ON_ALL_LOCALES:
                     $clause = [
@@ -189,7 +194,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                             ]
                         ]
                     ];
-                    $this->searchQueryBuilder->addShould($clause);
+
+                    $shouldClauses[] = $clause;
                     break;
                 case Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES:
                     $clause = [
@@ -210,7 +216,8 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                             ]
                         ]
                     ];
-                    $this->searchQueryBuilder->addShould($clause);
+
+                    $shouldClauses[] = $clause;
                     break;
                 case Operators::GREATER_OR_EQUALS_THAN_ON_ALL_LOCALES:
                     $clause = [
@@ -225,6 +232,11 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                 default:
                     throw InvalidOperatorException::notSupported($operator, static::class);
             }
+        }
+
+        if (!empty($shouldClauses))
+        {
+            $this->searchQueryBuilder->addFilter(['bool' => ['should' => $shouldClauses]]);
         }
 
         return $this;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
@@ -234,8 +234,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
             }
         }
 
-        if (!empty($shouldClauses))
-        {
+        if (!empty($shouldClauses)) {
             $this->searchQueryBuilder->addFilter(['bool' => ['should' => $shouldClauses]]);
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/search_specification.rst
@@ -1696,10 +1696,12 @@ EQUALS ON AT LEAST ONE LOCALE
     [
         'query' => [
             'bool' => [
-                'should' => [
-                    'term' => [
-                        'completeness.print.en_US' => 30,
-                        'completeness.print.fr_FR' => 30,
+                'filter' => [
+                    'bool' => [
+                        'should' => [
+                            ['term' => ['completeness.print.en_US' => 30]],
+                            ['term' => ['completeness.print.fr_FR' => 30]]
+                        ]
                     ]
                 ]
             ]
@@ -1761,10 +1763,12 @@ LOWER THAN ON AT LEAST ONE LOCALE
     [
         'query' => [
             'bool' => [
-                'should' => [
-                    'range' => [
-                        'completeness.print.en_US' => ['lt' => 30],
-                        'completeness.print.fr_FR' => ['lt' => 30],
+                'filter' => [
+                    'bool' => [
+                        'should' => [
+                            ['range' => ['completeness.print.en_US' => ['lt' => 30]]],
+                            ['range' => ['completeness.print.fr_FR' => ['lt' => 30]]]
+                        ]
                     ]
                 ]
             ]
@@ -1781,10 +1785,12 @@ LOWER OR EQUALS THAN ON AT LEAST ONE LOCALE
     [
         'query' => [
             'bool' => [
-                'should' => [
-                    'range' => [
-                        'completeness.print.en_US' => ['lte' => 30],
-                        'completeness.print.fr_FR' => ['lte' => 30],
+                'filter' => [
+                    'bool' => [
+                        'should' => [
+                            ['range' => ['completeness.print.en_US' => ['lte' => 30]]],
+                            ['range' => ['completeness.print.fr_FR' => ['lte' => 30]]]
+                        ]
                     ]
                 ]
             ]
@@ -1801,10 +1807,12 @@ GREATER THAN ON AT LEAST ONE LOCALE
     [
         'query' => [
             'bool' => [
-                'should' => [
-                    'range' => [
-                        'completeness.print.en_US' => ['gt' => 30],
-                        'completeness.print.fr_FR' => ['gt' => 30],
+                'filter' => [
+                    'bool' => [
+                        'should' => [
+                            ['range' => ['completeness.print.en_US' => ['gt' => 30]]],
+                            ['range' => ['completeness.print.fr_FR' => ['gt' => 30]]]
+                        ]
                     ]
                 ]
             ]
@@ -1821,10 +1829,12 @@ GREATER OR EQUALS THAN ON AT LEAST ONE LOCALE
     [
         'query' => [
             'bool' => [
-                'should' => [
-                    'range' => [
-                        'completeness.print.en_US' => ['gte' => 30],
-                        'completeness.print.fr_FR' => ['gte' => 30],
+                'filter' => [
+                    'bool' => [
+                        'should' => [
+                            ['range' => ['completeness.print.en_US' => ['gte' => 30]]],
+                            ['range' => ['completeness.print.fr_FR' => ['gte' => 30]]]
+                        ]
                     ]
                 ]
             ]

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -48,7 +48,7 @@ class SearchQueryBuilder
     private $sortClauses = [];
 
     /**
-     * Adds a filter clause to the query
+     * Adds a must_not clause to the query
      *
      * @param array $clause
      *
@@ -62,7 +62,7 @@ class SearchQueryBuilder
     }
 
     /**
-     * Adds a must_not clause to the query
+     * Adds a filter clause to the query
      *
      * @param array $clause
      *

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CompletenessFilterSpec.php
@@ -146,11 +146,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_one_locale_with_a_regular_filter($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'term' => [
-                    'completeness.ecommerce.en_US' => 56,
-                ],
+                'bool' => [
+                    'should' => [
+                        ['term' => ['completeness.ecommerce.en_US' => 56]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 
@@ -165,21 +167,16 @@ class CompletenessFilterSpec extends ObjectBehavior
         $channelRepository->findOneByIdentifier('ecommerce')->willReturn($ecommerce);
         $ecommerce->getLocaleCodes()->willReturn(['en_US', 'fr_FR']);
 
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'term' => [
-                    'completeness.ecommerce.en_US' => 56,
-                ],
+                'bool' => [
+                    'should' => [
+                        ['term' => ['completeness.ecommerce.en_US' => 56]],
+                        ['term' => ['completeness.ecommerce.fr_FR' => 56]]
+                    ]
+                ]
             ]
-        )->shouldBeCalled();
-
-        $sqb->addShould(
-            [
-                'term' => [
-                    'completeness.ecommerce.fr_FR' => 56,
-                ],
-            ]
-        )->shouldBeCalled();
+        );
 
         $this->addFieldFilter('completeness', Operators::EQUALS, 56, null, 'ecommerce', []);
     }
@@ -240,11 +237,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_EQUALS_ON_AT_LEAST_ONE_LOCALE_operator($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'term' => [
-                    'completeness.ecommerce.en_US' => 56,
-                ],
+                'bool' => [
+                    'should' => [
+                        ['term' => ['completeness.ecommerce.en_US' => 56]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 
@@ -324,11 +323,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_LOWER_THAN_ON_AT_LEAST_ONE_LOCALE_operator($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'range' => [
-                    'completeness.ecommerce.en_US' => ['lt' => 56],
-                ],
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['lt' => 56]]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 
@@ -365,11 +366,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_GREATER_THAN_ON_AT_LEAST_ONE_LOCALE_operator($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'range' => [
-                    'completeness.ecommerce.en_US' => ['gt' => 56],
-                ],
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['gt' => 56]]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 
@@ -406,11 +409,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_LOWER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE_operator($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'range' => [
-                    'completeness.ecommerce.en_US' => ['lte' => 56],
-                ],
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['lte' => 56]]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 
@@ -446,11 +451,13 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE_operator($sqb)
     {
-        $sqb->addShould(
+        $sqb->addFilter(
             [
-                'range' => [
-                    'completeness.ecommerce.en_US' => ['gte' => 56],
-                ],
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['gte' => 56]]]
+                    ]
+                ]
             ]
         )->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -58,7 +58,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
             $this->createProduct('product_two', [
                 'family' => 'familyB',
-                'categories' => ['categoryA2'],
+                'categories' => ['categoryA2', 'categoryA1'],
                 'values' => [
                     'a_metric'                           => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]],
                     'a_localized_and_scopable_text_area' => [['data' => 'text', 'locale' => 'en_US', 'scope' => 'tablet']],
@@ -75,7 +75,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
             $this->createProduct('empty_product', [
                 'family' => 'familyB',
-                'categories' => ['categoryA2']
+                'categories' => ['categoryA2', 'categoryA1']
             ]);
 
             $this->createProduct('no_family', [
@@ -396,7 +396,7 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $result = $this->executeFilter([
             ['completeness', '=', 100, ['scope' => 'tablet', 'locale' => 'en_US']],
-            ['categories', 'IN', ['categoryA2']]
+            ['categories', 'IN OR UNCLASSIFIED', ['categoryA1']]
         ]);
         $this->assert($result, ['product_two']);
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

The CompletenessFilter added its clauses into the global should clauses of the SQB so its filters when it was filters for "*_AT_LEAST_ONE_LOCALE" so they were not take in account next to other filters. :).


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
