### PR TITLE
TIP-713: Better manage exception in ProductValueFactory

### DIFF
--- a/.php_cd.php
+++ b/.php_cd.php
@@ -18,6 +18,7 @@ $cBusinessDeps = [
     'Symfony\Component\Security\Core', // for the moment, let's discuss about that later
 ];
 $cUtilsDeps    = [
+    'Psr\Log',
     'Symfony\Component\OptionsResolver',
     'Symfony\Component\PropertyAccess',
     'Symfony\Component\Filesystem',

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -208,6 +208,7 @@ services:
         public: false
         arguments:
             - '@pim_catalog.repository.attribute_option'
+            - '@logger'
             - '%pim_catalog.entity.product_value.options.class%'
             - 'pim_catalog_multiselect'
         tags:

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/factories.yml
@@ -18,6 +18,7 @@ services:
         public: false
         arguments:
             - '@pim_reference_data.repository_resolver'
+            - '@logger'
             - '%pim_reference_data.product_value.reference_data_collection.class%'
             - 'pim_reference_data_multiselect'
         tags:

--- a/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueCollectionFactory.php
@@ -7,6 +7,7 @@ use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\ProductValueCollection;
 use Pim\Component\Catalog\Model\ProductValueCollectionInterface;
+use Pim\Component\ReferenceData\Exception\InvalidReferenceDataException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,7 +77,15 @@ class ProductValueCollectionFactory
                         } catch (InvalidOptionException $e) {
                             $this->logger->warning(
                                 sprintf(
-                                    'Tried to load a product value with the option "%s" that does not exist.',
+                                    'Tried to load a product value with an option "%s" that does not exist.',
+                                    $e->getPropertyValue()
+                                )
+                            );
+                        } catch (InvalidReferenceDataException $e) {
+                            $this->logger->warning(
+                                sprintf(
+                                    'Tried to load a product value for the attribute "%s" with a reference data "%s" that does not exist.',
+                                    $attribute->getCode(),
                                     $e->getPropertyValue()
                                 )
                             );

--- a/src/Pim/Component/ReferenceData/Exception/InvalidReferenceDataException.php
+++ b/src/Pim/Component/ReferenceData/Exception/InvalidReferenceDataException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pim\Component\ReferenceData\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+
+/**
+ * Exception thrown when performing an action on a property with invalid option.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidReferenceDataException extends InvalidPropertyException
+{
+}

--- a/src/Pim/Component/ReferenceData/Factory/ProductValue/ReferenceDataProductValueFactory.php
+++ b/src/Pim/Component/ReferenceData/Factory/ProductValue/ReferenceDataProductValueFactory.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\ReferenceData\Factory\ProductValue;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Factory\ProductValue\ProductValueFactoryInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
@@ -100,7 +100,7 @@ class ReferenceDataProductValueFactory implements ProductValueFactoryInterface
      * @param ReferenceDataRepositoryInterface $repository
      * @param string                           $referenceDataCode
      *
-     * @throws InvalidPropertyException
+     * @throws InvalidOptionException
      * @return ReferenceDataInterface
      */
     protected function getReferenceData(
@@ -111,10 +111,10 @@ class ReferenceDataProductValueFactory implements ProductValueFactoryInterface
         $referenceData = $repository->findOneBy(['code' => $referenceDataCode]);
 
         if (null === $referenceData) {
-            throw InvalidPropertyException::validEntityCodeExpected(
+            throw InvalidOptionException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'reference data code',
-                sprintf('The code of the reference data "%s" does not exist', $attribute->getReferenceDataName()),
+                sprintf('The reference data "%s" does not exist', $attribute->getReferenceDataName()),
                 static::class,
                 $referenceDataCode
             );

--- a/src/Pim/Component/ReferenceData/spec/Factory/ProductValue/ReferenceDataProductValueFactorySpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Factory/ProductValue/ReferenceDataProductValueFactorySpec.php
@@ -3,9 +3,9 @@
 namespace spec\Pim\Component\ReferenceData\Factory\ProductValue;
 
 use Acme\Bundle\AppBundle\Entity\Color;
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\ReferenceData\Factory\ProductValue\ReferenceDataProductValueFactory;
 use Pim\Component\ReferenceData\ProductValue\ReferenceDataProductValue;
@@ -194,10 +194,10 @@ class ReferenceDataProductValueFactorySpec extends ObjectBehavior
         $repositoryResolver->resolve('color')->willReturn($referenceDataRepository);
         $referenceDataRepository->findOneBy(['code' => 'foobar'])->willReturn(null);
 
-        $exception = InvalidPropertyException::validEntityCodeExpected(
+        $exception = InvalidOptionException::validEntityCodeExpected(
             'reference_data_simple_select_attribute',
             'reference data code',
-            'The code of the reference data "color" does not exist',
+            'The reference data "color" does not exist',
             ReferenceDataProductValueFactory::class,
             'foobar'
         );


### PR DESCRIPTION
## Description

When loading products from storage, we create the product value objects from the database raw values. The product value factories are responsible for that, and ensure that raw data are correct.

For example, in this case, an invalid raw data would be an option or reference data code that does not exists anymore. The product value factory will throw an exception, logged it as a warning, and eventually will not load this invalid product value. As it is not loaded, it will be removed from database next time the product is saved.

Problem is with multi-select attributes: both options or reference data collections, and in EE, assets! When encountering an option or an asset that does not exists, the product value will not be created, despite the fact the other codes could be perfectly valid.

This PR attempt to throw an exception only if all options/assets/reference data do not exist. In all case, the non existing codes are logged as a warning. By doing so, the product value will not be created only if all raw data codes are invalid.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
